### PR TITLE
Improve MATLAB TRIAD file path handling

### DIFF
--- a/IMU_MATLAB/README.md
+++ b/IMU_MATLAB/README.md
@@ -64,12 +64,15 @@ To run only the TRIAD method use:
 
 
 ```matlab
-% use bundled sample files
+% use bundled sample files (paths resolved with get_data_file)
 result = TRIAD();
 
 % or specify your own files
 % result = TRIAD('IMU_X001.dat','GNSS_X001.csv');
 ```
+
+`TRIAD` resolves the file names with `get_data_file`, so the bundled logs are
+found even if you run the command from another folder.
 
 The returned struct matches the file `results/Result_IMU_X001_GNSS_X001_TRIAD.mat`.
 

--- a/IMU_MATLAB/TRIAD.m
+++ b/IMU_MATLAB/TRIAD.m
@@ -13,6 +13,11 @@ elseif nargin ~= 2
     error('Usage: TRIAD(''IMUFILE'',''GNSSFILE'') or TRIAD() for defaults');
 end
 
+% Resolve to full paths so the function works from any directory. The helper
+% GET_DATA_FILE searches IMU_MATLAB/data first and then the repository root.
+imuFile  = get_data_file(imuFile);
+gnssFile = get_data_file(gnssFile);
+
 Task_1(imuFile, gnssFile, 'TRIAD');
 Task_2(imuFile, gnssFile, 'TRIAD');
 Task_3(imuFile, gnssFile, 'TRIAD');


### PR DESCRIPTION
## Summary
- resolve dataset names with `get_data_file` inside `IMU_MATLAB/TRIAD.m`
- note automatic path lookup in the IMU_MATLAB README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e7c559aa8832594620c253cbb56a8