### PR TITLE
Fix TRIAD body vector

### DIFF
--- a/IMU_MATLAB/Task_2.m
+++ b/IMU_MATLAB/Task_2.m
@@ -240,7 +240,7 @@ omega_ie_NED = omega_E * [cos(lat_rad); 0; -sin(lat_rad)];
 
 % Use TRIAD with the measured vectors to obtain a rough attitude so that
 % the expected Earth rotation in the body frame can be determined.
-v1_B = static_acc_row'/norm(static_acc_row);
+v1_B = -static_acc_row'/norm(static_acc_row);   % accelerometer measures -g
 v2_B = static_gyro_row'/norm(static_gyro_row);
 g_NED = [0;0;9.81];
 v1_N = g_NED/norm(g_NED);


### PR DESCRIPTION
## Summary
- fix gravity vector sign in Task_2.m for MATLAB TRIAD
- keep other TRIAD math unchanged
- run limited unit tests

## Testing
- `pytest tests/test_utils_additional.py::test_adaptive_zupt_threshold_constant tests/test_utils_additional.py::test_save_static_zupt_params -q`

------
https://chatgpt.com/codex/tasks/task_e_68600907f9408325895c0a60392fdd43