### PR TITLE
Handle missing tabulate gracefully

### DIFF
--- a/run_all_datasets.py
+++ b/run_all_datasets.py
@@ -13,7 +13,12 @@ import sys
 import argparse
 import re
 import time
-from tabulate import tabulate
+try:
+    from tabulate import tabulate
+except ModuleNotFoundError:  # pragma: no cover - friendly message for manual runs
+    print("Missing required dependency 'tabulate'.")
+    print("Please install dependencies with 'pip install -r requirements.txt'.")
+    sys.exit(1)
 
 from tqdm import tqdm
 


### PR DESCRIPTION
## Summary
- handle missing dependency `tabulate` in `run_all_datasets.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ff730bb5883258134664973db84f1