### PR TITLE
Add tests for ecef_to_ned utility

### DIFF
--- a/tests/test_utils_additional.py
+++ b/tests/test_utils_additional.py
@@ -2,7 +2,12 @@ import os, sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import pytest
 np = pytest.importorskip("numpy")
-from utils import adaptive_zupt_threshold, save_static_zupt_params
+from utils import (
+    adaptive_zupt_threshold,
+    save_static_zupt_params,
+    ecef_to_ned,
+    compute_C_ECEF_to_NED,
+)
 
 
 def test_adaptive_zupt_threshold_constant():
@@ -22,3 +27,28 @@ def test_save_static_zupt_params(tmp_path):
     assert "Static length: 10" in content
     assert "ZUPT threshold: 0.4" in content
     assert "Total ZUPT events: 3" in content
+
+
+def test_ecef_to_ned_single_vector():
+    ref_lat = np.deg2rad(-32.0)
+    ref_lon = np.deg2rad(133.0)
+    pos_ecef = np.array([1234.0, 5678.0, 91011.0])
+    ref_ecef = np.array([1000.0, 2000.0, 3000.0])
+    ned = ecef_to_ned(pos_ecef, ref_lat, ref_lon, ref_ecef)
+    C = compute_C_ECEF_to_NED(ref_lat, ref_lon)
+    expected = C @ (pos_ecef - ref_ecef)
+    assert np.allclose(ned, expected)
+
+
+def test_ecef_to_ned_multi_vector():
+    ref_lat = np.deg2rad(12.5)
+    ref_lon = np.deg2rad(-45.0)
+    pos_ecef = np.array([
+        [1000.0, 2000.0, 3000.0],
+        [1100.0, 2100.0, 3200.0],
+    ])
+    ref_ecef = np.array([900.0, 1800.0, 2900.0])
+    ned = ecef_to_ned(pos_ecef, ref_lat, ref_lon, ref_ecef)
+    C = compute_C_ECEF_to_NED(ref_lat, ref_lon)
+    expected = np.array([C @ (p - ref_ecef) for p in pos_ecef])
+    assert np.allclose(ned, expected)


### PR DESCRIPTION
## Summary
- extend utils tests to cover `ecef_to_ned` conversion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686138e21b748325ac39ca0074a62bc3