### PR TITLE
Ensure IMU/ GNSS helper APIs use imu_path, gnss_path

### DIFF
--- a/IMU_MATLAB/TRIAD.m
+++ b/IMU_MATLAB/TRIAD.m
@@ -1,31 +1,31 @@
-function result = TRIAD(imuFile, gnssFile)
+function result = TRIAD(imu_path, gnss_path)
 %TRIAD Run the pipeline using only the TRIAD method.
-%   RESULT = TRIAD(IMUFILE, GNSSFILE) executes Tasks 1--5 with the TRIAD
+%   RESULT = TRIAD(IMU_PATH, GNSS_PATH) executes Tasks 1--5 with the TRIAD
 %   attitude initialisation and returns the Task 5 results struct. The
 %   results are also saved in results/Result_IMU_GNSS_TRIAD.mat and the
 %   summary line printed to the console.
 
 if nargin == 0
-    imuFile = 'IMU_X001.dat';
-    gnssFile = 'GNSS_X001.csv';
-    fprintf('[INFO] No files provided. Using defaults: %s, %s\n', imuFile, gnssFile);
+    imu_path = 'IMU_X001.dat';
+    gnss_path = 'GNSS_X001.csv';
+    fprintf('[INFO] No files provided. Using defaults: %s, %s\n', imu_path, gnss_path);
 elseif nargin ~= 2
-    error('Usage: TRIAD(''IMUFILE'',''GNSSFILE'') or TRIAD() for defaults');
+    error('Usage: TRIAD(''IMU_PATH'',''GNSS_PATH'') or TRIAD() for defaults');
 end
 
 % Resolve to full paths so the function works from any directory. The helper
 % GET_DATA_FILE searches IMU_MATLAB/data first and then the repository root.
-imuFile  = get_data_file(imuFile);
-gnssFile = get_data_file(gnssFile);
+imu_path  = get_data_file(imu_path);
+gnss_path = get_data_file(gnss_path);
 
-Task_1(imuFile, gnssFile, 'TRIAD');
-Task_2(imuFile, gnssFile, 'TRIAD');
-Task_3(imuFile, gnssFile, 'TRIAD');
-Task_4(imuFile, gnssFile, 'TRIAD');
-Task_5(imuFile, gnssFile, 'TRIAD');
+Task_1(imu_path, gnss_path, 'TRIAD');
+Task_2(imu_path, gnss_path, 'TRIAD');
+Task_3(imu_path, gnss_path, 'TRIAD');
+Task_4(imu_path, gnss_path, 'TRIAD');
+Task_5(imu_path, gnss_path, 'TRIAD');
 
-[~, imuName]  = fileparts(imuFile);
-[~, gnssName] = fileparts(gnssFile);
+[~, imuName]  = fileparts(imu_path);
+[~, gnssName] = fileparts(gnss_path);
 res_file = fullfile('results', sprintf('%s_%s_TRIAD_task5_results.mat', ...
     imuName, gnssName));
 if ~isfile(res_file)

--- a/IMU_MATLAB/Task_4.m
+++ b/IMU_MATLAB/Task_4.m
@@ -1,6 +1,6 @@
 function result = Task_4(imu_path, gnss_path, method)
 %TASK_4 GNSS and IMU data integration and comparison
-%   Task_4(IMUFILE, GNSSFILE, METHOD) runs the GNSS/IMU integration
+%   Task_4(IMU_PATH, GNSS_PATH, METHOD) runs the GNSS/IMU integration
 %   using the attitude estimates from Task 3. METHOD is unused but kept
 %   for backwards compatibility with older scripts.
 %   Requires that `Task_3` has already saved a dataset-specific

--- a/MATLAB/FINAL.m
+++ b/MATLAB/FINAL.m
@@ -1,6 +1,6 @@
-function FINAL(imuFile, gnssFile, varargin)
+function FINAL(imu_path, gnss_path, varargin)
 %FINAL  MATLAB reimplementation of GNSS_IMU_Fusion.py
-%   FINAL(IMUFILE, GNSSFILE, METHOD) processes a pair of IMU and GNSS
+%   FINAL(IMU_PATH, GNSS_PATH, METHOD) processes a pair of IMU and GNSS
 %   files using a selected attitude initialisation method.  The script
 %   is a simplified port of the Python reference implementation.  It
 %   performs the following steps:
@@ -28,7 +28,7 @@ if numel(dbstack) <= 1
 end
 
 if nargin < 2
-    error('Usage: FINAL(''IMUFILE'',''GNSSFILE'',[METHOD])');
+    error('Usage: FINAL(''IMU_PATH'',''GNSS_PATH'',[METHOD])');
 end
 
 if nargin < 3
@@ -38,10 +38,10 @@ else
 end
 
 %% ----- Task 1: reference vectors in NED -------------------------------
-T = readtable(gnssFile);
+T = readtable(gnss_path);
 valid = find(T.X_ECEF_m ~= 0 | T.Y_ECEF_m ~= 0 | T.Z_ECEF_m ~= 0, 1);
 if isempty(valid)
-    error('No valid GNSS rows in %s', gnssFile);
+    error('No valid GNSS rows in %s', gnss_path);
 end
 x = T.X_ECEF_m(valid); y = T.Y_ECEF_m(valid); z = T.Z_ECEF_m(valid);
 [lat, lon, ~] = ecef2geod(x, y, z);
@@ -51,7 +51,7 @@ omegaE = 7.2921159e-5;
 omega_ie_NED = omegaE * [cosd(lat);0;-sind(lat)];
 
 %% ----- Task 2: body frame vectors from IMU ----------------------------
-D = dlmread(imuFile);
+D = dlmread(imu_path);
 if size(D,2) < 8
     error('Unexpected IMU format');
 end
@@ -148,7 +148,7 @@ for k = 2:N
 end
 
 %% ----- Save results ----------------------------------------------------
-[~,istem] = fileparts(imuFile); [~,gstem] = fileparts(gnssFile);
+[~,istem] = fileparts(imu_path); [~,gstem] = fileparts(gnss_path);
 resultsDir = 'results';
 if ~exist(resultsDir,'dir'), mkdir(resultsDir); end
 matfile = fullfile(resultsDir, sprintf('%s_%s_%s_final.mat', istem, gstem, method));


### PR DESCRIPTION
## Summary
- harmonize helper scripts with Task_1–Task_3 parameter names
- keep all MATLAB helpers using `imu_path`/`gnss_path`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f747d1b8083258968fb45e76d36f2