### PR TITLE
Add helper script and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,19 @@ static accelerometer vector is used to compute a simple scale factor so that the
 measured gravity is close to 9.81 m/s². This improves the attitude
 initialisation when the first samples are not perfectly static or the sensor
 scale is slightly off.
+
+## Running all methods
+
+Use `run_all_methods.py` to execute the fusion script with TRIAD, Davenport and SVD sequentially:
+
+```bash
+python run_all_methods.py --imu-file IMU_X001.dat --gnss-file GNSS_X001.csv
+```
+
+## Tests
+
+Run the unit tests with `pytest`:
+
+```bash
+pytest -q
+```

--- a/run_all_methods.py
+++ b/run_all_methods.py
@@ -1,0 +1,23 @@
+import argparse
+import subprocess
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run GNSS_IMU_Fusion with multiple methods")
+    parser.add_argument("--imu-file", default="IMU_X001.dat", help="Path to IMU DAT file")
+    parser.add_argument("--gnss-file", default="GNSS_X001.csv", help="Path to GNSS CSV file")
+    args = parser.parse_args()
+
+    methods = ["TRIAD", "Davenport", "SVD"]
+    for m in methods:
+        cmd = [sys.executable, "GNSS_IMU_Fusion.py", "--method", m,
+               "--imu-file", args.imu_file, "--gnss-file", args.gnss_file]
+        print(f"Running method {m}...")
+        ret = subprocess.run(cmd)
+        if ret.returncode != 0:
+            print(f"Method {m} failed", file=sys.stderr)
+            sys.exit(ret.returncode)
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_missing_file.py
+++ b/tests/test_missing_file.py
@@ -1,0 +1,11 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import pytest
+from GNSS_IMU_Fusion import main
+
+
+def test_missing_gnss_file(monkeypatch):
+    args = ["--imu-file", "IMU_X001.dat", "--gnss-file", "missing.csv"]
+    monkeypatch.setattr("sys.argv", ["GNSS_IMU_Fusion.py"] + args)
+    with pytest.raises(FileNotFoundError):
+        main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,13 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import numpy as np
+from GNSS_IMU_Fusion import compute_C_ECEF_to_NED
+
+
+def test_rotation_matrix_orthonormal():
+    lat = np.deg2rad(-32.0)
+    lon = np.deg2rad(133.0)
+    C = compute_C_ECEF_to_NED(lat, lon)
+    # Orthonormal check
+    I = C @ C.T
+    assert np.allclose(I, np.eye(3), atol=1e-6)


### PR DESCRIPTION
## Summary
- add `run_all_methods.py` for running all available orientation methods
- document how to run all methods and run tests
- add unit tests for `compute_C_ECEF_to_NED` and for missing-file behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d6f578c4c832583b49105c98eb424