### PR TITLE
Restore package layout and EKF tuning

### DIFF
--- a/IMU_MATLAB/Task_5.m
+++ b/IMU_MATLAB/Task_5.m
@@ -133,8 +133,9 @@ x(4:6)  = gnss_vel_ned(1,:)';
 x(7:9)  = init_eul;
 x(10:12) = accel_bias(:);
 x(13:15) = gyro_bias(:);
-P = blkdiag(eye(9)*0.01, eye(3)*1e-4, eye(3)*1e-8);
-Q = blkdiag(eye(9)*0.01, eye(3)*(1e-4)^2, eye(3)*(1e-4)^2);
+% EKF tuning parameters
+P = blkdiag(eye(9) * 0.01, eye(3) * 1e-4, eye(3) * 1e-8);
+Q = blkdiag(eye(9) * 0.01, eye(3) * 1e-6, eye(3) * 1e-6);
 R = eye(6) * 0.1;
 H = [eye(6), zeros(6,9)];
 

--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ pip3 install filterpy
 
 ## Datasets
 
-The repository includes three IMU logs and two GNSS traces.  The first two
-pairs are straightforward: `IMU_X001.dat` ↔ `GNSS_X001.csv` and
-`IMU_X002.dat` ↔ `GNSS_X002.csv`.  The third IMU recording `IMU_X003.dat`
-pairs with `GNSS_X002.csv` as no dedicated GNSS file was captured for this
-run.
+The repository includes three IMU logs and two GNSS traces:
+
+* `IMU_X001.dat` with `GNSS_X001.csv`
+* `IMU_X002.dat` with `GNSS_X002.csv`
+* `IMU_X003.dat` with `GNSS_X002.csv` (no dedicated GNSS log was recorded)
 
 ## Running validation
 


### PR DESCRIPTION
## Summary
- tune EKF parameters in `Task_5.m`
- list provided logs under the `Datasets` section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861073c4ca483258b5d7375ec03f419