### PR TITLE
Fix Task 4 position offset subtraction

### DIFF
--- a/IMU_MATLAB/Task_4.m
+++ b/IMU_MATLAB/Task_4.m
@@ -14,7 +14,7 @@ function Task_4()
 
     C = ecef2ned_matrix(deg2rad(lat), deg2rad(lon));
     r0 = pos_ecef(1,:)';
-    pos_ned = (C*(pos_ecef - r0)')';
+    pos_ned = (C*(pos_ecef - r0')')';
     vel_ned = (C*vel_ecef')';
 
     data = load(get_data_file('IMU_X001.dat'));


### PR DESCRIPTION
## Summary
- fix dimension mismatch when converting GNSS ECEF positions to NED in MATLAB Task 4

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d1ace39b083259d221a2faf2dfdb0