### PR TITLE
Add method selection for MATLAB tasks

### DIFF
--- a/IMU_MATLAB/Task_3.m
+++ b/IMU_MATLAB/Task_3.m
@@ -1,9 +1,12 @@
-function Task_3(imuFile, gnssFile)
+function Task_3(imuFile, gnssFile, method)
     % TASK 3: Solve Wahba's problem (attitude determination)
     fprintf('\nTASK 3: Solve Wahba''s problem\n');
 
     if ~exist('results','dir')
         mkdir('results');
+    end
+    if nargin < 3 || isempty(method)
+        method = 'TRIAD';
     end
     [~, imu_name, ~] = fileparts(imuFile);
     [~, gnss_name, ~] = fileparts(gnssFile);
@@ -30,6 +33,24 @@ function Task_3(imuFile, gnssFile)
     q_tri = rotm2quat(R_tri);
     if q_tri(1) < 0, q_tri = -q_tri; end
 
+    % Davenport's Q-Method
+    w_gravity = 0.9999;
+    w_omega   = 0.0001;
+    B_dav = w_gravity*(v1_N*v1_B') + w_omega*(v2_N*v2_B');
+    sigma = trace(B_dav);
+    S = B_dav + B_dav';
+    Z = [B_dav(2,3)-B_dav(3,2); B_dav(3,1)-B_dav(1,3); B_dav(1,2)-B_dav(2,1)];
+    K = [sigma, Z'; Z, S - sigma*eye(3)];
+    [Vd, Dd] = eig(K);
+    [~, idx] = max(diag(Dd));
+    qd = Vd(:, idx);
+    if qd(1) < 0, qd = -qd; end
+    q_dav = [qd(1); -qd(2:4)]; % conjugate for body to NED
+    qw = q_dav(1); qx = q_dav(2); qy = q_dav(3); qz = q_dav(4);
+    R_dav = [1-2*(qy^2+qz^2), 2*(qx*qy - qw*qz), 2*(qx*qz + qw*qy);
+             2*(qx*qy + qw*qz), 1-2*(qx^2+qz^2), 2*(qy*qz - qw*qx);
+             2*(qx*qz - qw*qy), 2*(qy*qz + qw*qx), 1-2*(qx^2+qy^2)];
+
     % SVD alignment
     B = v1_N*v1_B' + v2_N*v2_B';
     [U,~,V] = svd(B);
@@ -37,8 +58,20 @@ function Task_3(imuFile, gnssFile)
     q_svd = rotm2quat(R_svd);
     if q_svd(1) < 0, q_svd = -q_svd; end
 
-    fprintf('Quaternion TRIAD: [% .8f % .8f % .8f % .8f]\n', q_tri);
-    fprintf('Quaternion SVD:   [% .8f % .8f % .8f % .8f]\n', q_svd);
+    fprintf('Quaternion TRIAD:     [% .8f % .8f % .8f % .8f]\n', q_tri);
+    fprintf('Quaternion Davenport: [% .8f % .8f % .8f % .8f]\n', q_dav);
+    fprintf('Quaternion SVD:       [% .8f % .8f % .8f % .8f]\n', q_svd);
 
-    save(fullfile('results', ['Task3_attitude_' tag '.mat']), 'R_tri', 'R_svd', 'q_tri', 'q_svd');
+    switch lower(method)
+        case 'triad'
+            R_BN = R_tri; q_BN = q_tri;
+        case 'davenport'
+            R_BN = R_dav; q_BN = q_dav;
+        case 'svd'
+            R_BN = R_svd; q_BN = q_svd;
+        otherwise
+            error('Unknown method: %s', method);
+    end
+
+    save(fullfile('results', ['Task3_attitude_' method '_' tag '.mat']), 'R_BN', 'q_BN');
 end

--- a/IMU_MATLAB/Task_4.m
+++ b/IMU_MATLAB/Task_4.m
@@ -1,18 +1,21 @@
-function Task_4(imuFile, gnssFile)
+function Task_4(imuFile, gnssFile, method)
     % TASK 4: GNSS + IMU data comparison
     fprintf('\nTASK 4: GNSS and IMU data comparison\n');
 
     if ~exist('results','dir')
         mkdir('results');
     end
+    if nargin < 3 || isempty(method)
+        method = 'TRIAD';
+    end
     [~, imu_name, ~] = fileparts(imuFile);
     [~, gnss_name, ~] = fileparts(gnssFile);
     tag = [imu_name '_' gnss_name];
 
     S1 = load(fullfile('results', ['Task1_init_' tag '.mat']));
-    S2 = load(fullfile('results', ['Task3_attitude_' tag '.mat']));
+    S2 = load(fullfile('results', ['Task3_attitude_' method '_' tag '.mat']));
     lat = S1.lat; lon = S1.lon; g_NED = S1.g_NED;
-    R_BN = S2.R_tri; % use TRIAD result
+    R_BN = S2.R_BN;
 
     opts = detectImportOptions(get_data_file(gnssFile), 'NumHeaderLines',0);
     T = readtable(get_data_file(gnssFile), opts);
@@ -41,9 +44,9 @@ function Task_4(imuFile, gnssFile)
     figure; subplot(3,1,1); plot(time,pos_ned(:,1),'k'); hold on; plot((0:length(pos_est)-1)*dt,pos_est(:,1),'r'); ylabel('North (m)');
     subplot(3,1,2); plot(time,pos_ned(:,2),'k'); hold on; plot((0:length(pos_est)-1)*dt,pos_est(:,2),'r'); ylabel('East (m)');
     subplot(3,1,3); plot(time,pos_ned(:,3),'k'); hold on; plot((0:length(pos_est)-1)*dt,pos_est(:,3),'r'); ylabel('Down (m)'); xlabel('Time (s)'); legend('GNSS','IMU');
-    saveas(gcf, fullfile('results', ['Task4_compare_' tag '.png'])); close;
+    saveas(gcf, fullfile('results', ['Task4_compare_' method '_' tag '.png'])); close;
 
-    save(fullfile('results', ['Task4_compare_' tag '.mat']), 'pos_ned','pos_est');
+    save(fullfile('results', ['Task4_compare_' method '_' tag '.mat']), 'pos_ned','pos_est');
 end
 
 function C = ecef2ned_matrix(lat, lon)

--- a/IMU_MATLAB/Task_5.m
+++ b/IMU_MATLAB/Task_5.m
@@ -1,18 +1,21 @@
-function Task_5(imuFile, gnssFile)
+function Task_5(imuFile, gnssFile, method)
     % TASK 5: Kalman filter sensor fusion
     fprintf('\nTASK 5: Kalman filter sensor fusion\n');
 
     if ~exist('results','dir')
         mkdir('results');
     end
+    if nargin < 3 || isempty(method)
+        method = 'TRIAD';
+    end
     [~, imu_name, ~] = fileparts(imuFile);
     [~, gnss_name, ~] = fileparts(gnssFile);
     tag = [imu_name '_' gnss_name];
 
     S1 = load(fullfile('results', ['Task1_init_' tag '.mat']));
-    S3 = load(fullfile('results', ['Task3_attitude_' tag '.mat']));
+    S3 = load(fullfile('results', ['Task3_attitude_' method '_' tag '.mat']));
     lat = S1.lat; lon = S1.lon; g_NED = S1.g_NED;
-    R_BN = S3.R_tri;
+    R_BN = S3.R_BN;
 
     T = readtable(get_data_file(gnssFile));
     gnss_t = T.Posix_Time - T.Posix_Time(1);
@@ -62,10 +65,10 @@ function Task_5(imuFile, gnssFile)
     figure; subplot(2,1,1); plot(imu_t,fused_pos); hold on; plot(gnss_t,pos_ned,'k.');
     legend('x','y','z','GNSS'); ylabel('Position (m)');
     subplot(2,1,2); plot(imu_t,fused_vel); ylabel('Velocity (m/s)'); xlabel('Time (s)');
-    saveas(gcf, fullfile('results', ['Task5_fused_' tag '.png'])); close;
+    saveas(gcf, fullfile('results', ['Task5_fused_' method '_' tag '.png'])); close;
 
 
-    save(fullfile('results', ['Task5_fused_' tag '.mat']),'fused_pos','fused_vel');
+    save(fullfile('results', ['Task5_fused_' method '_' tag '.mat']),'fused_pos','fused_vel');
 end
 
 function C = ecef2ned_matrix(lat, lon)


### PR DESCRIPTION
## Summary
- add optional `method` argument to MATLAB Task_3/4/5
- implement Davenport's Q‑Method
- save/load method‑specific results and plots

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d57a5fd148325b3b649dcc1dc6aae