### PR TITLE
Precompute rotated IMU states

### DIFF
--- a/IMU_MATLAB/Task_4.m
+++ b/IMU_MATLAB/Task_4.m
@@ -440,16 +440,18 @@ function plot_single_method(method, t_gnss, t_imu, C_B_N, p_gnss_ned, v_gnss_ned
     v_gnss_ecef = (C_n2e*v_gnss_ned')';
     a_gnss_ecef = (C_n2e*a_gnss_ned')';
     a_imu_ecef  = (C_n2e*a_imu')';
+    p_imu_ecef  = (C_n2e*p_imu')';
+    v_imu_ecef  = (C_n2e*v_imu')';
     dims_e = {'X','Y','Z'};
     for i = 1:3
         subplot(3,3,i); hold on;
         plot(t_gnss, p_gnss_ecef(:,i),'k--','DisplayName','GNSS');
-        plot(t_imu, (C_n2e*p_imu')(:,i),'b-','DisplayName',method);
+        plot(t_imu, p_imu_ecef(:,i),'b-','DisplayName',method);
         hold off; grid on; legend; title(['Position ' dims_e{i}]); ylabel('m');
 
         subplot(3,3,i+3); hold on;
         plot(t_gnss, v_gnss_ecef(:,i),'k--','DisplayName','GNSS');
-        plot(t_imu, (C_n2e*v_imu')(:,i),'b-','DisplayName',method);
+        plot(t_imu, v_imu_ecef(:,i),'b-','DisplayName',method);
         hold off; grid on; legend; title(['Velocity ' dims_e{i}]); ylabel('m/s');
 
         subplot(3,3,i+6); hold on;


### PR DESCRIPTION
## Summary
- compute IMU position and velocity in ECEF frame once in `Task_4`
- plot those precomputed arrays instead of rotating repeatedly

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e58226d2883258c0574e9612b3d3a