### PR TITLE
Enhance load_estimate with flexible key search

### DIFF
--- a/tests/test_validate_with_truth.py
+++ b/tests/test_validate_with_truth.py
@@ -49,3 +49,22 @@ def test_validate_with_truth(monkeypatch):
     if est["P"] is not None:
         sigma = 3 * np.sqrt(np.diagonal(est["P"], axis1=1, axis2=2)[:, :3])
         assert np.all(np.abs(err) <= sigma[: len(err)])
+
+
+def test_load_estimate_alt_names(tmp_path):
+    np = pytest.importorskip("numpy")
+    scipy = pytest.importorskip("scipy.io")
+    data = {
+        "fused_pos": np.ones((5, 3)),
+        "fused_vel": np.zeros((5, 3)),
+        "attitude_q": np.tile([1, 0, 0, 0], (5, 1)),
+        "P_hist": np.zeros((5, 3, 3)),
+        "time": np.arange(5),
+    }
+    f = tmp_path / "est.mat"
+    scipy.savemat(f, data)
+    est = load_estimate(str(f))
+    assert np.allclose(est["pos"], data["fused_pos"])
+    assert np.allclose(est["vel"], data["fused_vel"])
+    assert np.allclose(est["quat"], data["attitude_q"])
+    assert np.allclose(est["P"], data["P_hist"])


### PR DESCRIPTION
## Summary
- update `load_estimate` to look for `fused_pos`, `fused_vel`, `attitude_q` and `P_hist`
- implement new `pick_key` helper supporting shape-based fallbacks and key listing
- avoid covariance check when estimate arrays are missing
- add regression test for alternate MAT field names

## Testing
- `python -m pytest tests/test_validate_with_truth.py::test_validate_with_truth -q`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860626b14808325a568a7d2708a554f