### PR TITLE
Centralize ECEF->NED rotation helpers

### DIFF
--- a/FINAL.m
+++ b/FINAL.m
@@ -13,6 +13,7 @@ gnss_file = 'GNSS_X001.csv';
 % Create results directory
 results_dir = 'results';
 if ~exist(results_dir, 'dir'); mkdir(results_dir); end
+addpath('IMU_MATLAB');
 
 %% ========================================================================
 %% Task 1: Define reference vectors in NED
@@ -292,11 +293,6 @@ function [lat_deg, lon_deg, alt] = ecef2geodetic_custom(x,y,z)
     lat = atan2( z + ep^2*b*sin(th).^3, p - e^2*a*cos(th).^3 );
     N = a./sqrt(1-e^2*sin(lat).^2); alt = p./cos(lat) - N;
     lat_deg = rad2deg(lat); lon_deg = rad2deg(lon);
-end
-
-function C = compute_C_ECEF_to_NED(lat, lon)
-    sphi=sin(lat); cphi=cos(lat); slam=sin(lon); clam=cos(lon);
-    C=[-sphi*clam,-sphi*slam,cphi; -slam,clam,0; -cphi*clam,-cphi*slam,-sphi];
 end
 
 function var_win = sliding_variance(x, w)

--- a/GNSS_IMU_Fusion.py
+++ b/GNSS_IMU_Fusion.py
@@ -15,7 +15,7 @@ from typing import Tuple
 
 import pathlib
 from scripts.plot_utils import save_plot, plot_attitude
-from utils import detect_static_interval, is_static
+from utils import detect_static_interval, is_static, compute_C_ECEF_to_NED
 from scripts.validate_filter import compute_residuals, plot_residuals
 from scipy.spatial.transform import Rotation as R
 
@@ -62,18 +62,6 @@ def svd_alignment(body_vecs, ref_vecs, weights=None):
     U, _, Vt = np.linalg.svd(B)
     M = np.diag([1, 1, np.sign(np.linalg.det(U @ Vt))])
     return U @ M @ Vt
-
-def compute_C_ECEF_to_NED(lat, lon):
-    """Compute rotation matrix from ECEF to NED frame."""
-    sin_phi = np.sin(lat)
-    cos_phi = np.cos(lat)
-    sin_lambda = np.sin(lon)
-    cos_lambda = np.cos(lon)
-    return np.array([
-        [-sin_phi * cos_lambda, -sin_phi * sin_lambda, cos_phi],
-        [-sin_lambda, cos_lambda, 0],
-        [-cos_phi * cos_lambda, -cos_phi * sin_lambda, -sin_phi],
-    ])
 
 def butter_lowpass_filter(data, cutoff=5.0, fs=400.0, order=4):
     """Apply a zero-phase Butterworth low-pass filter to the data."""

--- a/IMU_MATLAB/Task_4.m
+++ b/IMU_MATLAB/Task_4.m
@@ -320,16 +320,6 @@ end % End of main function: run_task4
 %  LOCAL FUNCTIONS
 % =========================================================================
 
-function C = compute_C_ECEF_to_NED(lat_rad, lon_rad)
-    % Compute rotation matrix from ECEF to NED frame.
-    s_lat = sin(lat_rad); c_lat = cos(lat_rad);
-    s_lon = sin(lon_rad); c_lon = cos(lon_rad);
-
-    C = [-s_lat * c_lon, -s_lat * s_lon,  c_lat;
-         -s_lon,          c_lon,         0;
-         -c_lat * c_lon, -c_lat * s_lon, -s_lat];
-end
-
 function plot_comparison_in_frame(frame_name, t_gnss, t_imu, methods, C_B_N_methods, p_gnss, v_gnss, a_gnss, p_imu, v_imu, a_imu, f_b_corr, filename, r0_ecef, C_e2n)
     % Helper function to generate all comparison plots.
     fig = figure('Name', ['Comparison Plots in ' frame_name], 'Position', [100 100 1200 900], 'Visible', 'off');

--- a/IMU_MATLAB/Task_5.m
+++ b/IMU_MATLAB/Task_5.m
@@ -494,11 +494,3 @@ end % End of main function
                    all(var(gyro,0,1) < gyro_thresh);
     end
 
