### PR TITLE
Add MATLAB pipeline smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,3 +9,5 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run tests
         run: make test
+      - name: Run MATLAB smoke test
+        run: pytest -q tests/test_pipeline_smoke.py

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -1,0 +1,23 @@
+import os
+import subprocess
+import shutil
+from pathlib import Path
+import pytest
+import scipy.io
+
+
+def test_pipeline_smoke(tmp_path):
+    matlab = shutil.which("matlab")
+    if not matlab:
+        pytest.skip("MATLAB not available")
+    # Run MATLAB pipeline from repo root
+    subprocess.run([matlab, "-batch", "main"], check=True)
+    out4 = Path("results/task4_results.mat")
+    out5 = Path("results/task5_results.mat")
+    assert out4.exists(), f"Missing {out4}"
+    assert out5.exists(), f"Missing {out5}"
+    data4 = scipy.io.loadmat(out4)
+    data5 = scipy.io.loadmat(out5)
+    for data in (data4, data5):
+        assert "gnss_pos_ned" in data
+        assert "gnss_vel_ned" in data


### PR DESCRIPTION
## Summary
- add `test_pipeline_smoke.py` to run the MATLAB pipeline when MATLAB is available
- execute this new smoke test in CI

## Testing
- `make test`
- `pytest -q tests/test_pipeline_smoke.py`

------
https://chatgpt.com/codex/tasks/task_e_685e01d89db48325a274a8369734bec0