### PR TITLE
Fix Matlab Wahba message quoting

### DIFF
--- a/IMU_MATLAB/Task_3.m
+++ b/IMU_MATLAB/Task_3.m
@@ -1,6 +1,6 @@
 function Task_3()
     % TASK 3: Solve Wahba's problem (attitude determination)
-    fprintf('\nTASK 3: Solve Wahba\'s problem\n');
+    fprintf('\nTASK 3: Solve Wahba''s problem\n');
 
     S1 = load(fullfile('results','Task1_init.mat'));
     S2 = load(fullfile('results','Task2_body.mat'));


### PR DESCRIPTION
## Summary
- fix escaped single quote in `Task_3.m`

## Testing
- `pytest -q`
- `octave -qf Task_3.m` *(fails: unable to find file results/Task1_init.mat)*

------
https://chatgpt.com/codex/tasks/task_e_685d1909d7b88325a5443e4c5a040236