### PR TITLE
Centralize dependency installation

### DIFF
--- a/FINAL.py
+++ b/FINAL.py
@@ -21,24 +21,7 @@ import yaml
 
 HERE = pathlib.Path(__file__).resolve().parent
 
-
-def ensure_dependencies():
-    """Install required packages if they're missing."""
-    try:  # check a couple of external deps
-        import tabulate  # noqa: F401
-        import tqdm  # noqa: F401
-    except ModuleNotFoundError:
-        print("Installing Python dependencies ...")
-        req = HERE / "requirements.txt"
-        subprocess.check_call([
-            sys.executable,
-            "-m",
-            "pip",
-            "install",
-            "-r",
-            str(req),
-        ])
-
+from utils import ensure_dependencies
 
 ensure_dependencies()
 

--- a/run_all_datasets.py
+++ b/run_all_datasets.py
@@ -19,24 +19,7 @@ import yaml
 
 HERE = pathlib.Path(__file__).resolve().parent
 
-
-def ensure_dependencies():
-    """Install required packages if they're missing."""
-    try:  # check a couple of external deps
-        import tabulate  # noqa: F401
-        import tqdm  # noqa: F401
-    except ModuleNotFoundError:
-        print("Installing Python dependencies ...")
-        req = HERE / "requirements.txt"
-        subprocess.check_call([
-            sys.executable,
-            "-m",
-            "pip",
-            "install",
-            "-r",
-            str(req),
-        ])
-
+from utils import ensure_dependencies
 
 ensure_dependencies()
 

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,29 @@
 import numpy as np
 from typing import Tuple
+import pathlib
+import subprocess
+import sys
+
+
+def ensure_dependencies(requirements: pathlib.Path | None = None) -> None:
+    """Install packages from ``requirements.txt`` if key deps are missing."""
+    try:
+        import tabulate  # noqa: F401
+        import tqdm  # noqa: F401
+    except ModuleNotFoundError:
+        if requirements is None:
+            requirements = pathlib.Path(__file__).resolve().parent / "requirements.txt"
+        else:
+            requirements = pathlib.Path(requirements)
+        print("Installing Python dependencies ...")
+        subprocess.check_call([
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "-r",
+            str(requirements),
+        ])
 
 
 def detect_static_interval(accel_data, gyro_data, window_size=200,


### PR DESCRIPTION
## Summary
- share dependency installation logic in utils.ensure_dependencies
- use shared helper in FINAL.py and run_all_datasets.py

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860fbd5cc0c83258a4a739927c97492