### PR TITLE
Add flexible path handling to export_mat.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,22 @@ plot_results('results/IMU_X001_GNSS_X001_TRIAD_kf_output.mat');
 validate_3sigma('results/IMU_X001_GNSS_X001_TRIAD_kf_output.mat', 'STATE_X001.txt');
 ```
 
+## Export to MATLAB (.mat) files
+To convert the saved Python results into MATLAB `.mat` files, run from the repo root:
+
+```bash
+cd /path/to/IMU
+pip install numpy scipy
+python export_mat.py
+```
+
+Or from *any* directory by giving the full path:
+
+```bash
+pip install numpy scipy
+python /path/to/IMU/export_mat.py
+```
+
 ## Next Steps
 
 - **Logging:** Extend the built-in `logging` with the `rich` console handler to

--- a/export_mat.py
+++ b/export_mat.py
@@ -1,8 +1,17 @@
 #!/usr/bin/env python3
 """Export results for MATLAB"""
+import os
+import sys
+script_dir = os.path.dirname(os.path.abspath(__file__))
+os.chdir(script_dir)
+
 import numpy as np
 from scipy.io import savemat
 import pathlib
+
+if not os.path.exists('STATE_X001.txt'):
+    print("ERROR: export_mat.py must be run from its own folder or with full path.")
+    sys.exit(1)
 
 DATASETS = ['X001', 'X002', 'X003']
 


### PR DESCRIPTION
## Summary
- allow `export_mat.py` to change into its own directory before loading files
- stop execution if it's run from the wrong location
- document how to run `export_mat.py` in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855c7b2ea648325aca18941e527846a