### PR TITLE
Add TRIAD-only helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,16 @@ All cases: 100%|##########| 9/9 [00:12<00:00,  1.31s/it]
 └─────────┴──────────┴──────────────┴───────────┘
 ```
 
+## Running only the TRIAD method
+
+If you want to process all datasets using just the TRIAD initialisation method, run the helper script `run_triad_only.py`:
+
+```bash
+python run_triad_only.py
+```
+This is equivalent to running `run_all_datasets.py --method TRIAD`.
+
+
 After all runs complete you can compare the datasets side by side:
 
 ```bash

--- a/run_triad_only.py
+++ b/run_triad_only.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+"""Run all datasets using only the TRIAD initialisation method."""
+import subprocess
+import sys
+import pathlib
+
+HERE = pathlib.Path(__file__).resolve().parent
+cmd = [sys.executable, str(HERE / "run_all_datasets.py"), "--method", "TRIAD"] + sys.argv[1:]
+subprocess.run(cmd, check=True)


### PR DESCRIPTION
## Summary
- add `run_triad_only.py` wrapper to run all datasets with TRIAD
- document new script in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685097ea16a483258170f435111f98a3