### PR TITLE
Fix Python 3.8 compatibility

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,5 @@
 import numpy as np
+from typing import Tuple
 
 
 def detect_static_interval(accel_data, gyro_data, window_size=200,
@@ -94,7 +95,7 @@ def save_static_zupt_params(filename: str, static_start: int, static_end: int,
 
 
 def adaptive_zupt_threshold(accel_data: np.ndarray, gyro_data: np.ndarray,
-                            factor: float = 3.0) -> tuple[float, float]:
+                            factor: float = 3.0) -> Tuple[float, float]:
     """Return adaptive thresholds based on early-sample statistics."""
     norm_accel = np.linalg.norm(accel_data, axis=1)
     norm_gyro = np.linalg.norm(gyro_data, axis=1)

--- a/validate_filter.py
+++ b/validate_filter.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import argparse
 import os
-from typing import Sequence
+from typing import Sequence, Tuple
 
 import numpy as np
 import pandas as pd
@@ -27,7 +27,7 @@ def _find_cols(df: pd.DataFrame, options: Sequence[Sequence[str]]) -> Sequence[s
     raise KeyError(f"None of the column sets {options!r} found in {list(df.columns)}")
 
 
-def load_data(est_path: str, gnss_path: str) -> tuple[pd.DataFrame, pd.DataFrame]:
+def load_data(est_path: str, gnss_path: str) -> Tuple[pd.DataFrame, pd.DataFrame]:
     est = pd.read_csv(est_path)
     gnss = pd.read_csv(gnss_path)
 
@@ -45,7 +45,7 @@ def load_data(est_path: str, gnss_path: str) -> tuple[pd.DataFrame, pd.DataFrame
     return est, gnss
 
 
-def compute_residuals(est: pd.DataFrame, gnss: pd.DataFrame) -> tuple[pd.DataFrame, np.ndarray]:
+def compute_residuals(est: pd.DataFrame, gnss: pd.DataFrame) -> Tuple[pd.DataFrame, np.ndarray]:
     """Merge filter estimates with GNSS and return residual arrays."""
     pos_cols_est = _find_cols(est, [
         ['x', 'y', 'z'],


### PR DESCRIPTION
## Summary
- add missing typing imports
- use `Tuple` instead of `tuple[...]` generics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685109d6f3fc8325a0c1cac0e2d7a6fe