### PR TITLE
Fix type hint compatibility

### DIFF
--- a/plots.py
+++ b/plots.py
@@ -1,5 +1,6 @@
 import numpy as np
 from pathlib import Path
+from typing import Optional
 try:
     import matplotlib.pyplot as plt
 except Exception:  # pragma: no cover - matplotlib optional
@@ -22,7 +23,7 @@ def plot_frame(
     vel_fused: np.ndarray,
     acc_fused: np.ndarray,
     out_dir: str,
-    truth: tuple | None = None,
+    truth: Optional[tuple] = None,
 ) -> None:
     """Plot comparison for one frame.
 


### PR DESCRIPTION
## Summary
- handle older Python by replacing PEP604 union type

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68623cf0ad4883258488ae31ea755f2e