### PR TITLE
Fix typing annotations for Python 3.8

### DIFF
--- a/compare_python_matlab.py
+++ b/compare_python_matlab.py
@@ -2,6 +2,7 @@ import argparse
 import subprocess
 import shutil
 from pathlib import Path
+from typing import Tuple
 import numpy as np
 import pandas as pd
 import scipy.io
@@ -42,14 +43,14 @@ def run_matlab_pipeline(imu_file: str, gnss_file: str, method: str) -> Path:
     return Path("results") / f"{imu_stem}_{gnss_stem}_{method}_task5_results.mat"
 
 
-def load_python_metrics(mat_path: Path) -> tuple[float, float]:
+def load_python_metrics(mat_path: Path) -> Tuple[float, float]:
     data = scipy.io.loadmat(mat_path)
     rmse = float(np.squeeze(data["rmse_pos"]))
     final = float(np.squeeze(data["final_pos"]))
     return rmse, final
 
 
-def load_matlab_metrics(mat_path: Path, imu_file: str, gnss_file: str) -> tuple[float, float]:
+def load_matlab_metrics(mat_path: Path, imu_file: str, gnss_file: str) -> Tuple[float, float]:
     data = scipy.io.loadmat(mat_path)
     x_log = data["x_log"]
     gnss_pos = data["gnss_pos_ned"]

--- a/gnss_imu_fusion/kalman_filter.py
+++ b/gnss_imu_fusion/kalman_filter.py
@@ -1,5 +1,7 @@
 """Kalman filter utilities extracted from the original script."""
 
+from __future__ import annotations
+
 import numpy as np
 
 


### PR DESCRIPTION
## Summary
- avoid using built-in generics that break on Python 3.8
- load `Tuple` from typing in the comparison helper
- postpone type evaluation in kalman utilities

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68610b6ba0dc8325a6698d275ef7cd79