### PR TITLE
Add small dataset config and adaptive bias estimation

### DIFF
--- a/GNSS_IMU_Fusion.py
+++ b/GNSS_IMU_Fusion.py
@@ -895,9 +895,9 @@ def main():
         acc_body = butter_lowpass_filter(acc_body)
         gyro_body = butter_lowpass_filter(gyro_body)
         
-        N_static = 4000
+        N_static = min(4000, max(len(imu_data) // 10, 100))
         if len(imu_data) < N_static:
-            raise ValueError("Insufficient static samples for bias estimation.")
+            N_static = len(imu_data) // 2
         
         # Compute static bias for accelerometers and gyroscopes
         static_acc = np.mean(acc_body[:N_static], axis=0)
@@ -1219,9 +1219,9 @@ def main():
     imu_time = np.arange(len(imu_data)) * dt_ilu + gnss_time[0]
     acc_body = imu_data[[5,6,7]].values / dt_ilu
     acc_body = butter_lowpass_filter(acc_body)
-    N_static = 4000
+    N_static = min(4000, max(len(imu_data) // 10, 100))
     if len(imu_data) < N_static:
-        raise ValueError("Insufficient static samples.")
+        N_static = len(imu_data) // 2
     static_acc = np.mean(acc_body[:N_static], axis=0)
     
     

--- a/README.md
+++ b/README.md
@@ -71,7 +71,15 @@ file:
 * `STATE_X001_small.txt` holds the first 100 reference states
 
 These mini logs drastically reduce runtimes when validating the pipeline or
-the MATLAB scripts.
+the MATLAB scripts.  Use the helper configuration `config_small.yml` to run all
+three mini logs in one go:
+
+```bash
+python run_triad_only.py --config config_small.yml --verbose
+```
+
+The script automatically validates `IMU_X001_small` against
+`STATE_X001_small.txt` and stores the summaries in `results/`.
 
 ## Running validation
 

--- a/config_small.yml
+++ b/config_small.yml
@@ -1,0 +1,9 @@
+datasets:
+  - imu: IMU_X001_small.dat
+    gnss: GNSS_X001_small.csv
+  - imu: IMU_X002_small.dat
+    gnss: GNSS_X002_small.csv
+  - imu: IMU_X003_small.dat
+    gnss: GNSS_X002_small.csv
+methods:
+  - TRIAD

--- a/run_triad_only.py
+++ b/run_triad_only.py
@@ -22,11 +22,16 @@ subprocess.run(cmd, check=True)
 # --- Validate results when STATE_<id>.txt exists -----------------------------
 results = HERE / "results"
 for mat in results.glob("*_TRIAD_kf_output.mat"):
-    m = re.match(r"IMU_(X\d+)_.*_TRIAD_kf_output\.mat", mat.name)
+    m = re.match(r"IMU_(X\d+)(?:_small)?_.*_TRIAD_kf_output\.mat", mat.name)
     if not m:
         continue
-    truth = HERE / f"STATE_{m.group(1)}.txt"
-    if not truth.exists():
+    dataset = m.group(1)
+    candidates = [
+        HERE / f"STATE_{dataset}_small.txt",
+        HERE / f"STATE_{dataset}.txt",
+    ]
+    truth = next((c for c in candidates if c.exists()), None)
+    if truth is None:
         continue
     vcmd = [
         sys.executable,


### PR DESCRIPTION
## Summary
- handle `_small` datasets in `run_triad_only.py`
- adapt static interval length to IMU data size
- add `config_small.yml` for quick validation
- document running small datasets in README

## Testing
- `pytest -q`
- `python run_triad_only.py --config config_small.yml --verbose > run_small.log`

------
https://chatgpt.com/codex/tasks/task_e_686123a00f588325a6391ad466b40fce