### PR TITLE
Enforce reference position parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,15 +292,25 @@ validate_3sigma('results/IMU_X001_GNSS_X001_TRIAD_kf_output.mat', 'STATE_X001.tx
 ### Validating with Python
 
 You can also check the exported results directly in Python. Run the helper
-script with the `.mat` file and the reference trajectory:
+script with the `.mat` file, the reference trajectory and the reference
+position:
 
 ```bash
-python validate_with_truth.py --est-file results/IMU_X001_GNSS_X001_TRIAD_kf_output.mat --truth-file STATE_X001.txt
+python validate_with_truth.py \
+  --est-file results/IMU_X001_GNSS_X001_TRIAD_kf_output.mat \
+  --truth-file STATE_X001.txt \
+  --ref-lat -32.026554 --ref-lon 133.455801 \
+  --ref-r0 -3729051 3935676 -3348394
 ```
 Add `--index-align` to skip time interpolation and compare samples by index:
 
 ```bash
-python validate_with_truth.py --est-file results/IMU_X001_GNSS_X001_TRIAD_kf_output.mat --truth-file STATE_X001.txt --index-align
+python validate_with_truth.py \
+  --est-file results/IMU_X001_GNSS_X001_TRIAD_kf_output.mat \
+  --truth-file STATE_X001.txt \
+  --ref-lat -32.026554 --ref-lon 133.455801 \
+  --ref-r0 -3729051 3935676 -3348394 \
+  --index-align
 ```
 
 ### Interpolating to Ground Truth

--- a/tests/test_validate_with_truth.py
+++ b/tests/test_validate_with_truth.py
@@ -126,6 +126,14 @@ def test_index_align(monkeypatch):
         "results/IMU_X001_GNSS_X001_TRIAD_kf_output.mat",
         "--truth-file",
         "STATE_X001.txt",
+        "--ref-lat",
+        "-32.026554",
+        "--ref-lon",
+        "133.455801",
+        "--ref-r0",
+        "-3729051",
+        "3935676",
+        "-3348394",
         "--index-align",
     ]
     monkeypatch.setattr(sys, "argv", ["validate_with_truth.py"] + args)

--- a/validate_with_truth.py
+++ b/validate_with_truth.py
@@ -268,9 +268,9 @@ def main():
             ref_r0 = np.asarray(v).squeeze()
 
     if ref_lat is None or ref_lon is None or ref_r0 is None:
-        ref_lat = np.deg2rad(-32.026554)
-        ref_lon = np.deg2rad(133.455801)
-        ref_r0 = np.array([-3729051, 3935676, -3348394])
+        ap.error(
+            "ref_lat, ref_lon and ref_r0 must be provided via command line or contained in the estimate file"
+        )
 
     C = compute_C_ECEF_to_NED(ref_lat, ref_lon)
 


### PR DESCRIPTION
## Summary
- drop dataset-specific defaults in `validate_with_truth.py`
- document the now required reference position arguments
- update tests for new CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861be0d8c108325878dd7c5112873af