### PR TITLE
Add summary metrics to validation tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,9 @@ The script now produces position, velocity **and** attitude error plots. When
 the covariance matrix `P` is available each figure includes the ±3σ envelopes
 derived from the corresponding sub-blocks of `P`.
 The output directory given via `--output` is created automatically if it does
-not exist.
+not exist. After generating the plots the script prints the final position
+error and RMSE (and velocity metrics when available) and saves this short
+summary to `validation_summary.txt` inside the output directory.
 
 The exported `.npz` and `.mat` structures now expose additional fields alongside
 the existing error metrics:

--- a/validate_with_truth.py
+++ b/validate_with_truth.py
@@ -199,6 +199,32 @@ def main():
         r_err = r_interp * r_true.inv()
         err_quat = r_err.as_quat()[:, [3, 0, 1, 2]]
 
+    # --- Performance metrics ----------------------------------------------
+    final_pos_error = np.linalg.norm(err_pos[-1])
+    rmse_pos = np.sqrt(np.mean(np.sum(err_pos ** 2, axis=1)))
+    summary_lines = [
+        f"Final position error: {final_pos_error:.2f} m",
+        f"RMSE position error: {rmse_pos:.2f} m",
+    ]
+    final_vel_error = rmse_vel = None
+    if err_vel is not None:
+        final_vel_error = np.linalg.norm(err_vel[-1])
+        rmse_vel = np.sqrt(np.mean(np.sum(err_vel ** 2, axis=1)))
+        summary_lines += [
+            f"Final velocity error: {final_vel_error:.2f} m/s",
+            f"RMSE velocity error: {rmse_vel:.2f} m/s",
+        ]
+
+    for line in summary_lines:
+        print(line)
+
+    summary_path = os.path.join(args.output, "validation_summary.txt")
+    try:
+        with open(summary_path, "w") as f:
+            f.write("\n".join(summary_lines) + "\n")
+    except OSError as e:
+        print(f"Could not write summary file: {e}")
+
     sigma_pos = sigma_vel = sigma_quat = None
     if est["P"] is not None:
         diag = np.diagonal(est["P"], axis1=1, axis2=2)


### PR DESCRIPTION
## Summary
- compute RMSE and final error in `validate_with_truth.py`
- print metrics and write them to `validation_summary.txt`
- document the new summary in the README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68606d6f055c832591d1664953aef395