### PR TITLE
Improve Python compatibility

### DIFF
--- a/gnss_imu_fusion/init_vectors.py
+++ b/gnss_imu_fusion/init_vectors.py
@@ -1,6 +1,6 @@
 """Vector initialisation utilities extracted from the original script."""
 
-from typing import Iterable, Tuple
+from typing import Iterable, Tuple, Optional
 
 import numpy as np
 from scipy.signal import butter, filtfilt
@@ -16,7 +16,7 @@ def average_rotation_matrices(rotations: Iterable[np.ndarray]) -> np.ndarray:
 def svd_alignment(
     body_vecs: Iterable[np.ndarray],
     ref_vecs: Iterable[np.ndarray],
-    weights: Iterable[float] | None = None,
+    weights: Optional[Iterable[float]] = None,
 ) -> np.ndarray:
     """Return body->NED rotation using SVD for an arbitrary number of vector pairs."""
     if weights is None:

--- a/scripts/random_fractal.py
+++ b/scripts/random_fractal.py
@@ -1,6 +1,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.colors import rgb2hex
+from typing import Optional
 
 
 def generate_colors(num_points: int, colormap: str = "hsv"):
@@ -25,7 +26,7 @@ def chaos_game(num_points: int = 50000):
     return points
 
 
-def plot_fractal(num_points: int = 50000, outfile: str | None = None) -> None:
+def plot_fractal(num_points: int = 50000, outfile: Optional[str] = None) -> None:
     """Plot a random fractal with a hex-based spectral gradient.
 
     If ``outfile`` is provided the figure is saved instead of shown. This allows

--- a/utils.py
+++ b/utils.py
@@ -1,11 +1,11 @@
 import numpy as np
-from typing import Tuple
+from typing import Tuple, Optional
 import pathlib
 import subprocess
 import sys
 
 
-def ensure_dependencies(requirements: pathlib.Path | None = None) -> None:
+def ensure_dependencies(requirements: Optional[pathlib.Path] = None) -> None:
     """Install packages from ``requirements.txt`` if key deps are missing."""
     try:
         import tabulate  # noqa: F401


### PR DESCRIPTION
## Summary
- avoid PEP604 unions so code runs on Python 3.8

## Testing
- `python -m py_compile utils.py gnss_imu_fusion/init_vectors.py scripts/random_fractal.py`
- `pytest -k utils -q` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_68610a4efb9c8325b88f1b51469be23f