### PR TITLE
Add MATLAB Task 4 verification

### DIFF
--- a/tests/test_matlab_tasks.py
+++ b/tests/test_matlab_tasks.py
@@ -17,6 +17,7 @@ def test_matlab_tasks(tmp_path):
         "Task_1(imu, gnss, 'TRIAD');"
         "Task_2(imu, gnss, 'TRIAD');"
         "Task_3(imu, gnss, 'TRIAD');"
+        "Task_4(imu, gnss, 'TRIAD');"
     )
     subprocess.run([matlab, "-batch", cmd], check=True)
     mat_file = Path('results/Task3_results_IMU_X001_GNSS_X001.mat')
@@ -28,4 +29,14 @@ def test_matlab_tasks(tmp_path):
     assert isinstance(R, np.ndarray)
     assert R.shape == (3, 3)
     assert np.isfinite(R).all()
+
+    mat_file4 = Path('results/Task4_results_IMU_X001_GNSS_X001.mat')
+    assert mat_file4.exists(), f"Missing {mat_file4}"
+    data4 = scipy.io.loadmat(mat_file4)
+    assert 'gnss_pos_ned' in data4
+    gnss_pos_ned = data4['gnss_pos_ned']
+    assert isinstance(gnss_pos_ned, np.ndarray)
+    assert gnss_pos_ned.ndim == 2
+    assert gnss_pos_ned.shape[1] == 3
+    assert np.isfinite(gnss_pos_ned).all()
 


### PR DESCRIPTION
## Summary
- run MATLAB `Task_4` after `Task_3` from the test
- check the dataset‐specific Task 4 results and required fields

## Testing
- `pytest -k matlab_tasks -q`

------
https://chatgpt.com/codex/tasks/task_e_685f747b4a7c83259b691afde19b7a85