### PR TITLE
Support default files in TRIAD MATLAB functions

### DIFF
--- a/IMU_MATLAB/README.md
+++ b/IMU_MATLAB/README.md
@@ -62,8 +62,13 @@ run_all_datasets
 
 To run only the TRIAD method use:
 
+
 ```matlab
-result = TRIAD('IMU_X001.dat','GNSS_X001.csv');
+% use bundled sample files
+result = TRIAD();
+
+% or specify your own files
+% result = TRIAD('IMU_X001.dat','GNSS_X001.csv');
 ```
 
 The returned struct matches the file `results/Result_IMU_X001_GNSS_X001_TRIAD.mat`.

--- a/IMU_MATLAB/TRIAD.m
+++ b/IMU_MATLAB/TRIAD.m
@@ -5,8 +5,12 @@ function result = TRIAD(imuFile, gnssFile)
 %   results are also saved in results/Result_IMU_GNSS_TRIAD.mat and the
 %   summary line printed to the console.
 
-if nargin < 2
-    error('Usage: TRIAD(''IMUFILE'',''GNSSFILE'')');
+if nargin == 0
+    imuFile = 'IMU_X001.dat';
+    gnssFile = 'GNSS_X001.csv';
+    fprintf('[INFO] No files provided. Using defaults: %s, %s\n', imuFile, gnssFile);
+elseif nargin ~= 2
+    error('Usage: TRIAD(''IMUFILE'',''GNSSFILE'') or TRIAD() for defaults');
 end
 
 Task_1(imuFile, gnssFile, 'TRIAD');

--- a/MATLAB/TRIAD.m
+++ b/MATLAB/TRIAD.m
@@ -22,8 +22,12 @@ if numel(dbstack) <= 1
            '    TRIAD(''IMU_X001.dat'', ''GNSS_X001.csv'');']);
 end
 
-if nargin < 2
-    error('Usage: TRIAD(''IMUFILE'',''GNSSFILE'')');
+if nargin == 0
+    imuFile = 'IMU_X001.dat';
+    gnssFile = 'GNSS_X001.csv';
+    fprintf('[INFO] No files provided. Using defaults: %s, %s\n', imuFile, gnssFile);
+elseif nargin ~= 2 && nargin ~= 3
+    error('Usage: TRIAD(''IMUFILE'',''GNSSFILE'') or TRIAD() for defaults');
 end
 
 if isempty(varargin)


### PR DESCRIPTION
## Summary
- let `IMU_MATLAB/TRIAD.m` and `MATLAB/TRIAD.m` use default filenames when called without arguments
- document the new `TRIAD()` usage in `IMU_MATLAB/README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e74306b188325aa8d0f1275e114ca