### PR TITLE
Update validation

### DIFF
--- a/run_triad_only.py
+++ b/run_triad_only.py
@@ -49,19 +49,14 @@ import pandas as pd
 import matplotlib.pyplot as plt
 from scipy.spatial.transform import Rotation as R
 from pathlib import Path
-import scipy.io as sio                              # only if you store .mat
+from validate_with_truth import load_estimate
 
 
 def validate_against_truth(
-        truth_path      = Path('STATE_X001.txt'),
-        est_mat_path    = Path('results/IMU_X001_GNSS_X001_TRIAD_kf_output.mat'),
-        results_dir     = Path('results'),
-        plot_fname      = 'Task6_Validation_TRIAD.pdf',
-        time_key        = 'time_residuals',
-        pos_key         = 'fused_pos',
-        vel_key         = 'fused_vel',
-        quat_key        = 'attitude_q',            # (body→ECEF, scalar-first)
-        P_key           = 'P_hist'
+        truth_path   = Path('STATE_X001.txt'),
+        est_mat_path = Path('results/IMU_X001_GNSS_X001_TRIAD_kf_output.mat'),
+        results_dir  = Path('results'),
+        plot_fname   = 'Task6_Validation_TRIAD.pdf',
 ):
     """Compare EKF estimates with ground truth and verify 3-sigma consistency."""
     # -------------------------------------------------------------------------
@@ -78,14 +73,14 @@ def validate_against_truth(
 
     # -------------------------------------------------------------------------
     # 2. load estimator output  ----------------------------------------------
-    est = sio.loadmat(est_mat_path)
-    t_est  = est[time_key].ravel()
-    pos_est = est[pos_key]
-    vel_est = est[vel_key]
-    quat_est = est[quat_key]                     # shape (N,4)
+    est = load_estimate(str(est_mat_path))
+    t_est = est["time"]
+    pos_est = est["pos"]
+    vel_est = est["vel"]
+    quat_est = est["quat"]                     # shape (N,4)
     P_diag = None
-    if P_key in est:
-        P_diag = np.diagonal(est[P_key], axis1=1, axis2=2)
+    if est.get("P") is not None:
+        P_diag = np.diagonal(est["P"], axis1=1, axis2=2)
 
     # -------------------------------------------------------------------------
     # 3. time-sync by interpolation  ------------------------------------------

--- a/tests/test_validate_against_truth_func.py
+++ b/tests/test_validate_against_truth_func.py
@@ -1,0 +1,61 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import pytest
+
+np = pytest.importorskip("numpy")
+scipy = pytest.importorskip("scipy.io")
+
+
+
+
+def test_validate_against_truth_pos_vel_keys(tmp_path, monkeypatch):
+    import importlib
+    import subprocess
+
+    # Avoid executing the batch processor on import
+    def dummy_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 0)
+
+    monkeypatch.setattr(subprocess, "run", dummy_run)
+    monkeypatch.setattr(sys, "argv", ["run_triad_only.py"])
+
+    if "run_triad_only" in sys.modules:
+        del sys.modules["run_triad_only"]
+    rto = importlib.import_module("run_triad_only")
+
+    class DummyRot:
+        def __init__(self, arr):
+            self.n = len(arr)
+        def inv(self):
+            return self
+        def __mul__(self, other):
+            return self
+        def magnitude(self):
+            return np.zeros(self.n)
+
+    monkeypatch.setattr(rto, "R", type("DummyR", (), {"from_quat": staticmethod(lambda a: DummyRot(a))}))
+
+    # Create minimal estimator output using pos_ned/vel_ned only
+    data = {
+        "pos_ned": np.zeros((5, 3)),
+        "vel_ned": np.zeros((5, 3)),
+        "attitude_q": np.tile([1, 0, 0, 0], (5, 1)),
+        "time": np.arange(5),
+    }
+    est_file = tmp_path / "est.mat"
+    scipy.savemat(est_file, data)
+
+    truth = np.column_stack([
+        np.arange(5),  # count
+        np.arange(5, dtype=float),
+        np.zeros((5, 3)),
+        np.zeros((5, 3)),
+        np.tile([1, 0, 0, 0], (5, 1)),
+    ])
+    truth_file = tmp_path / "truth.txt"
+    np.savetxt(truth_file, truth)
+
+    rto.validate_against_truth(truth_file, est_file, results_dir=tmp_path, plot_fname="out.pdf")
+    assert (tmp_path / "out.pdf").exists()


### PR DESCRIPTION
## Summary
- remove hard-coded field names from `validate_against_truth`
- reuse `validate_with_truth.load_estimate()`
- add regression test for flexible key loading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68606d6065748325bd1f09ab8d3273e6