### PR TITLE
Add matplotlib requirement and guard imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,9 @@ jobs:
       image: mcr.microsoft.com/vscode/devcontainers/python:0-3.10
     steps:
       - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt -r requirements.txt
       - name: Run tests
-        run: make test
+        run: pytest -q
       - name: Run MATLAB smoke test
         run: pytest -q tests/test_pipeline_smoke.py

--- a/GNSS_IMU_Fusion.py
+++ b/GNSS_IMU_Fusion.py
@@ -5,7 +5,10 @@ import os
 from pathlib import Path
 
 
-import matplotlib.pyplot as plt
+try:
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - optional plotting dependency
+    plt = None
 import numpy as np
 import pandas as pd
 from filterpy.kalman import KalmanFilter

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: test
 
 test:
-	pip install -r requirements.txt
-	pytest -q
+        pip install -r requirements-dev.txt -r requirements.txt
+        pytest -q

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ pip install numpy matplotlib filterpy
 ```
 
 The tests, however, require the **full** `requirements.txt`, including hefty
-dependencies like `cartopy`. Installing them inside a virtual environment or
-a container helps keep your base Python setup clean.
+dependencies like `cartopy`. Plotting checks additionally rely on
+`matplotlib`. Installing the dependencies inside a virtual environment or a
+container helps keep your base Python setup clean.
 
 If you run into issues with filterpy on Ubuntu:
 
@@ -39,7 +40,9 @@ pip3 install filterpy
 
 ### Installing test requirements
 
-To run the unit tests you need `numpy`, `pandas`, `scipy` and `cartopy` which are all included in `requirements.txt`. Install them together with `pytest` via:
+To run the unit tests you need `numpy`, `pandas`, `scipy`, `cartopy` and
+`matplotlib`. They are all included in `requirements.txt`. Install them together
+with `pytest` via:
 
 ```bash
 pip install -r requirements-dev.txt -r requirements.txt

--- a/auto_plots.py
+++ b/auto_plots.py
@@ -12,7 +12,10 @@ import os
 from typing import Iterable, Tuple
 
 import pandas as pd
-import matplotlib.pyplot as plt
+try:
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - optional plotting dependency
+    plt = None
 import numpy as np
 
 from utils import compute_C_ECEF_to_NED

--- a/fusion_single.py
+++ b/fusion_single.py
@@ -4,7 +4,10 @@ import numpy as np
 import pandas as pd
 from scipy.signal import butter, filtfilt
 from scipy.spatial.transform import Rotation as R
-import matplotlib.pyplot as plt
+try:
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - optional plotting dependency
+    plt = None
 from kalman import GNSSIMUKalman, rts_smoother
 from utils import compute_C_ECEF_to_NED
 

--- a/gnss_imu_fusion/plots.py
+++ b/gnss_imu_fusion/plots.py
@@ -1,6 +1,9 @@
 """Plotting helpers extracted from the original script."""
 
-import matplotlib.pyplot as plt
+try:
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - optional plotting dependency
+    plt = None
 import numpy as np
 
 

--- a/plot_overlay.py
+++ b/plot_overlay.py
@@ -1,7 +1,10 @@
 import os
 from pathlib import Path
 import numpy as np
-import matplotlib.pyplot as plt
+try:
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - optional plotting dependency
+    plt = None
 
 
 def _norm(v: np.ndarray) -> np.ndarray:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
 pytest
+matplotlib

--- a/scripts/plot_utils.py
+++ b/scripts/plot_utils.py
@@ -1,4 +1,7 @@
-import matplotlib.pyplot as plt
+try:
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - optional plotting dependency
+    plt = None
 from scipy.spatial.transform import Rotation as R
 from typing import List
 

--- a/scripts/random_fractal.py
+++ b/scripts/random_fractal.py
@@ -1,6 +1,10 @@
 import numpy as np
-import matplotlib.pyplot as plt
-from matplotlib.colors import rgb2hex
+try:
+    import matplotlib.pyplot as plt
+    from matplotlib.colors import rgb2hex
+except Exception:  # pragma: no cover - optional plotting dependency
+    plt = None
+    rgb2hex = None
 from typing import Optional
 
 

--- a/scripts/validate_filter.py
+++ b/scripts/validate_filter.py
@@ -1,5 +1,8 @@
 import numpy as np
-import matplotlib.pyplot as plt
+try:
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - optional plotting dependency
+    plt = None
 
 
 def compute_residuals(gnss_times, gnss_pos, filt_times, filt_pos):

--- a/validate_with_truth.py
+++ b/validate_with_truth.py
@@ -4,7 +4,10 @@ import os
 import numpy as np
 from scipy.io import loadmat
 from scipy.spatial.transform import Rotation as R, Slerp
-import matplotlib.pyplot as plt
+try:
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - optional plotting dependency
+    plt = None
 
 from utils import compute_C_ECEF_to_NED
 from plot_overlay import plot_overlay


### PR DESCRIPTION
## Summary
- add `matplotlib` to `requirements-dev.txt`
- document that plotting tests rely on matplotlib
- install all test requirements in CI
- install dev requirements in `Makefile`
- avoid ImportError when matplotlib isn't installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861be17c2b48325a336f7a43107688a