### PR TITLE
Add existence checks for MATLAB tasks

### DIFF
--- a/IMU_MATLAB/Task_3.m
+++ b/IMU_MATLAB/Task_3.m
@@ -25,8 +25,16 @@ tag = [imu_name '_' gnss_name];
 results_dir = 'results';
 
 % Load vectors produced by Task 1 and Task 2
-init_data = load(fullfile(results_dir, ['Task1_init_' tag '.mat']));
-body_data = load(fullfile(results_dir, ['Task2_body_' tag '.mat']));
+task1_file = fullfile(results_dir, ['Task1_init_' tag '.mat']);
+task2_file = fullfile(results_dir, ['Task2_body_' tag '.mat']);
+if ~isfile(task1_file)
+    error('Task_3:MissingFile', 'Missing Task 1 output: %s', task1_file);
+end
+if ~isfile(task2_file)
+    error('Task_3:MissingFile', 'Missing Task 2 output: %s', task2_file);
+end
+init_data = load(task1_file);
+body_data = load(task2_file);
 
 g_NED = init_data.g_NED;
 omega_ie_NED = init_data.omega_NED;

--- a/IMU_MATLAB/Task_4.m
+++ b/IMU_MATLAB/Task_4.m
@@ -54,6 +54,9 @@ fprintf('-> Rotation matrices accessed for methods: %s\n', strjoin(methods, ', '
 % =========================================================================
 fprintf('\nSubtask 4.3: Loading GNSS data.\n');
 gnss_path = get_data_file(gnss_file);
+if ~isfile(gnss_path)
+    error('Task_4:MissingFile', 'GNSS file not found: %s', gnss_path);
+end
 try
     gnss_data = readtable(gnss_path);
 catch e
@@ -120,6 +123,9 @@ fprintf('-> GNSS acceleration estimated in NED frame.\n');
 % =========================================================================
 fprintf('\nSubtask 4.9: Loading IMU data and correcting for bias for each method.\n');
 imu_path = get_data_file(imu_file);
+if ~isfile(imu_path)
+    error('Task_4:MissingFile', 'IMU file not found: %s', imu_path);
+end
 imu_raw_data = readmatrix(imu_path);
 dt_imu = mean(diff(imu_raw_data(1:100,2)));
 if dt_imu <= 0 || isnan(dt_imu), dt_imu = 1/400; end

--- a/IMU_MATLAB/Task_5.m
+++ b/IMU_MATLAB/Task_5.m
@@ -5,6 +5,13 @@
 % =========================================================================
 fprintf('\nTASK 5: Sensor Fusion with Kalman Filter\n');
 
+% Ensure Task 3 results are available
+results_dir = 'results';
+results_file = fullfile(results_dir, 'task3_results.mat');
+if ~isfile(results_file)
+    error('Task_5:MissingFile', 'Task 3 results not found: %s', results_file);
+end
+
 %% ========================================================================
 % Subtask 5.1-5.5: Configure and Initialize 9-State Filter
 % =========================================================================


### PR DESCRIPTION
## Summary
- validate Task1/Task2 MAT files before solving Wahba problem
- verify GNSS and IMU files before loading in Task 4
- ensure Task 5 fails clearly if Task 3 results are missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e01d5b774832598281550421b9bc8