### PR TITLE
Enhance static detection and ZUPT

### DIFF
--- a/tests/test_static_detection.py
+++ b/tests/test_static_detection.py
@@ -17,6 +17,21 @@ def test_detect_static_interval_basic():
     assert end > 400
 
 
+def test_detect_static_interval_longest():
+    rng = np.random.default_rng(2)
+    static_short_acc = rng.normal(0, 0.001, size=(80, 3))
+    static_short_gyro = rng.normal(0, 1e-5, size=(80, 3))
+    moving = rng.normal(0, 0.1, size=(200, 3))
+    moving_g = rng.normal(0, 0.01, size=(200, 3))
+    static_long_acc = rng.normal(0, 0.001, size=(200, 3))
+    static_long_gyro = rng.normal(0, 1e-5, size=(200, 3))
+    accel = np.vstack([static_short_acc, moving, static_long_acc])
+    gyro = np.vstack([static_short_gyro, moving_g, static_long_gyro])
+    start, end = detect_static_interval(accel, gyro, window_size=50, min_length=80)
+    assert start >= len(static_short_acc) + len(moving) - 1
+    assert end - start >= len(static_long_acc)
+
+
 def test_is_static_true_false():
     rng = np.random.default_rng(1)
     static_acc = rng.normal(0, 0.001, size=(200, 3))

--- a/utils.py
+++ b/utils.py
@@ -48,10 +48,14 @@ def detect_static_interval(accel_data, gyro_data, window_size=200,
             i0 = g[0][0]
             i1 = g[-1][0] + window_size
             groups.append((i0, i1))
+
+    # pick the longest static group that satisfies the minimum length
+    longest = (0, window_size)
     for i0, i1 in groups:
-        if i1 - i0 >= min_length:
-            return i0, i1
-    return 0, window_size
+        if i1 - i0 >= min_length and i1 - i0 > longest[1] - longest[0]:
+            longest = (i0, i1)
+
+    return longest
 
 
 def is_static(accel_win, gyro_win, accel_var_thresh=0.01, gyro_var_thresh=1e-6):


### PR DESCRIPTION
## Summary
- improve `detect_static_interval` to choose the longest static block
- test detection of the longest static interval
- detect TRIAD window via rolling variance and log details
- output initial attitude angles and apply ZUPT dynamically during Kalman filtering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685102de9cc883259a4f80ec98514c91