### PR TITLE
Improve MATLAB toolbox compatibility

### DIFF
--- a/IMU_MATLAB/Task_1.m
+++ b/IMU_MATLAB/Task_1.m
@@ -135,29 +135,33 @@ fprintf('Longitude (deg):             %.6f\n', lon_deg);
 % ================================
 fprintf('\nSubtask 1.5: Plotting location on Earth map.\n');
 
-% Create a geographic plot (requires Mapping Toolbox)
-figure('Name', 'Initial Location on Earth Map', 'Position', [100, 100, 1000, 500]);
-geobasemap satellite; % Use satellite imagery as the basemap
+% Create a geographic plot if Mapping Toolbox is available
+if exist('geoplot', 'file') == 2 && license('test', 'map_toolbox')
+    figure('Name', 'Initial Location on Earth Map', 'Position', [100, 100, 1000, 500]);
+    geobasemap satellite; % Use satellite imagery as the basemap
 
-% Set map limits to focus on the location
-geolimits([lat_deg - 2, lat_deg + 2], [lon_deg - 2, lon_deg + 2]);
+    % Set map limits to focus on the location
+    geolimits([lat_deg - 2, lat_deg + 2], [lon_deg - 2, lon_deg + 2]);
 
-% Plot the initial location with a red marker
-hold on;
-geoplot(lat_deg, lon_deg, 'ro', 'MarkerSize', 10, 'MarkerFaceColor', 'r');
+    % Plot the initial location with a red marker
+    hold on;
+    geoplot(lat_deg, lon_deg, 'ro', 'MarkerSize', 10, 'MarkerFaceColor', 'r');
 
-% Add a text label
-text_str = sprintf('Lat: %.4f°, Lon: %.4f°', lat_deg, lon_deg);
-text(lon_deg + 0.1, lat_deg, text_str, 'Color', 'white', 'FontSize', 12, 'FontWeight', 'bold');
-hold off;
+    % Add a text label
+    text_str = sprintf('Lat: %.4f°, Lon: %.4f°', lat_deg, lon_deg);
+    text(lon_deg + 0.1, lat_deg, text_str, 'Color', 'white', 'FontSize', 12, 'FontWeight', 'bold');
+    hold off;
 
-% Set plot title
-title('Initial Location on Earth Map');
+    % Set plot title
+    title('Initial Location on Earth Map');
 
-% Save the plot
-output_filename = fullfile(results_dir, sprintf('%s_location_map.pdf', tag));
-saveas(gcf, output_filename);
-fprintf('Location map saved to %s\n', output_filename);
+    % Save the plot
+    output_filename = fullfile(results_dir, sprintf('%s_location_map.pdf', tag));
+    saveas(gcf, output_filename);
+    fprintf('Location map saved to %s\n', output_filename);
+else
+    warning('Mapping Toolbox not found. Skipping geographic plot.');
+end
 % close(gcf); % Uncomment to close the figure after saving
 
 % Save results for later tasks

--- a/IMU_MATLAB/Task_2.m
+++ b/IMU_MATLAB/Task_2.m
@@ -98,9 +98,18 @@ cutoff = 5.0;
 order = 4;
 nyquist_freq = 0.5 * fs;
 normal_cutoff = cutoff / nyquist_freq;
-[b, a] = butter(order, normal_cutoff, 'low');
-acc_filt = filtfilt(b, a, acc);
-gyro_filt = filtfilt(b, a, gyro);
+
+if exist('filtfilt', 'file') == 2 && exist('butter', 'file') == 2 && license('test','Signal_Processing_Toolbox')
+    [b, a] = butter(order, normal_cutoff, 'low');
+    acc_filt = filtfilt(b, a, acc);
+    gyro_filt = filtfilt(b, a, gyro);
+else
+    warning('Signal Processing Toolbox not found. Using simple moving average filter.');
+    win = max(1, round(fs * 0.05));
+    kernel = ones(win,1) / win;
+    acc_filt = conv(acc, kernel, 'same');
+    gyro_filt = conv(gyro, kernel, 'same');
+end
 
 % --- Detect a static interval automatically (inlined logic) ---
 fprintf('Detecting static interval using variance thresholds...\n');


### PR DESCRIPTION
## Summary
- skip map plotting in Task 1 when Mapping Toolbox isn't installed
- provide a simple moving-average filter fallback in Task 2

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ef0af4a448325b55f113929f57d40