### PR TITLE
Add kalman residual tests and orientation estimator test

### DIFF
--- a/imu_fusion/attitude.py
+++ b/imu_fusion/attitude.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 
 
 def compute_C_ECEF_to_NED(lat: float, lon: float) -> np.ndarray:
@@ -59,3 +60,27 @@ def quat_multiply(q: np.ndarray, r: np.ndarray) -> np.ndarray:
 
 def quat_normalize(q: np.ndarray) -> np.ndarray:
     return q / np.linalg.norm(q)
+
+
+def estimate_initial_orientation(imu: np.ndarray, gnss: pd.DataFrame) -> np.ndarray:
+    """Estimate initial body-to-NED quaternion from GNSS velocity."""
+    lat = np.deg2rad(float(gnss.iloc[0].get("Latitude_deg", 0.0)))
+    lon = np.deg2rad(float(gnss.iloc[0].get("Longitude_deg", 0.0)))
+    vel_cols = ["VX_ECEF_mps", "VY_ECEF_mps", "VZ_ECEF_mps"]
+    if set(vel_cols) <= set(gnss.columns):
+        v_ecef = gnss.iloc[0][vel_cols].to_numpy(float)
+    else:
+        v_ecef = np.zeros(3)
+    C = compute_C_ECEF_to_NED(lat, lon)
+    v_ned = C @ v_ecef
+    yaw = float(np.arctan2(v_ned[1], v_ned[0]))
+    cy = np.cos(yaw)
+    sy = np.sin(yaw)
+    R = np.array(
+        [
+            [cy, sy, 0.0],
+            [-sy, cy, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    return rot_to_quaternion(R)

--- a/tests/test_attitude.py
+++ b/tests/test_attitude.py
@@ -1,7 +1,14 @@
 import sys, os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import numpy as np
-from imu_fusion.attitude import compute_C_ECEF_to_NED, rot_to_quaternion, quat_multiply, quat_normalize
+from imu_fusion.attitude import (
+    compute_C_ECEF_to_NED,
+    rot_to_quaternion,
+    quat_multiply,
+    quat_normalize,
+    estimate_initial_orientation,
+)
+import pandas as pd
 
 
 def test_compute_C_ECEF_to_NED_identity_lat_lon_zero():
@@ -24,3 +31,17 @@ def test_quaternion_helpers_roundtrip():
     q2 = quat_multiply(q, q)
     q2n = quat_normalize(q2)
     assert np.allclose(q2n, expected)
+
+
+def test_estimate_initial_orientation_identity_yaw():
+    imu = np.zeros((1, 6))
+    gnss = pd.DataFrame({
+        "Latitude_deg": [0.0],
+        "Longitude_deg": [0.0],
+        "VX_ECEF_mps": [1.0],
+        "VY_ECEF_mps": [0.0],
+        "VZ_ECEF_mps": [0.0],
+    })
+    q = estimate_initial_orientation(imu, gnss)
+    expected = np.array([1.0, 0.0, 0.0, 0.0])
+    assert np.allclose(q, expected)

--- a/tests/test_kalman.py
+++ b/tests/test_kalman.py
@@ -1,0 +1,33 @@
+import numpy as np
+from imu_fusion.kalman import kalman_with_residuals
+
+
+def test_kalman_with_residuals_constant_velocity():
+    zs = np.arange(1, 6).reshape(-1, 1).astype(float)
+    F = np.array([[1.0, 1.0], [0.0, 1.0]])
+    H = np.array([[1.0, 0.0]])
+    Q = np.zeros((2, 2))
+    R = np.eye(1) * 0.1
+    x0 = np.array([0.0, 0.0])
+
+    xs, res = kalman_with_residuals(zs, F, H, Q, R, x0)
+
+    expected_res = np.array([
+        1.0,
+        0.57142857,
+        0.19298246,
+        0.08300908,
+        0.04485263,
+    ]).reshape(-1, 1)
+    expected_xs = np.array(
+        [
+            [0.95238095, 0.47619048],
+            [1.92982456, 0.87719298],
+            [2.95719844, 0.95979248],
+            [3.97266126, 0.98248612],
+            [4.98125335, 0.99089448],
+        ]
+    )
+
+    assert np.allclose(xs, expected_xs)
+    assert np.allclose(res, expected_res)


### PR DESCRIPTION
## Summary
- test kalman_with_residuals using simple synthetic data
- add estimate_initial_orientation helper and unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cb8dad5ec83258e6f81ecd5dc8175