### PR TITLE
Fix Euler angles time mismatch

### DIFF
--- a/GNSS_IMU_Fusion.py
+++ b/GNSS_IMU_Fusion.py
@@ -1390,6 +1390,8 @@ def main():
         orientations[0] = initial_quats[m]
         attitude_q.append(orientations[0])
         q_cur = orientations[0]
+        roll, pitch, yaw = quat2euler(q_cur)
+        euler_list.append([roll, pitch, yaw])
         
 
         


### PR DESCRIPTION
## Summary
- ensure initial quaternion is converted to Euler angles
- keep euler time series length consistent with imu time

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685d5bbfb6908325872534e006158510