### PR TITLE
Improve gravity handling in attitude init

### DIFF
--- a/GNSS_IMU_Fusion.py
+++ b/GNSS_IMU_Fusion.py
@@ -12,4 +12,3 @@ from fusion_single import main
 
 if __name__ == "__main__":
     main()
-

--- a/TRIAD_method/evaluate_triad.py
+++ b/TRIAD_method/evaluate_triad.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pandas as pd
 from imu_fusion.data import load_gnss_csv, load_imu_dat
 from imu_fusion.wahba import triad_method
 from imu_fusion.attitude import (

--- a/fusion_single.py
+++ b/fusion_single.py
@@ -132,6 +132,8 @@ def estimate_initial_orientation(gnss: pd.DataFrame, imu: np.ndarray) -> tuple[n
     acc_mean = np.mean(acc[:N_static], axis=0)
     gyro_mean = np.mean(gyro[:N_static], axis=0)
     g_body = -acc_mean
+    if np.linalg.norm(g_body) > 1e-3:
+        g_body = 9.81 * g_body / np.linalg.norm(g_body)
     omega_body = gyro_mean
 
     C_b_n = triad(g_body, omega_body, g_ned, omega_ned)

--- a/tests/test_attitude.py
+++ b/tests/test_attitude.py
@@ -1,6 +1,7 @@
 import sys, os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import numpy as np
+import imu_fusion.attitude as attitude
 from imu_fusion.attitude import (
     compute_C_ECEF_to_NED,
     rot_to_quaternion,
@@ -8,6 +9,7 @@ from imu_fusion.attitude import (
     quat_normalize,
 
     estimate_initial_orientation,
+    estimate_initial_orientation_triad,
 )
 import pandas as pd
 
@@ -45,6 +47,15 @@ def test_estimate_initial_orientation_identity_yaw():
         "VZ_ECEF_mps": [0.0],
     })
     q = estimate_initial_orientation(imu, gnss)
+    expected = np.array([1.0, 0.0, 0.0, 0.0])
+    assert np.allclose(q, expected)
+
+
+def test_estimate_initial_orientation_triad_normalizes_gravity():
+    accel = np.repeat([[0.0, 0.0, -12.0]], 100, axis=0)
+    gyro = np.repeat([[7.2921159e-5, 0.0, 0.0]], 100, axis=0)
+    gnss = pd.DataFrame({"Latitude_deg": [0.0], "Longitude_deg": [0.0]})
+    q = attitude.estimate_initial_orientation_triad(accel, gyro, gnss, samples=100)
     expected = np.array([1.0, 0.0, 0.0, 0.0])
     assert np.allclose(q, expected)
 


### PR DESCRIPTION
## Summary
- normalize the gravity vector when estimating initial attitude
- add unit test for estimate_initial_orientation_triad

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d5825053483259cf32f4f72316f10