### PR TITLE
Add MATLAB run_triad_only helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,14 @@ the MATLAB scripts.
 ## Running validation
 
 To process the bundled datasets using only the TRIAD initialisation and
-validate the results, run:
+validate the results, run either the Python or MATLAB helper script:
 
 ```bash
 python run_triad_only.py
+```
+
+```matlab
+run_triad_only
 ```
 
 All output files are written to the `results/` directory.  When a matching
@@ -183,10 +187,13 @@ All cases: 100%|##########| 9/9 [00:12<00:00,  1.31s/it]
 
 ## Running only the TRIAD method
 
-If you want to process all datasets using just the TRIAD initialisation method, run the helper script `run_triad_only.py`:
+If you want to process all datasets using just the TRIAD initialisation method, run the helper script `run_triad_only.py` or the MATLAB script `run_triad_only.m`:
 
 ```bash
 python run_triad_only.py
+```
+```matlab
+run_triad_only
 ```
 This is equivalent to running `run_all_datasets.py --method TRIAD`.
 

--- a/docs/TRIAD_Task3_Wiki.md
+++ b/docs/TRIAD_Task3_Wiki.md
@@ -45,4 +45,4 @@ Optional comparison plots
 
 ## Result
 
-Task 3 outputs the rotation matrix and quaternion describing the initial attitude. The error and quaternion plots are saved to the `results/` folder and listed in `plot_summary.md`. Use `run_triad_only.py` to process all datasets and generate these figures. The attitude estimate serves as the starting point for the IMU/GNSS comparison in **Task 4** and the subsequent Kalman filter fusion in **Task 5**.
+Task 3 outputs the rotation matrix and quaternion describing the initial attitude. The error and quaternion plots are saved to the `results/` folder and listed in `plot_summary.md`. Use `run_triad_only.py` (or the MATLAB script `run_triad_only.m`) to process all datasets and generate these figures. The attitude estimate serves as the starting point for the IMU/GNSS comparison in **Task 4** and the subsequent Kalman filter fusion in **Task 5**.

--- a/run_triad_only.m
+++ b/run_triad_only.m
@@ -1,0 +1,45 @@
+%% RUN_TRIAD_ONLY  Run all datasets using the TRIAD method and validate results
+% This MATLAB script mirrors run_triad_only.py. It calls the Python batch
+% processor with the TRIAD method and then validates the generated MAT files
+% against the reference STATE_X*.txt logs when available.
+%
+% Usage:
+%   run_triad_only
+%
+% All .mat files are written to the 'results' folder in the repository root.
+% When a matching STATE_<id>.txt exists the script invokes
+% validate_with_truth.py for the dataset.
+
+here = fileparts(mfilename('fullpath'));
+
+%% -- Run the Python batch processor ---------------------------------------
+py_script = fullfile(here, 'run_all_datasets.py');
+cmd = sprintf('python "%s" --method TRIAD', py_script);
+status = system(cmd);
+if status ~= 0
+    error('run_all_datasets.py failed');
+end
+
+%% -- Validate each result when ground truth is available ------------------
+results_dir = fullfile(here, 'results');
+mat_files = dir(fullfile(results_dir, '*_TRIAD_kf_output.mat'));
+
+for k = 1:numel(mat_files)
+    name = mat_files(k).name;
+    tokens = regexp(name, '^IMU_(X\d+)_.*_TRIAD_kf_output\.mat$', 'tokens');
+    if isempty(tokens)
+        continue
+    end
+    ds = tokens{1}{1};
+    truth_file = fullfile(here, ['STATE_' ds '.txt']);
+    if ~isfile(truth_file)
+        continue
+    end
+    validate_py = fullfile(here, 'validate_with_truth.py');
+    vcmd = sprintf('python "%s" --est-file "%s" --truth-file "%s" --output "%s"', ...
+        validate_py, fullfile(results_dir, name), truth_file, results_dir);
+    vstatus = system(vcmd);
+    if vstatus ~= 0
+        warning('Validation failed for %s', name);
+    end
+end


### PR DESCRIPTION
## Summary
- add `run_triad_only.m` to mirror the Python helper
- document the MATLAB script in README and Task 3 wiki

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686159c320748325a0af367655423765