### PR TITLE
Add ZUPT diagnostics utilities

### DIFF
--- a/scripts/plot_utils.py
+++ b/scripts/plot_utils.py
@@ -23,3 +23,50 @@ def plot_attitude(time, quats, outpath):
     fig.tight_layout(rect=[0, 0, 1, 0.96])
     fig.savefig(outpath)
     plt.close(fig)
+
+import numpy as np
+
+
+def plot_zupt_detection(accel_data: np.ndarray, gyro_data: np.ndarray,
+                        zupt_mask: np.ndarray, sampling_period: float):
+    """Plot acceleration and gyro norms with highlighted ZUPT segments."""
+    t = np.arange(len(accel_data)) * sampling_period
+    accel_norm = np.linalg.norm(accel_data, axis=1)
+    gyro_norm = np.linalg.norm(gyro_data, axis=1)
+
+    fig, axs = plt.subplots(2, 1, sharex=True)
+    axs[0].plot(t, accel_norm, label="|accel|")
+    axs[1].plot(t, gyro_norm, label="|gyro|")
+    axs[0].set_ylabel("Accel Norm [m/s²]")
+    axs[1].set_ylabel("Gyro Norm [rad/s]")
+    axs[1].set_xlabel("Time [s]")
+
+    for ax in axs:
+        ax.fill_between(t, ax.get_ylim()[0], ax.get_ylim()[1],
+                        where=zupt_mask, color='green', alpha=0.1,
+                        label='ZUPT active')
+        ax.legend()
+        ax.grid(True)
+
+    fig.tight_layout()
+    return fig
+
+
+def plot_initial_attitude(triad_rotation_matrices: dict):
+    """Print and plot initial Euler angles from TRIAD results."""
+    results = {}
+    for ds, R_b2n in triad_rotation_matrices.items():
+        rot = R.from_matrix(R_b2n)
+        euler_deg = rot.as_euler('zyx', degrees=True)
+        results[ds] = euler_deg
+        fig, ax = plt.subplots()
+        ax.bar(['Yaw', 'Pitch', 'Roll'], euler_deg)
+        ax.set_ylabel('Degrees')
+        ax.set_title(f'Initial Attitude (TRIAD) for {ds}')
+        fig.tight_layout()
+        plt.close(fig)
+        print(
+            f"Dataset {ds}: Initial Yaw={euler_deg[0]:.2f}°, "
+            f"Pitch={euler_deg[1]:.2f}°, Roll={euler_deg[2]:.2f}°"
+        )
+    return results

--- a/tests/test_utils_additional.py
+++ b/tests/test_utils_additional.py
@@ -1,0 +1,23 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import numpy as np
+from utils import adaptive_zupt_threshold, save_static_zupt_params
+
+
+def test_adaptive_zupt_threshold_constant():
+    accel = np.ones((500, 3))
+    gyro = np.ones((500, 3)) * 0.5
+    a_t, g_t = adaptive_zupt_threshold(accel, gyro, factor=2.0)
+    assert np.isclose(a_t, np.sqrt(3))
+    assert np.isclose(g_t, np.sqrt(3) * 0.5)
+
+
+def test_save_static_zupt_params(tmp_path):
+    f = tmp_path / "params.txt"
+    save_static_zupt_params(f, 10, 20, 3, 0.4)
+    content = f.read_text()
+    assert "Static start: 10" in content
+    assert "Static end: 20" in content
+    assert "Static length: 10" in content
+    assert "ZUPT threshold: 0.4" in content
+    assert "Total ZUPT events: 3" in content


### PR DESCRIPTION
## Summary
- add diagnostics helpers for ZUPT detection and logging
- support plotting functions for ZUPT detection and initial attitude
- add tests for new utilities

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685107e5867c8325a4ef896d8dab7d3b