### PR TITLE
Fix final position error calculation in MATLAB FINAL

### DIFF
--- a/MATLAB/FINAL.m
+++ b/MATLAB/FINAL.m
@@ -200,8 +200,10 @@ end
 resultsDir = 'results';
 if ~exist(resultsDir,'dir'), mkdir(resultsDir); end
 matfile = fullfile(resultsDir, sprintf('%s_%s_%s_final.mat', istem, gstem, method));
+
 summary.q0 = q_nb;
-summary.final_pos = norm(fused_pos(end,:));
+summary.final_pos = norm(fused_pos(end,:) - pos_gnss(end,:));
+save(matfile, 'fused_pos', 'fused_vel', 'summary');
 
 fprintf('Saved %s\n', matfile);
 


### PR DESCRIPTION
## Summary
- compute final fused position error relative to final GNSS position
- save Kalman filter results to `results/` directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686068ebbde0832595ba2cab2856a90f