### PR TITLE
Fix test for missing cartopy

### DIFF
--- a/tests/test_missing_file.py
+++ b/tests/test_missing_file.py
@@ -1,6 +1,7 @@
 import os, sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import pytest
+pytest.importorskip("cartopy")
 from GNSS_IMU_Fusion import main
 
 


### PR DESCRIPTION
## Summary
- ensure the missing file test is skipped if `cartopy` isn't installed

## Testing
- `pytest tests/test_missing_file.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686042610104832583ecb7bfaabcc135