### PR TITLE
Improve subprocess call formatting

### DIFF
--- a/run_all_datasets.py
+++ b/run_all_datasets.py
@@ -78,7 +78,12 @@ def run_one(imu, gnss, method, verbose=False):
         cmd.append("--verbose")
     summary_lines = []
     with log.open("w") as fh:
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
         for line in proc.stdout:  # live-stream to console & file
             print(line, end="")
             fh.write(line)

--- a/run_all_methods.py
+++ b/run_all_methods.py
@@ -91,7 +91,12 @@ def main(argv=None):
         if args.no_plots:
             cmd.append("--no-plots")
         with open(log_path, "w") as log:
-            subprocess.run(cmd, stdout=log, stderr=subprocess.STDOUT, check=True)
+            subprocess.run(
+                cmd,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                check=True,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- wrap subprocess calls so arguments fit within 79 columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860664995948325a61319e075dca738