### PR TITLE
Document matplotlib requirement for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ pip3 install filterpy
 
 ### Installing test requirements
 
-To run the unit tests you need `numpy`, `pandas`, `scipy`, `cartopy` and
-`matplotlib`. They are all included in `requirements.txt`. Install them together
-with `pytest` via:
+To run the unit tests you need `numpy`, `pandas`, `scipy`, `cartopy` **and**
+`matplotlib`. Plotting checks require `matplotlib` so it must be installed for
+the full suite to pass. All of these packages are included in `requirements.txt`.
+Install them together with `pytest` via:
 
 ```bash
 pip install -r requirements-dev.txt -r requirements.txt
@@ -268,9 +269,9 @@ writes `results/summary.csv`. Each row contains:
 
 Run the unit tests with `pytest`. **Installing the required Python packages is
 mandatory** before executing any tests. The suite relies on *all* entries in
-`requirements.txt` – including heavier libraries such as `cartopy` that can take
-some time to build. Using a dedicated virtual environment or container is
-strongly recommended:
+`requirements.txt` – including heavier libraries such as `cartopy` and the
+plotting backend `matplotlib`. Using a dedicated virtual environment or
+container is strongly recommended:
 
 ```bash
 pip install -r requirements.txt

--- a/plot_compare_all.py
+++ b/plot_compare_all.py
@@ -4,7 +4,11 @@ Compare the three data sets (X001,X002,X003) on the same axes
 for each attitude-initialisation method (TRIAD | Davenport | SVD).
 """
 
-import pathlib, gzip, pickle, matplotlib.pyplot as plt
+import pathlib, gzip, pickle
+try:
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - optional plotting dependency
+    plt = None
 import numpy as np
 
 RESULTS_DIR = pathlib.Path("results")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
 pytest
-matplotlib
+matplotlib  # required for plotting tests


### PR DESCRIPTION
## Summary
- document matplotlib as required for running tests
- mark matplotlib dependency in requirements-dev
- make plotting script tolerate missing matplotlib

## Testing
- `pip install -r requirements-dev.txt -r requirements.txt`
- `pytest -q` *(fails: KeyboardInterrupt after tests finished)*

------
https://chatgpt.com/codex/tasks/task_e_6861c12fce308325bd47dc6e9d08d69b