### PR TITLE
Fix summary parsing and update alignment test

### DIFF
--- a/run_all_datasets.py
+++ b/run_all_datasets.py
@@ -82,7 +82,9 @@ def main():
         summary = run_one(imu, gnss, method, verbose=args.verbose)
         runtime = time.time() - start
         if summary:
-            kv = dict(pair.split("=", 1) for pair in summary.split())
+            # split on key=value pairs allowing spaces after '=' for
+            # formatted numbers like "final_pos=  10.84m"
+            kv = dict(re.findall(r"(\w+)=\s*([^\s]+)", summary))
             table.add_row(
                 kv.get("method", method),
                 kv.get("rmse_pos", "n/a").replace("m", ""),

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -6,5 +6,6 @@ def _latest_npzs():
 
 @pytest.mark.parametrize("tag,data", _latest_npzs())
 def test_final_alignment(tag, data, tol=15.0):
-    err = data["summary"].item()["final_alignment_error"]
+    summary = data["summary"].item()
+    err = summary.get("final_alignment_error", summary.get("final_pos"))
     assert err < tol, f"{tag} drift {err:.2f} m > {tol}"


### PR DESCRIPTION
## Summary
- handle padded values in `run_all_datasets.py` summary parsing
- make `test_alignment` fall back to `final_pos` when `final_alignment_error` is absent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f558f28fc8325a906ecc26d696877