### PR TITLE
Fix missing tqdm dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ filterpy
 scipy
 rich
 tabulate
+tqdm


### PR DESCRIPTION
## Summary
- include tqdm in requirements.txt so run_all_datasets.py can install all needed packages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685004ab793c8325a5333b56bd06e779