### PR TITLE
Improve test docs and tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,5 @@ jobs:
       image: mcr.microsoft.com/vscode/devcontainers/python:0-3.10
     steps:
       - uses: actions/checkout@v3
-      - name: Install deps
-        run: pip install -r requirements.txt
-      - name: Run smoke tests
-        run: pytest --maxfail=1 --disable-warnings -q
+      - name: Run tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: test
+
+test:
+	pip install -r requirements.txt
+	pytest -q

--- a/README.md
+++ b/README.md
@@ -178,11 +178,16 @@ A codex-style plotting checklist is available in [docs/PlottingChecklist.md](doc
 
 ## Tests
 
-Run the unit tests with `pytest`:
+Run the unit tests with `pytest`. Make sure the Python dependencies are
+installed first:
 
 ```bash
+pip install -r requirements.txt
 pytest -q
 ```
+
+You can also simply run `make test` to install the requirements and execute the
+test suite in one command.
 
 ## MATLAB Compatibility
 


### PR DESCRIPTION
## Summary
- document that pytest requires dependencies from requirements.txt
- add a Makefile with a `test` target
- update CI to run `make test`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685d62f192f48325a7f00a54a908934f