### PR TITLE
Relax earth-rate warning

### DIFF
--- a/GNSS_IMU_Fusion.py
+++ b/GNSS_IMU_Fusion.py
@@ -648,11 +648,26 @@ def main():
     for m, o in omega_errors.items():
         print(f"  {m:10s}: {o:.6f}°")
 
-    omega_errs = list(omega_errors.values())
-    tol = 1e-6
-    if max(omega_errs) - min(omega_errs) < tol:
-        raise AssertionError(
-            f"All Earth-rate errors are effectively identical (\u0394 < {tol}): {omega_errs}"
+    # Relaxed Earth-rate error check --------------------------------------
+
+    omega_errs = {
+        'TRIAD':     omega_errors['TRIAD'],
+        'Davenport': omega_errors['Davenport'],
+        'SVD':       omega_errors['SVD']
+    }
+    diff = max(omega_errs.values()) - min(omega_errs.values())
+    tol = 1e-5   # allow up to 0.00001° of spread without complaint
+
+    # always print them so you can see the tiny spreads at runtime
+    print("\nEarth-rate errors by method:")
+    for name, err in omega_errs.items():
+        print(f"  {name:10s}: {err:.9f}°")
+    print(f"  Δ = {diff:.2e}° (tolerance = {tol:.1e})\n")
+
+    if diff < tol:
+        logging.warning(
+            "All Earth-rate errors are very close; differences "
+            f"are within {tol:.1e}°"
         )
 
     print("\n==== Method Comparison for Case X001 and Case X001_doc ====")


### PR DESCRIPTION
## Summary
- relax the earth-rate check in `GNSS_IMU_Fusion.py`
- log individual errors with Δ spread and issue a warning instead of raising

## Testing
- `pytest -q`
- `python run_all_datasets.py` (interrupted after plots started)

------
https://chatgpt.com/codex/tasks/task_e_684f37228a788325aca3c8ad18f92f5a