### PR TITLE
Enhance MATLAB pipeline with method selection

### DIFF
--- a/IMU_MATLAB/README.md
+++ b/IMU_MATLAB/README.md
@@ -21,18 +21,20 @@ missing, the scripts will also look for the files in the repository root. The
 scripts save outputs and plots in `results/`.
 
 Run the entire pipeline from MATLAB by executing `main.m`. The script now
-accepts optional file names so you can run:
+accepts optional file names **and** a list of methods so you can run:
 
 ```matlab
-main                 % uses IMU\_X001.dat and GNSS\_X001.csv
+main                 % uses all bundled datasets and all methods
 main('IMU_X002.dat','GNSS_X002.csv')
+main('IMU_X001.dat','GNSS_X001.csv','TRIAD')
+main({'IMU_X001.dat','IMU_X002.dat'}, {'GNSS_X001.csv','GNSS_X002.csv'}, {'SVD'})
 Task_4('IMU_X001.dat','GNSS_X001.csv')
 Task_5('IMU_X001.dat','GNSS_X001.csv', gnss_pos_ned)
 ```
 
-`main` executes `Task_1`–`Task_5` for each of the attitude initialisation
-methods (`TRIAD`, `Davenport` and `SVD`). Output files include the method
-name so results are preserved for every run.
+`main` executes `Task_1`–`Task_5` for each selected attitude initialisation
+method (TRIAD, Davenport and SVD by default). Output files include the
+method name so results are preserved for every run.
 
 `Task_4` expects the rotation matrices produced by `Task_3` to be saved as
 `results/task3_results.mat`. Make sure `Task_3` completes before running

--- a/IMU_MATLAB/main.m
+++ b/IMU_MATLAB/main.m
@@ -1,13 +1,27 @@
-function main(imu_path, gnss_path)
+function main(imu_path, gnss_path, methods)
 %MAIN Run the IMU+GNSS initialization pipeline on a single dataset or list.
-%   main()                      - use the default sample files
-%   main('imu.dat','gnss.csv') - run with custom data files
-%   main({'IMU_X001.dat','IMU_X002.dat'}, {'GNSS_X001.csv','GNSS_X002.csv'})
-%   will iterate over both dataset pairs.
+%   main()                              - use all sample files with all methods
+%   main('imu.dat','gnss.csv')          - run one dataset with all methods
+%   main('imu.dat','gnss.csv','TRIAD')  - run one dataset with a single method
+%   main({'IMU_X001.dat','IMU_X002.dat'}, {'GNSS_X001.csv','GNSS_X002.csv'}, ...
+%        {'TRIAD','SVD'})               - iterate over both dataset pairs and
+%                                         selected methods
 
-% Resolve default data file paths or lists
-imu_list  = {get_data_file('IMU_X001.dat')};
-gnss_list = {get_data_file('GNSS_X001.csv')};
+% Resolve default data file paths or lists. The pipeline ships with three IMU
+% logs and two GNSS logs. By default we pair them as:
+%   IMU_X001.dat <-> GNSS_X001.csv
+%   IMU_X002.dat <-> GNSS_X002.csv
+%   IMU_X003.dat <-> GNSS_X002.csv
+imu_list = {
+    get_data_file('IMU_X001.dat'), ...
+    get_data_file('IMU_X002.dat'), ...
+    get_data_file('IMU_X003.dat')  ...
+    };
+gnss_list = {
+    get_data_file('GNSS_X001.csv'), ...
+    get_data_file('GNSS_X002.csv'), ...
+    get_data_file('GNSS_X002.csv')  ...
+    };
 
 % If the user passes in a single string, use it as a single item list
 if nargin >= 1 && ~isempty(imu_path)
@@ -25,6 +39,16 @@ if nargin >= 2 && ~isempty(gnss_path)
     end
 end
 
+% Optional third argument: list of methods to run
+method_list = {'TRIAD','Davenport','SVD'};
+if nargin >= 3 && ~isempty(methods)
+    if ischar(methods) || isstring(methods)
+        method_list = {char(methods)};
+    else
+        method_list = cellfun(@char, methods, 'UniformOutput', false);
+    end
+end
+
 if numel(imu_list) ~= numel(gnss_list)
     error('IMU and GNSS file lists must have the same length');
 end
@@ -38,7 +62,7 @@ end
 
 fprintf('Running IMU+GNSS Initialization Pipeline (MATLAB Version)\n');
 
-methods = {'TRIAD','Davenport','SVD'};
+methods = method_list;
 
 for dataIdx = 1:numel(imu_list)
     imu_file  = imu_list{dataIdx};


### PR DESCRIPTION
## Summary
- allow `main.m` to accept a list of methods (TRIAD/Davenport/SVD)
- include all provided IMU/GNSS pairs by default
- document the new arguments in `IMU_MATLAB/README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e68c7d8e4832592aa2ff881ccf20b