### PR TITLE
Fix MATLAB Kalman filter initialization

### DIFF
--- a/IMU_MATLAB/Task_5.m
+++ b/IMU_MATLAB/Task_5.m
@@ -12,7 +12,9 @@ function Task_5()
     pos_ecef = [T.X_ECEF_m T.Y_ECEF_m T.Z_ECEF_m];
     C = ecef2ned_matrix(deg2rad(lat), deg2rad(lon));
     r0 = pos_ecef(1,:)';
-    pos_ned = (C*(pos_ecef - r0)')';
+    % convert GNSS ECEF coordinates to NED relative to the start point
+    % use r0' to broadcast the origin across all rows
+    pos_ned = (C*(pos_ecef - r0')')';
 
     imu = load(get_data_file('IMU_X001.dat'));
     dt = mean(diff(imu(1:100,2))); if dt<=0, dt=1/400; end


### PR DESCRIPTION
## Summary
- address dimension mismatch when converting GNSS ECEF to NED in Task 5

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d26c4b644832597b6ce04a078f8aa