### PR TITLE
Update body frame plot test

### DIFF
--- a/tests/test_new_plots.py
+++ b/tests/test_new_plots.py
@@ -39,7 +39,7 @@ def test_body_frame_plots(tmp_path, monkeypatch):
     res_dir = Path("results")
     expected = [
         "*_task4_all_body.pdf",
-        "*_task5_compare_body.pdf",
+        "*_Body_Truth_GNSS_IMU.pdf",
     ]
     for pattern in expected:
         matches = list(res_dir.glob(pattern))


### PR DESCRIPTION
## Summary
- expect `<dataset>_Body_Truth_GNSS_IMU.pdf` instead of deprecated `*_task5_compare_body.pdf`

## Testing
- `pytest tests/test_new_plots.py::test_body_frame_plots -vv` *(fails: Missing plot \*_Body_Truth_GNSS_IMU.pdf)*

------
https://chatgpt.com/codex/tasks/task_e_6861c696b8808325a0ba7c3e158255a5