### PR TITLE
Fix README run_all_methods section

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,15 @@ If the measured magnitude differs by more than a few percent, the IMU may not be
 
 ## Running all methods
 
-Use `run_all_methods.py` to execute the fusion script with TRIAD, Davenport and SVD sequentially:
+Use `run_all_methods.py` to execute the fusion script with the TRIAD,
+Davenport and SVD initialisation methods in sequence.  Provide a YAML
+configuration file to specify the datasets:
 
 ```bash
-python run_all_methods.py --imu-file IMU_X001.dat --gnss-file GNSS_X001.csv
+python run_all_methods.py --config your_config.yml
 ```
+
+Running the script without `--config` processes the bundled example data sets.
 
 
 ## Running all data sets


### PR DESCRIPTION
## Summary
- update example command for `run_all_methods.py`
- explain that omitting `--config` processes default datasets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686114564244832589c5c296243bd480