### PR TITLE
Fix bias range and print magnitude

### DIFF
--- a/IMU_MATLAB/Task_2.m
+++ b/IMU_MATLAB/Task_2.m
@@ -167,6 +167,14 @@ if start_idx == -1
     if size(acc_filt, 1) < end_idx, end_idx = size(acc_filt, 1); end
 end
 
+% Override with the fixed static interval used by the Python pipeline
+user_static_start = 283;
+user_static_end   = 480030;
+if user_static_end <= size(acc_filt, 1)
+    start_idx = user_static_start;
+    end_idx   = user_static_end;
+end
+
 % Use the automatically detected static interval
 % The Python reference implementation selects a short early segment
 % where the device is stationary.  Re-using that here avoids
@@ -218,6 +226,7 @@ fprintf('Orig gyro bias : [% .6e % .6e % .6e]\n', orig_gyro_bias);
 fprintf('New gyro bias  : [% .6e % .6e % .6e]\n', corrected_gyro_bias);
 gyro_bias = corrected_gyro_bias;        % overwrite for downstream tasks
 % --- END PATCH ---
+fprintf('Accel bias magnitude: %.4f\n', norm(accel_bias));
 
 fprintf('Gravity vector in body frame (g_body):           [%.4f; %.4f; %.4f] m/s^2\n', g_body);
 fprintf('Earth rotation rate in body frame (omega_ie_body): [%.6e; %.6e; %.6e] rad/s\n', omega_ie_body);

--- a/IMU_MATLAB/Task_4.m
+++ b/IMU_MATLAB/Task_4.m
@@ -180,8 +180,8 @@ static_acc  = mean(acc_body_filt(start_idx:end_idx, :), 1);
 static_gyro = mean(gyro_body_filt(start_idx:end_idx, :), 1);
 
 % Override with the fixed static interval used by the Python pipeline
-start_idx = 297;
-end_idx   = 479907;
+start_idx = 283;
+end_idx   = 480030;
 static_acc  = mean(acc_body_filt(start_idx:end_idx, :), 1);
 static_gyro = mean(gyro_body_filt(start_idx:end_idx, :), 1);
 fprintf('Static interval forced to [%d, %d]\n', start_idx, end_idx);

--- a/IMU_MATLAB/Task_5.m
+++ b/IMU_MATLAB/Task_5.m
@@ -201,8 +201,8 @@ for i = 1:num_imu_samples
     
     % --- 4. Zero-Velocity Update (ZUPT) ---
     win_size = 80;
-    static_start = 297;
-    static_end   = min(479907, num_imu_samples);
+    static_start = 283;
+    static_end   = min(480030, num_imu_samples);
 
     if i >= static_start && i <= static_end
         zupt_count = zupt_count + 1;

--- a/docs/DebuggingDrift.md
+++ b/docs/DebuggingDrift.md
@@ -18,7 +18,7 @@ This guide explains how to track down extremely large position errors (tens of k
 2. **Analyse velocity during known static periods.** Non-zero values indicate the Zero Velocity Update (ZUPT) logic is ineffective.
 
    ```matlab
-   static_vel = vel_ned(297:479907, :);
+   static_vel = vel_ned(283:480030, :);
    fprintf('mean vel = [%g %g %g]\n', mean(static_vel));
    fprintf('std  vel = [%g %g %g]\n', std(static_vel));
    ```


### PR DESCRIPTION
## Summary
- adjust static index range to [283,480030]
- print accelerometer bias magnitude
- keep Tasks 4/5 in sync with the new range
- mention new interval in debugging docs

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685fd0e3fcd88325b0329476711115f7