### PR TITLE
Fix Rich dependency installation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /workspace
 # Install Python deps
 COPY --chown=vscode:vscode requirements.txt .
 RUN pip install --user --upgrade pip setuptools wheel \
-    && pip install --user -r requirements.txt
+    && pip install --user --no-cache-dir -r requirements.txt
 
 # Add ~/.local/bin to PATH
 ENV PATH=/home/$USER/.local/bin:$PATH

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pandas
 matplotlib
 pyproj
 pynmea2
-rich
+rich  # colourful console output
 black
 flake8
 pytest


### PR DESCRIPTION
## Summary
- install requirements with `--no-cache-dir`
- document use of Rich in requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f49db9f448325a8b113e18af6fc8f