### PR TITLE
Fix type annotations for Python 3.8

### DIFF
--- a/scripts/plot_utils.py
+++ b/scripts/plot_utils.py
@@ -1,5 +1,6 @@
 import matplotlib.pyplot as plt
 from scipy.spatial.transform import Rotation as R
+from typing import List
 
 
 def save_plot(fig, outpath, title):
@@ -122,7 +123,7 @@ def plot_zupt_and_variance(accel: np.ndarray, zupt_mask: np.ndarray, dt: float,
     return fig
 
 
-def plot_triad_euler(triad_rotmats: list[np.ndarray], dataset_names: list[str]):
+def plot_triad_euler(triad_rotmats: List[np.ndarray], dataset_names: List[str]):
     """Plot TRIAD initial Euler angles (roll, pitch, yaw) for multiple datasets."""
     eulers = [R.from_matrix(Rm).as_euler("zyx", degrees=True) for Rm in triad_rotmats]
     eulers = np.asarray(eulers)


### PR DESCRIPTION
## Summary
- import List from typing in `plot_utils.py`
- use List[...] to avoid runtime `TypeError` on Python 3.8

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68511b65ddec8325bbe36e6c706be034