### PR TITLE
Enhance IMU calibration with filtering and scaling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas
 matplotlib
 cartopy
 filterpy
+scipy


### PR DESCRIPTION
## Summary
- add Butterworth low-pass filtering helper
- filter IMU accelerometer and gyro data before use
- estimate accelerometer scale factor during bias calibration
- apply scale correction when removing bias
- require `scipy` for filtering

## Testing
- `python -m py_compile GNSS_IMU_Fusion.py`
- `python -m pip install --quiet scipy` *(fails: network unreachable)*
- `python GNSS_IMU_Fusion.py --imu-file IMU_X001.dat --gnss-file GNSS_X001.csv --method Davenport`

------
https://chatgpt.com/codex/tasks/task_e_684d64debd448325a75d39724d48c207