### PR TITLE
Improve PEP8 compliance

### DIFF
--- a/run_triad_only.py
+++ b/run_triad_only.py
@@ -15,7 +15,8 @@ cmd = [
     str(HERE / "run_all_datasets.py"),
     "--method",
     "TRIAD",
-] + sys.argv[1:]
+    *sys.argv[1:],
+]
 subprocess.run(cmd, check=True)
 
 # --- Validate results when STATE_<id>.txt exists -----------------------------


### PR DESCRIPTION
## Summary
- use starred args to break `cmd` list across lines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68602fcaf1988325b1174ed45e978879