### PR TITLE
Add state truth loader and MATLAB counterpart

### DIFF
--- a/load_state_truth.m
+++ b/load_state_truth.m
@@ -1,0 +1,12 @@
+function [t_true, pos_ecef_true, vel_ecef_true] = load_state_truth(path)
+%LOAD_STATE_TRUTH Load reference state file.
+%   [t_true, pos_ecef_true, vel_ecef_true] = LOAD_STATE_TRUTH(PATH) reads the
+%   reference state file located at PATH using READMATRIX while ignoring lines
+%   starting with '#'. The function returns the timestamp vector and the ECEF
+%   position and velocity components as double precision arrays.
+
+data = readmatrix(path, 'CommentStyle', '#');
+t_true = double(data(:,2));
+pos_ecef_true = double(data(:,3:5));
+vel_ecef_true = double(data(:,6:8));
+end

--- a/plots.py
+++ b/plots.py
@@ -1,8 +1,76 @@
 import numpy as np
+from pathlib import Path
+try:
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - matplotlib optional
+    plt = None
 
+
+def plot_frame(
+    frame: str,
+    method: str,
+    t_imu: np.ndarray,
+    pos_imu: np.ndarray,
+    vel_imu: np.ndarray,
+    acc_imu: np.ndarray,
+    t_gnss: np.ndarray,
+    pos_gnss: np.ndarray,
+    vel_gnss: np.ndarray,
+    acc_gnss: np.ndarray,
+    t_fused: np.ndarray,
+    pos_fused: np.ndarray,
+    vel_fused: np.ndarray,
+    acc_fused: np.ndarray,
+    out_dir: str,
+    truth: tuple | None = None,
+) -> None:
+    """Plot comparison for one frame.
 
     Parameters
     ----------
     frame : str
+        Name of the frame (``NED``, ``ECEF`` or ``Body``).
+    method : str
+        Name of the initialisation method.
+    out_dir : str
+        Directory where the PNG will be written.
+    truth : optional tuple
+        ``(t, pos, vel, acc)`` arrays for the ground truth.
+    """
+    if plt is None:
+        return
 
+    labels = {
+        "NED": ["N", "E", "D"],
+        "ECEF": ["X", "Y", "Z"],
+        "Body": ["X", "Y", "Z"],
+    }.get(frame.upper(), ["X", "Y", "Z"])
+
+    fig, axes = plt.subplots(3, 3, figsize=(12, 8), sharex=False)
+
+    def _plot_row(ax, t_truth, data_truth, t1, d1, t2, d2, t3, d3, ylabel, title):
+        for j, lab in enumerate(labels):
+            ax[j].plot(t_gnss, d1[:, j], "k-", label="GNSS")
+            ax[j].plot(t_imu, d2[:, j], "b--", label="IMU")
+            ax[j].plot(t_fused, d3[:, j], "r-", label="Fused")
+            if t_truth is not None:
+                ax[j].plot(t_truth, data_truth[:, j], "g-", label="Truth")
+            ax[j].set_title(f"{title} {lab}")
+            ax[j].set_xlabel("Time [s]")
+            ax[j].set_ylabel(ylabel)
+            ax[j].legend()
+
+    if truth is not None:
+        t_truth, pos_truth, vel_truth, acc_truth = truth
+    else:
+        t_truth = pos_truth = vel_truth = acc_truth = None
+
+    _plot_row(axes[0], t_truth, pos_truth, t_gnss, pos_gnss, t_imu, pos_imu, t_fused, pos_fused, "[m]", "Position")
+    _plot_row(axes[1], t_truth, vel_truth, t_gnss, vel_gnss, t_imu, vel_imu, t_fused, vel_fused, "[m/s]", "Velocity")
+    _plot_row(axes[2], t_truth, acc_truth, t_gnss, acc_gnss, t_imu, acc_imu, t_fused, acc_fused, "[m/s$^2$]", "Acceleration")
+
+    fig.suptitle(f"{method} comparison in {frame} frame")
+    fig.tight_layout(rect=[0, 0, 1, 0.95])
+    out_path = Path(out_dir) / f"Task5_compare_{frame.upper()}.png"
+    fig.savefig(out_path, dpi=200)
     plt.close(fig)


### PR DESCRIPTION
## Summary
- implement `load_state_truth` in `validate_with_truth.py`
- auto-compute reference location from truth file if missing
- restore working `plot_frame` helper
- add MATLAB implementation `load_state_truth.m`

## Testing
- `pytest tests/test_validate_with_truth.py::test_validate_with_truth -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861c677654c8325807adeb56f7ef8d4