### PR TITLE
Fix static interval selection

### DIFF
--- a/IMU_MATLAB/Task_2.m
+++ b/IMU_MATLAB/Task_2.m
@@ -151,9 +151,10 @@ if start_idx == -1
     if size(acc_filt, 1) < end_idx, end_idx = size(acc_filt, 1); end
 end
 
-% Override with specified static interval to match Python pipeline
-start_idx = 297;
-end_idx   = min(479907, size(acc_filt,1));
+% Use the automatically detected static interval
+% The Python reference implementation selects a short early segment
+% where the device is stationary.  Re-using that here avoids
+% overestimating biases when the whole dataset is treated as static.
 
 % --- Calculate static vectors from the interval ---
 N_static = end_idx - start_idx + 1;


### PR DESCRIPTION
## Summary
- remove hard-coded static interval in `IMU_MATLAB/Task_2.m`
- rely on automatically detected interval to avoid inflated biases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ea5c8fe088325a05348b65945f083