### PR TITLE
Fix MATLAB pipeline per-method outputs

### DIFF
--- a/IMU_MATLAB/README.md
+++ b/IMU_MATLAB/README.md
@@ -30,10 +30,9 @@ Task_4('IMU_X001.dat','GNSS_X001.csv')
 Task_5('IMU_X001.dat','GNSS_X001.csv', gnss_pos_ned)
 ```
 
-`main` executes `Task_1` and `Task_2` once and then runs `Task_3`–`Task_5`
-for each of the attitude initialisation methods (`TRIAD`, `Davenport` and
-`SVD`). Output files include the method name so results are preserved for
-every run.
+`main` executes `Task_1`–`Task_5` for each of the attitude initialisation
+methods (`TRIAD`, `Davenport` and `SVD`). Output files include the method
+name so results are preserved for every run.
 
 `Task_4` expects the rotation matrices produced by `Task_3` to be saved as
 `results/task3_results.mat`. Make sure `Task_3` completes before running
@@ -44,10 +43,11 @@ every run.
 `Task_5` looks for this file when started or you can pass `gnss_pos_ned`
 directly as an argument.
 
-`Task_1` and `Task_2` are now functions, so you can also call them directly as
+`Task_1` and `Task_2` are now functions that accept an optional method name,
+so you can call them directly as
 ```matlab
