### PR TITLE
Remove extra whitespace from Task_5.m

### DIFF
--- a/IMU_MATLAB/Task_5.m
+++ b/IMU_MATLAB/Task_5.m
@@ -193,7 +193,6 @@ for i = 1:num_imu_samples
     x(1:3) = pos_new;
     x(7:9) = quat_to_euler(q_b_n);
     acc_log(:,i) = a_ned;
-    
     % --- 3. Measurement Update (Correction) ---
     z = [gnss_pos_interp(i,:)'; gnss_vel_interp(i,:)'];
     y = z - H * x;
@@ -205,7 +204,6 @@ for i = 1:num_imu_samples
     % update integrator history after correction
     prev_vel = x(4:6);
     prev_a_ned = a_ned;
-    
     % --- 4. Zero-Velocity Update (ZUPT) ---
     win_size = 80;
     static_start = 297;


### PR DESCRIPTION
## Summary
- remove stray whitespace-only lines in IMU_MATLAB/Task_5.m

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861050aa37c8325a5cc08b829d9c5ae