### PR TITLE
Auto-install dependencies on first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ IMU data processing and initialization tools (Python)
 
 ## Installation
 
-Install dependencies with:
+`run_all_datasets.py` installs the required packages automatically the first
+time you run it. If you'd rather set them up beforehand, install the
+dependencies manually with:
 
 ```bash
 pip install -r requirements.txt

--- a/run_all_datasets.py
+++ b/run_all_datasets.py
@@ -13,13 +13,31 @@ import sys
 import argparse
 import re
 import time
-try:
-    from tabulate import tabulate
-except ModuleNotFoundError:  # pragma: no cover - friendly message for manual runs
-    print("Missing required dependency 'tabulate'.")
-    print("Please install dependencies with 'pip install -r requirements.txt'.")
-    sys.exit(1)
 
+HERE = pathlib.Path(__file__).resolve().parent
+
+
+def ensure_dependencies():
+    """Install required packages if they're missing."""
+    try:  # check a couple of external deps
+        import tabulate  # noqa: F401
+        import tqdm  # noqa: F401
+    except ModuleNotFoundError:
+        print("Installing Python dependencies ...")
+        req = HERE / "requirements.txt"
+        subprocess.check_call([
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "-r",
+            str(req),
+        ])
+
+
+ensure_dependencies()
+
+from tabulate import tabulate
 from tqdm import tqdm
 
 HERE     = pathlib.Path(__file__).resolve().parent


### PR DESCRIPTION
## Summary
- ensure dependencies are installed before running `run_all_datasets.py`
- document automatic dependency installation in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ff8acf21c8325a1e58f17a52465bf