### PR TITLE
Fix MATLAB TRIAD biases and earth rotation

### DIFF
--- a/IMU_MATLAB/Task_3.m
+++ b/IMU_MATLAB/Task_3.m
@@ -128,12 +128,16 @@ fprintf('\nSubtask 3.2: Computing rotation matrix using TRIAD method.\n');
 M_body = triad_basis(v1_B, v2_B);
 M_ned_1 = triad_basis(v1_N, v2_N);
 R_tri = M_ned_1 * M_body';
+[U,~,V] = svd(R_tri);
+R_tri = U*V';
 fprintf('Rotation matrix (TRIAD method, Case 1):\n');
 disp(R_tri);
 
 % Case 2
 M_ned_2 = triad_basis(v1_N, v2_N_doc);
 R_tri_doc = M_ned_2 * M_body';
+[U,~,V] = svd(R_tri_doc);
+R_tri_doc = U*V';
 fprintf('Rotation matrix (TRIAD method, Case 2):\n');
 disp(R_tri_doc);
 


### PR DESCRIPTION
## Summary
- tighten static detection thresholds and correct bias computation in `Task_2`
- orthogonalize TRIAD DCM in `Task_3`
- detect static interval without forcing indices and account for Earth rotation when integrating in `Task_4`
- apply dynamic Earth-rate compensation and improved initial covariance in `Task_5`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cartopy')*

------
https://chatgpt.com/codex/tasks/task_e_685ff68146788325a4b1f7558c34b301