### PR TITLE
Fix residual velocity plot length mismatch

### DIFF
--- a/scripts/validate_filter.py
+++ b/scripts/validate_filter.py
@@ -18,7 +18,8 @@ def plot_residuals(gnss_times, res, outpath):
     axs[0].plot(gnss_times, res[:, 2], label='Down')
     axs[0].set_ylabel('Position residual (m)')
     axs[0].legend()
-    axs[1].plot(gnss_times, np.diff(res, axis=0) / np.diff(gnss_times)[:, None])
+    axs[1].plot(gnss_times[:-1],
+                np.diff(res, axis=0) / np.diff(gnss_times)[:, None])
     axs[1].set_ylabel('Velocity residual (m/s)')
     axs[1].set_xlabel('Time (s)')
     fig.suptitle('Position & Velocity Residuals')


### PR DESCRIPTION
## Summary
- handle off-by-one issue in plot_residuals by using gnss_times[:-1]

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685013b5c1648325935eaac3780202b9