### PR TITLE
Clean up MATLAB dataset handling

### DIFF
--- a/IMU_MATLAB/Task_3.m
+++ b/IMU_MATLAB/Task_3.m
@@ -7,10 +7,10 @@ function task3_results = Task_3(imuFile, gnssFile, method)
 % matrices for later tasks.
 
 if nargin < 1 || isempty(imuFile)
-    imuFile = 'IMU_X001.dat';
+    error('IMU file not specified');
 end
 if nargin < 2 || isempty(gnssFile)
-    gnssFile = 'GNSS_X001.csv';
+    error('GNSS file not specified');
 end
 if nargin < 3
     method = ''; %#ok<NASGU>  % unused but kept for API compatibility

--- a/IMU_MATLAB/Task_4.m
+++ b/IMU_MATLAB/Task_4.m
@@ -6,10 +6,10 @@ function Task_4(imu_file, gnss_file, method)
 %   Requires that `Task_3` has already saved `results/task3_results.mat`.
 
 if nargin < 1 || isempty(imu_file)
-    imu_file = 'IMU_X001.dat';
+    error('IMU file not specified');
 end
 if nargin < 2 || isempty(gnss_file)
-    gnss_file = 'GNSS_X001.csv';
+    error('GNSS file not specified');
 end
 if nargin < 3
     method = ''; %#ok<NASGU>

--- a/IMU_MATLAB/main.m
+++ b/IMU_MATLAB/main.m
@@ -3,11 +3,15 @@ function main(imuFile, gnssFile)
 %   main()                      - use the default sample files
 %   main('imu.dat','gnss.csv') - run with custom data files
 
-if nargin < 1 || isempty(imuFile)
-    imuFile = 'IMU_X001.dat';
+% Resolve default data file paths
+imu_file  = get_data_file('IMU_X001');
+gnss_file = get_data_file('GNSS_X001');
+
+if nargin >= 1 && ~isempty(imuFile)
+    imu_file = imuFile;
 end
-if nargin < 2 || isempty(gnssFile)
-    gnssFile = 'GNSS_X001.csv';
+if nargin >= 2 && ~isempty(gnssFile)
+    gnss_file = gnssFile;
 end
 
 clc; close all;
@@ -19,15 +23,15 @@ end
 
 fprintf('Running IMU+GNSS Initialization Pipeline (MATLAB Version)\n');
 
-Task_1(imuFile, gnssFile);
-Task_2(imuFile, gnssFile);
+Task_1(imu_file, gnss_file);
+Task_2(imu_file, gnss_file);
 
 methods = {'TRIAD','Davenport','SVD'};
 for i = 1:numel(methods)
     method = methods{i};
-    Task_3(imuFile, gnssFile, method);
-    Task_4(imuFile, gnssFile, method);
-    Task_5(imuFile, gnssFile, method);
+    Task_3(imu_file, gnss_file, method);
+    Task_4(imu_file, gnss_file, method);
+    Task_5(imu_file, gnss_file, method);
 end
 
 fprintf('All tasks completed!\n');


### PR DESCRIPTION
## Summary
- centralize default data resolution in `main.m`
- remove hard-coded dataset names from Task scripts
- update Task calls to use resolved paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e01d35ce0832580b7b454bed1d818