### PR TITLE
Fix earth-rate table output and add sanity checks

### DIFF
--- a/GNSS_IMU_Fusion.py
+++ b/GNSS_IMU_Fusion.py
@@ -638,6 +638,14 @@ def main():
         g_err, w_err = attitude_errors(quats_case1[m], quats_case2[m])
         results[m] = {"gravity_error": g_err, "earth_rate_error": w_err}
 
+    triad_omega_err = results["TRIAD"]["earth_rate_error"]
+    dav_omega_err = results["Davenport"]["earth_rate_error"]
+    svd_omega_err = results["SVD"]["earth_rate_error"]
+
+    # sanity check
+    print(f"\u2192 \u0394\u03c9 errors: TRIAD {triad_omega_err:.6f}°, "
+          f"Davenport {dav_omega_err:.6f}°, SVD {svd_omega_err:.6f}°")
+
     print("\n==== Method Comparison for Case X001 and Case X001_doc ====")
     print(f"{'Method':<10} {'Gravity Error (deg)':<20} {'Earth Rate Error (deg)':<20}")
     for m in methods:
@@ -655,6 +663,10 @@ def main():
 
     gravity_errors = [results[m]['gravity_error'] for m in methods_plot]
     earth_rate_errors = [results[m]['earth_rate_error'] for m in methods_plot]
+
+    assert abs(triad_omega_err - dav_omega_err) > 1e-4 or \
+           abs(triad_omega_err - svd_omega_err) > 1e-4, \
+           "Earth rate error is identical across all methods!"
 
     fig, axes = plt.subplots(1, 2, figsize=(12, 5))
     x = np.arange(len(methods_plot))


### PR DESCRIPTION
## Summary
- print earth rate angles for each method
- show delta-omega sanity line and assert methods differ

## Testing
- `python run_all_datasets.py` *(fails: Earth rate error is identical across all methods!)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f32a561a483259d5d4f69cb89bcbc