### PR TITLE
Improve Task_4 robustness

### DIFF
--- a/IMU_MATLAB/README.md
+++ b/IMU_MATLAB/README.md
@@ -33,6 +33,10 @@ for each of the attitude initialisation methods (`TRIAD`, `Davenport` and
 `SVD`). Output files include the method name so results are preserved for
 every run.
 
+`Task_4` expects the rotation matrices produced by `Task_3` to be saved as
+`results/task3_results.mat`. Make sure `Task_3` completes before running
+`Task_4` separately.
+
 `Task_1` and `Task_2` are now functions, so you can also call them directly as
 ```matlab
 Task_1('IMU_X001.dat','GNSS_X001.csv')

--- a/IMU_MATLAB/Task_4.m
+++ b/IMU_MATLAB/Task_4.m
@@ -3,6 +3,7 @@ function Task_4(imu_file, gnss_file, method)
 %   Task_4(IMUFILE, GNSSFILE, METHOD) runs the GNSS/IMU integration
 %   using the attitude estimates from Task 3. METHOD is unused but kept
 %   for backwards compatibility with older scripts.
+%   Requires that `Task_3` has already saved `results/task3_results.mat`.
 
 if nargin < 1 || isempty(imu_file)
     imu_file = 'IMU_X001.dat';
@@ -22,7 +23,16 @@ results_dir = 'results';
 [~, gnss_name, ~] = fileparts(gnss_file);
 tag = [imu_name '_' gnss_name];
 
-load(fullfile(results_dir, 'task3_results.mat'), 'task3_results');
+% Load rotation matrices produced by Task 3
+results_file = fullfile(results_dir, 'task3_results.mat');
+if ~isfile(results_file)
+    error('Task 3 results not found: %s', results_file);
+end
+data = load(results_file);
+if ~isfield(data, 'task3_results')
+    error('Variable ''task3_results'' missing from %s', results_file);
+end
+task3_results = data.task3_results;
 
 fprintf('\nTASK 4: GNSS and IMU Data Integration and Comparison\n');
 
@@ -43,8 +53,9 @@ fprintf('-> Rotation matrices accessed for methods: %s\n', strjoin(methods, ', '
 % Subtask 4.3: Load GNSS Data
 % =========================================================================
 fprintf('\nSubtask 4.3: Loading GNSS data.\n');
+gnss_path = get_data_file(gnss_file);
 try
-    gnss_data = readtable(gnss_file);
+    gnss_data = readtable(gnss_path);
 catch e
     error('Failed to load GNSS data file: %s', e.message);
 end


### PR DESCRIPTION
## Summary
- explain that Task_3 results are required in Task_4 README
- handle missing `task3_results.mat` in Task_4
- resolve GNSS path using `get_data_file`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d92ef43a0832595c4e76ee643c3ea