### PR TITLE
Add output archiver

### DIFF
--- a/run_all_methods.py
+++ b/run_all_methods.py
@@ -2,23 +2,27 @@ import argparse
 import os
 import subprocess
 import sys
+import pathlib
 
 
 def main():
     parser = argparse.ArgumentParser(description="Run GNSS_IMU_Fusion with multiple methods")
     args = parser.parse_args()
 
-    cases = [
-        ("IMU_X001.dat", "GNSS_X001.csv", "clean"),
-        ("IMU_X002.dat", "GNSS_X002.csv", "noise"),
-        ("IMU_X003.dat", "GNSS_X003.csv", "bias"),
+    pairs = [
+        ("IMU_X001.dat", "GNSS_X001.csv"),
+        ("IMU_X002.dat", "GNSS_X002.csv"),
     ]
+    if os.path.exists("GNSS_X003.csv"):
+        pairs.append(("IMU_X003.dat", "GNSS_X003.csv"))
+        pairs.append(("IMU_X002.dat", "GNSS_X003.csv"))
 
     methods = ["TRIAD", "Davenport", "SVD", "ALL"]
-    os.makedirs("logs", exist_ok=True)
-    for imu, gnss, tag in cases:
+    os.makedirs("results", exist_ok=True)
+    for imu, gnss in pairs:
+        stem = f"{pathlib.Path(imu).stem}_{pathlib.Path(gnss).stem}"
         for m in methods:
-            log_name = os.path.join("logs", f"{tag}_{m}.log")
+            log_name = os.path.join("results", f"{stem}_{m}.log")
             cmd = [
                 sys.executable,
                 "GNSS_IMU_Fusion.py",
@@ -28,12 +32,14 @@ def main():
                 imu,
                 "--gnss-file",
                 gnss,
+                "--output-dir",
+                "results",
             ]
-            print(f"Running {tag} with method {m}...")
+            print(f"Running {stem} with method {m}...")
             with open(log_name, "w") as f:
                 ret = subprocess.run(cmd, stdout=f, stderr=subprocess.STDOUT)
             if ret.returncode != 0:
-                print(f"{tag} {m} failed", file=sys.stderr)
+                print(f"{stem} {m} failed", file=sys.stderr)
                 sys.exit(ret.returncode)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- store per-run logs and results in a `results/` folder
- prefix generated plot names with dataset and method
- dump Kalman filter outputs to an NPZ file for later comparisons
- update driver script to write logs and pass output directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d7bf168288325918f6604043fd80e