### PR TITLE
Handle missing cartopy gracefully

### DIFF
--- a/GNSS_IMU_Fusion.py
+++ b/GNSS_IMU_Fusion.py
@@ -5,7 +5,6 @@ import os
 from pathlib import Path
 
 
-import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -367,26 +366,36 @@ def main():
     # Subtask 1.5: Plot Location on Earth Map
     # --------------------------------
     logging.info("Subtask 1.5: Plotting location on Earth map.")
-    
-    # Create figure with PlateCarree projection
-    fig = plt.figure(figsize=(10, 5))
-    ax = fig.add_subplot(1, 1, 1, projection=ccrs.PlateCarree())
-    ax.stock_img()  # Add Earth background image
-    
-    # Set map extent to focus on the location
-    ax.set_extent([lon_deg - 5, lon_deg + 5, lat_deg - 5, lat_deg + 5], crs=ccrs.PlateCarree())
-    
-    # Plot the initial location with a red marker
-    ax.plot(lon_deg, lat_deg, 'ro', markersize=10, transform=ccrs.PlateCarree())
-    ax.text(lon_deg + 1, lat_deg, f"Lat: {lat_deg:.4f}°, Lon: {lon_deg:.4f}°", transform=ccrs.PlateCarree())
-    
-    # Set plot title and save
-    plt.title("Initial Location on Earth Map")
     if not args.no_plots:
-        plt.savefig(f"results/{tag}_location_map.pdf")
-    plt.close()
+        try:
+            import cartopy.crs as ccrs
+        except Exception as e:
+            logging.warning(f"cartopy not available, skipping map generation: {e}")
+        else:
+            # Create figure with PlateCarree projection
+            fig = plt.figure(figsize=(10, 5))
+            ax = fig.add_subplot(1, 1, 1, projection=ccrs.PlateCarree())
+            ax.stock_img()  # Add Earth background image
 
-    logging.info("Location map saved")
+            # Set map extent to focus on the location
+            ax.set_extent([lon_deg - 5, lon_deg + 5, lat_deg - 5, lat_deg + 5], crs=ccrs.PlateCarree())
+
+            # Plot the initial location with a red marker
+            ax.plot(lon_deg, lat_deg, 'ro', markersize=10, transform=ccrs.PlateCarree())
+            ax.text(
+                lon_deg + 1,
+                lat_deg,
+                f"Lat: {lat_deg:.4f}°, Lon: {lon_deg:.4f}°",
+                transform=ccrs.PlateCarree(),
+            )
+
+            # Set plot title and save
+            plt.title("Initial Location on Earth Map")
+            plt.savefig(f"results/{tag}_location_map.pdf")
+            plt.close()
+            logging.info("Location map saved")
+    else:
+        logging.info("Skipping plot generation (--no-plots)")
     
     
     # ================================

--- a/tests/test_missing_file.py
+++ b/tests/test_missing_file.py
@@ -1,7 +1,6 @@
 import os, sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import pytest
-pytest.importorskip("cartopy")
 from GNSS_IMU_Fusion import main
 
 

--- a/tests/test_no_plots_without_cartopy.py
+++ b/tests/test_no_plots_without_cartopy.py
@@ -1,0 +1,35 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import builtins
+import sys
+import pytest
+pd = pytest.importorskip("pandas")
+from GNSS_IMU_Fusion import main
+
+
+def test_no_plots_without_cartopy(monkeypatch):
+    orig_import = builtins.__import__
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name.startswith("cartopy"):
+            raise ImportError("No cartopy")
+        return orig_import(name, globals, locals, fromlist, level)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    orig_read_csv = pd.read_csv
+    def head5000(*args, **kwargs):
+        df = orig_read_csv(*args, **kwargs)
+        return df.head(5000)
+    monkeypatch.setattr(pd, "read_csv", head5000)
+
+    args = [
+        "--imu-file",
+        "IMU_X001.dat",
+        "--gnss-file",
+        "GNSS_X001.csv",
+        "--method",
+        "TRIAD",
+        "--no-plots",
+    ]
+    monkeypatch.setattr(sys, "argv", ["GNSS_IMU_Fusion.py"] + args)
+    main()
+


### PR DESCRIPTION
## Summary
- make cartopy import optional and skip map generation if unavailable
- drop requirement for cartopy in the missing-file test
- add a new test ensuring `--no-plots` works without cartopy

## Testing
- `pytest -q tests/test_no_plots_without_cartopy.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860829804748325b26bd4b524af99ff