-    function C = compute_C_ECEF_to_NED(lat_rad, lon_rad)
-        s_lat = sin(lat_rad); c_lat = cos(lat_rad);
-        s_lon = sin(lon_rad); c_lon = cos(lon_rad);
-        C = [-s_lat * c_lon, -s_lat * s_lon,  c_lat;
-             -s_lon,          c_lon,         0;
-             -c_lat * c_lon, -c_lat * s_lon, -s_lat];
-    end
-

--- a/IMU_MATLAB/compute_C_ECEF_to_NED.m
+++ b/IMU_MATLAB/compute_C_ECEF_to_NED.m
@@ -1,0 +1,14 @@
+function C = compute_C_ECEF_to_NED(lat_rad, lon_rad)
+%COMPUTE_C_ECEF_TO_NED Rotation matrix from ECEF to NED.
+%   C = COMPUTE_C_ECEF_TO_NED(LAT_RAD, LON_RAD) returns the 3x3 rotation
+%   matrix that transforms vectors from the Earth-Centered Earth-Fixed
+%   frame to the local North-East-Down frame at the specified latitude and
+%   longitude (given in radians).
+
+s_lat = sin(lat_rad); c_lat = cos(lat_rad);
+s_lon = sin(lon_rad); c_lon = cos(lon_rad);
+
+C = [-s_lat * c_lon, -s_lat * s_lon,  c_lat;
+     -s_lon,          c_lon,         0;
+     -c_lat * c_lon, -c_lat * s_lon, -s_lat];
+end

--- a/fusion_single.py
+++ b/fusion_single.py
@@ -6,6 +6,7 @@ from scipy.signal import butter, filtfilt
 from scipy.spatial.transform import Rotation as R
 import matplotlib.pyplot as plt
 from kalman import GNSSIMUKalman, rts_smoother
+from utils import compute_C_ECEF_to_NED
 
 
 def butter_lowpass_filter(data, cutoff=5.0, fs=400.0, order=4):
@@ -14,17 +15,6 @@ def butter_lowpass_filter(data, cutoff=5.0, fs=400.0, order=4):
     b, a = butter(order, normal_cutoff, btype="low")
     return filtfilt(b, a, data, axis=0)
 
-
-def compute_C_ECEF_to_NED(lat, lon):
-    sin_phi = np.sin(lat)
-    cos_phi = np.cos(lat)
-    sin_lambda = np.sin(lon)
-    cos_lambda = np.cos(lon)
-    return np.array([
-        [-sin_phi * cos_lambda, -sin_phi * sin_lambda, cos_phi],
-        [-sin_lambda, cos_lambda, 0],
-        [-cos_phi * cos_lambda, -cos_phi * sin_lambda, -sin_phi],
-    ])
 
 
 def quat_mult(q, r):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import os, sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import numpy as np
-from GNSS_IMU_Fusion import compute_C_ECEF_to_NED
+from utils import compute_C_ECEF_to_NED
 
 
 def test_rotation_matrix_orthonormal():

--- a/utils.py
+++ b/utils.py
@@ -109,3 +109,29 @@ def save_mat(filename: str, data: dict) -> None:
     """Save *data* dictionary to a MATLAB ``.mat`` file."""
     from scipy.io import savemat
     savemat(filename, data)
+
+
+def compute_C_ECEF_to_NED(lat: float, lon: float) -> np.ndarray:
+    """Return rotation matrix from ECEF to NED frame.
+
+    Parameters
+    ----------
+    lat : float
+        Geodetic latitude in radians.
+    lon : float
+        Longitude in radians.
+
+    Returns
+    -------
+    ndarray of shape (3, 3)
+        Rotation matrix from ECEF to NED.
+    """
+    s_lat = np.sin(lat)
+    c_lat = np.cos(lat)
+    s_lon = np.sin(lon)
+    c_lon = np.cos(lon)
+    return np.array([
+        [-s_lat * c_lon, -s_lat * s_lon, c_lat],
+        [-s_lon, c_lon, 0.0],
+        [-c_lat * c_lon, -c_lat * s_lon, -s_lat],
+    ])


### PR DESCRIPTION
## Summary
- move `compute_C_ECEF_to_NED` to `utils.py`
- import the shared helper in `GNSS_IMU_Fusion.py` and `fusion_single.py`
- update tests to use the central utility
- add MATLAB version `compute_C_ECEF_to_NED.m`
- reference the MATLAB function from `FINAL.m` and remove inline copies in tasks 4 & 5

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fd98216688325977e3b01f6195e59