-Task_1('IMU_X001.dat','GNSS_X001.csv')
-Task_2('IMU_X001.dat','GNSS_X001.csv')
+Task_1('IMU_X001.dat','GNSS_X001.csv','TRIAD')
+Task_2('IMU_X001.dat','GNSS_X001.csv','TRIAD')
 ```
 
 ### Compatibility notes

--- a/IMU_MATLAB/Task_1.m
+++ b/IMU_MATLAB/Task_1.m
@@ -1,7 +1,11 @@
-function Task_1(imu_path, gnss_path)
+function Task_1(imu_path, gnss_path, method)
 % TASK 1: Define Reference Vectors in NED Frame
 % This function translates Task 1 from the Python file GNSS_IMU_Fusion.py
 % into MATLAB.
+
+if nargin < 3 || isempty(method)
+    method = '';
+end
 
 if ~isfile(gnss_path)
     error('Task_1:GNSSFileNotFound', ...
@@ -20,13 +24,22 @@ if ~exist('results','dir')
     mkdir('results');
 end
 
-fprintf('TASK 1: Define reference vectors in NED frame\n');
+if isempty(method)
+    log_tag = '';
+else
+    log_tag = [' (' method ')'];
+end
+fprintf('TASK 1%s: Define reference vectors in NED frame\n', log_tag);
 
 % --- Configuration ---
 results_dir = 'results';
 [~, imu_name, ~] = fileparts(imu_path);
 [~, gnss_name, ~] = fileparts(gnss_path);
-tag = [imu_name '_' gnss_name];
+if isempty(method)
+    tag = [imu_name '_' gnss_name];
+else
+    tag = [imu_name '_' gnss_name '_' method];
+end
 
 
 % ================================

--- a/IMU_MATLAB/Task_2.m
+++ b/IMU_MATLAB/Task_2.m
@@ -1,11 +1,15 @@
 
-function Task_2(imu_path, gnss_path)
+function Task_2(imu_path, gnss_path, method)
 % =========================================================================
 % TASK 2: Measure the Vectors in the Body Frame
 %
 % This function translates Task 2 from the Python file GNSS_IMU_Fusion.py
 % into MATLAB.
 % =========================================================================
+
+if nargin < 3 || isempty(method)
+    method = '';
+end
 
 if ~isfile(gnss_path)
     error('Task_2:GNSSFileNotFound', ...
@@ -19,7 +23,12 @@ if ~isfile(imu_path)
 end
 
 
-fprintf('TASK 2: Measure the vectors in the body frame\n');
+if isempty(method)
+    log_tag = '';
+else
+    log_tag = [' (' method ')'];
+end
+fprintf('TASK 2%s: Measure the vectors in the body frame\n', log_tag);
 
 % --- Configuration ---
 if ~exist('results','dir')
@@ -27,7 +36,11 @@ if ~exist('results','dir')
 end
 [~, imu_name, ~] = fileparts(imu_path);
 [~, gnss_name, ~] = fileparts(gnss_path);
-tag = [imu_name '_' gnss_name];
+if isempty(method)
+    tag = [imu_name '_' gnss_name];
+else
+    tag = [imu_name '_' gnss_name '_' method];
+end
 
 imu_file = imu_path;
 

--- a/IMU_MATLAB/Task_3.m
+++ b/IMU_MATLAB/Task_3.m
@@ -60,7 +60,12 @@ omega_ie_body = body_data.omega_ie_body;
 
 omega_E = 7.2921159e-5; % Earth rotation rate [rad/s]
 
-fprintf('\nTASK 3: Solve Wahba\x2019s problem (find initial attitude from body to NED)\n');
+if isempty(method)
+    log_tag = '';
+else
+    log_tag = [' (' method ')'];
+end
+fprintf('\nTASK 3%s: Solve Wahba\x2019s problem (find initial attitude from body to NED)\n', log_tag);
 
 %% ========================================================================
 % Subtask 3.1: Prepare Vector Pairs for Attitude Determination
@@ -214,6 +219,10 @@ task3_results.Davenport.R = R_dav;
 task3_results.SVD.R = R_svd;
 save(fullfile(results_dir, 'task3_results.mat'), 'task3_results');
 fprintf('-> Task 3 results (Case 1) stored in memory and saved to file: task3_results.mat\n');
+
+% Also save a method-specific copy for later tasks
+method_results = task3_results.(method_tag);
+save(fullfile(results_dir, sprintf('Task3_results_%s.mat', tag)), 'method_results');
 
 end
 

--- a/IMU_MATLAB/Task_4.m
+++ b/IMU_MATLAB/Task_4.m
@@ -50,7 +50,12 @@ if ~isfield(data, 'task3_results')
 end
 task3_results = data.task3_results;
 
-fprintf('\nTASK 4: GNSS and IMU Data Integration and Comparison\n');
+if isempty(method)
+    log_tag = '';
+else
+    log_tag = [' (' method ')'];
+end
+fprintf('\nTASK 4%s: GNSS and IMU Data Integration and Comparison\n', log_tag);
 
 %% ========================================================================
 % Subtask 4.1: Access Rotation Matrices from Task 3

--- a/IMU_MATLAB/Task_5.m
+++ b/IMU_MATLAB/Task_5.m
@@ -28,7 +28,12 @@ function Task_5(imu_path, gnss_path, method, gnss_pos_ned)
     [~, gnss_name, ~] = fileparts(gnss_path);
     tag = [imu_name '_' gnss_name '_' method];
 
-    fprintf('\nTASK 5: Sensor Fusion with Kalman Filter\n');
+    if isempty(method)
+        log_tag = '';
+    else
+        log_tag = [' (' method ')'];
+    end
+    fprintf('\nTASK 5%s: Sensor Fusion with Kalman Filter\n', log_tag);
 
     % Load attitude estimate from Task 3 results
     results_file = fullfile(results_dir, 'task3_results.mat');

--- a/IMU_MATLAB/main.m
+++ b/IMU_MATLAB/main.m
@@ -23,14 +23,13 @@ end
 
 fprintf('Running IMU+GNSS Initialization Pipeline (MATLAB Version)\n');
 
-Task_1(imu_file, gnss_file);
-Task_2(imu_file, gnss_file);
-
 methods = {'TRIAD','Davenport','SVD'};
 for i = 1:numel(methods)
     method = methods{i};
-    fprintf('\n--- Running Tasks 3-5 for method: %s ---\n', method);
+    fprintf('\n=== Running pipeline for method: %s ===\n', method);
     try
+        Task_1(imu_file, gnss_file, method);
+        Task_2(imu_file, gnss_file, method);
         Task_3(imu_file, gnss_file, method);
         Task_4(imu_file, gnss_file, method);
         Task_5(imu_file, gnss_file, method);


### PR DESCRIPTION
## Summary
- loop over methods in main.m and run Tasks 1-5 for each
- allow Task_1 and Task_2 to take optional `method` parameter
- save Task1 and Task2 outputs with method suffix
- emit method names in logs for Tasks 1-5
- write method-specific Task3 result MAT files
- update README usage instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e1826e1bc83259490005ef4d89071