### PR TITLE
Fix missing tabulate dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ cartopy
 filterpy
 scipy
 rich
+tabulate


### PR DESCRIPTION
## Summary
- add tabulate to requirements so `run_all_datasets.py` works out of the box

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ff659e0208325b0df0c1b19ca0173