### PR TITLE
Enhance TRIAD runner with automatic validation

### DIFF
--- a/run_triad_only.py
+++ b/run_triad_only.py
@@ -1,9 +1,41 @@
 #!/usr/bin/env python3
-"""Run all datasets using only the TRIAD initialisation method."""
+"""Run all datasets using only the TRIAD initialisation method and
+validate results when ground truth data is available."""
+
 import subprocess
 import sys
 import pathlib
+import re
 
 HERE = pathlib.Path(__file__).resolve().parent
-cmd = [sys.executable, str(HERE / "run_all_datasets.py"), "--method", "TRIAD"] + sys.argv[1:]
+
+# --- Run the batch processor -------------------------------------------------
+cmd = [
+    sys.executable,
+    str(HERE / "run_all_datasets.py"),
+    "--method",
+    "TRIAD",
+] + sys.argv[1:]
 subprocess.run(cmd, check=True)
+
+# --- Validate results when STATE_<id>.txt exists -----------------------------
+results = HERE / "results"
+for mat in results.glob("*_TRIAD_kf_output.mat"):
+    m = re.match(r"IMU_(X\d+)_.*_TRIAD_kf_output\.mat", mat.name)
+    if not m:
+        continue
+    truth = HERE / f"STATE_{m.group(1)}.txt"
+    if not truth.exists():
+        continue
+    vcmd = [
+        sys.executable,
+        str(HERE / "validate_with_truth.py"),
+        "--est-file",
+        str(mat),
+        "--truth-file",
+        str(truth),
+        "--output",
+        str(results),
+    ]
+    subprocess.run(vcmd, check=True)
+


### PR DESCRIPTION
## Summary
- add a validation step in `run_triad_only.py`
- automatically run `validate_with_truth.py` for datasets that have ground truth

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68602160100c8325a00d884e3ae6e3b1