### PR TITLE
Add file lookup helper to MATLAB TRIAD

### DIFF
--- a/MATLAB/TRIAD.m
+++ b/MATLAB/TRIAD.m
@@ -5,7 +5,8 @@ function TRIAD(imuFile, gnssFile, varargin)
 %   implementation mirrors the Python script GNSS_IMU_Fusion.py but in a
 %   greatly simplified form.  Only the key steps of the attitude
 %   initialisation, IMU integration and Kalman filter fusion are
-%   implemented.
+%   implemented.  The file names are resolved using GET_DATA_FILE so the
+%   sample logs bundled with the repository can be referenced by name.
 %
 %   Example:
 %       TRIAD('IMU_X001.dat','GNSS_X001.csv');
@@ -26,9 +27,11 @@ if nargin == 0
     imuFile = 'IMU_X001.dat';
     gnssFile = 'GNSS_X001.csv';
     fprintf('[INFO] No files provided. Using defaults: %s, %s\n', imuFile, gnssFile);
+    % The helper GET_DATA_FILE will resolve these names to full paths
 elseif nargin ~= 2 && nargin ~= 3
     error('Usage: TRIAD(''IMUFILE'',''GNSSFILE'') or TRIAD() for defaults');
 end
+
 
 if isempty(varargin)
     resultsDir = 'results';
@@ -38,6 +41,10 @@ end
 if ~exist(resultsDir, 'dir')
     mkdir(resultsDir);
 end
+
+% Locate data files bundled with the repository
+imuFile = get_data_file(imuFile);
+gnssFile = get_data_file(gnssFile);
 
 %% ----- Task 1: Reference vectors in NED frame -------------------------
 % Load first valid GNSS ECEF coordinate and convert to geodetic

--- a/MATLAB/get_data_file.m
+++ b/MATLAB/get_data_file.m
@@ -1,0 +1,17 @@
+function path = get_data_file(filename)
+    %GET_DATA_FILE Returns the full path to a data file.
+    %   Searches in IMU_MATLAB/data and repository root.
+    script_dir = fileparts(mfilename('fullpath'));
+    p1 = fullfile(script_dir, 'data', filename);
+    if exist(p1, 'file')
+        path = p1;
+        return;
+    end
+    root_dir = fileparts(script_dir);
+    p2 = fullfile(root_dir, filename);
+    if exist(p2, 'file')
+        path = p2;
+        return;
+    end
+    error('Data file not found: %s', filename);
+end

--- a/README.md
+++ b/README.md
@@ -209,6 +209,9 @@ main(imu_path, gnss_path);
 ```
 
 `main.m` now takes the full paths to the IMU and GNSS files as arguments.
+The helper function `get_data_file` searches both the repository root and
+`IMU_MATLAB/data`, letting `TRIAD` and related scripts locate the bundled
+sample logs automatically when you pass just the file names.
 
 ## Export to MATLAB (.mat) files
 To convert the saved Python results into MATLAB `.mat` files, run from the repo root:


### PR DESCRIPTION
## Summary
- add `get_data_file.m` to `MATLAB/`
- use `get_data_file` in `MATLAB/TRIAD.m`
- document automatic file lookup in the README

## Testing
- `make test`
- `pytest -q tests/test_pipeline_smoke.py`

------
https://chatgpt.com/codex/tasks/task_e_685e790262488325bdb918aed1385a5f