### PR TITLE
Add truth-file option for TRIAD scripts

### DIFF
--- a/IMU_MATLAB/TRIAD.m
+++ b/IMU_MATLAB/TRIAD.m
@@ -1,17 +1,22 @@
-function results = TRIAD(imu_paths, gnss_paths)
+function results = TRIAD(imu_paths, gnss_paths, truthFile)
 %TRIAD  Run the pipeline using only the TRIAD method.
-%   RESULTS = TRIAD(IMU_PATHS, GNSS_PATHS) executes Tasks 1--5 with the
-%   TRIAD attitude initialisation for one or more IMU/GNSS file pairs.
-%   When called without arguments all bundled sample datasets are
-%   processed.  Single file names or cell arrays of names are accepted.
-%   The Task 5 results for each pair are returned as a struct (or a cell
-%   array of structs) and saved in results/Result_<IMU>_<GNSS>_TRIAD.mat.
+%   RESULTS = TRIAD(IMU_PATHS, GNSS_PATHS, TRUTHFILE) executes Tasks 1--5
+%   with the TRIAD attitude initialisation for one or more IMU/GNSS file
+%   pairs. When TRUTHFILE is provided it is forwarded to Task_5 so the
+%   comparison plots include the reference trajectory. When called without
+%   arguments all bundled sample datasets are processed. Single file names
+%   or cell arrays of names are accepted. The Task 5 results for each pair
+%   are returned as a struct (or a cell array of structs) and saved in
+%   results/Result_<IMU>_<GNSS>_TRIAD.mat.
 
 if nargin == 0
     imu_paths = {'IMU_X001.dat','IMU_X002.dat','IMU_X003.dat'};
     gnss_paths = {'GNSS_X001.csv','GNSS_X002.csv','GNSS_X002.csv'};
-elseif nargin ~= 2
-    error('Usage: TRIAD(''IMU_PATH'',''GNSS_PATH'') or TRIAD() for defaults');
+    truthFile = '';
+elseif nargin == 2
+    truthFile = '';
+elseif nargin ~= 3
+    error('Usage: TRIAD(''IMU_PATH'',''GNSS_PATH'',''truthFile'') or TRIAD() for defaults');
 end
 
 % Convert to cell arrays for uniform handling
@@ -36,7 +41,7 @@ for k = 1:numel(imu_paths)
     Task_2(imu_file, gnss_file, 'TRIAD');
     Task_3(imu_file, gnss_file, 'TRIAD');
     Task_4(imu_file, gnss_file, 'TRIAD');
-    Task_5(imu_file, gnss_file, 'TRIAD');
+    Task_5(imu_file, gnss_file, 'TRIAD', [], truthFile);
 
     [~, imuName]  = fileparts(imu_file);
     [~, gnssName] = fileparts(gnss_file);

--- a/IMU_MATLAB/Task_5.m
+++ b/IMU_MATLAB/Task_5.m
@@ -1,4 +1,4 @@
-function result = Task_5(imu_path, gnss_path, method, gnss_pos_ned)
+function result = Task_5(imu_path, gnss_path, method, gnss_pos_ned, truthFile)
 %TASK_5  Run 9-state KF using IMU & GNSS NED positions
     if nargin < 1 || isempty(imu_path)
         error('IMU path not specified');
@@ -8,6 +8,12 @@ function result = Task_5(imu_path, gnss_path, method, gnss_pos_ned)
     end
     if nargin < 3 || isempty(method)
         method = 'TRIAD';
+    end
+    if nargin < 4
+        gnss_pos_ned = [];
+    end
+    if nargin < 5
+        truthFile = '';
     end
 
     results_dir = 'results';
@@ -308,12 +314,19 @@ end
 % --- Frame comparisons with Truth ----------------------------------
 token = regexp(imu_name,'IMU_(X\d+)','tokens');
 dataset_id = token{1}{1};
-truth_candidates = {sprintf('STATE_%s_small.txt',dataset_id), sprintf('STATE_%s.txt',dataset_id)};
+if ~isempty(truthFile)
+    truth_candidates = {truthFile};
+else
+    truth_candidates = {sprintf('STATE_%s_small.txt',dataset_id), sprintf('STATE_%s.txt',dataset_id)};
+end
 truth_data = [];
 for i=1:numel(truth_candidates)
     if exist(truth_candidates{i},'file')
         truth_data = load(truth_candidates{i});
         break; end
+end
+if ~isempty(truthFile) && isempty(truth_data)
+    warning('Reference file %s not found. Skipping overlay.', truthFile);
 end
 if ~isempty(truth_data)
     t_truth = truth_data(:,2) + gnss_time(1);

--- a/run_triad_only.py
+++ b/run_triad_only.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
-"""Run all datasets using only the TRIAD initialisation method and
-validate results when ground truth data is available."""
+"""Run all datasets using only the TRIAD initialisation method.
 
+Optionally validate the Kalman filter output against a reference state
+with ``--truth-file PATH``. The file is passed to ``validate_with_truth``
+and skipped if not found.
+"""
+
+import argparse
 import subprocess
 import sys
 import pathlib
 import re
+import numpy as np
 from plot_overlay import plot_overlay
 from validate_with_truth import load_estimate, assemble_frames
 from utils import ecef_to_geodetic
@@ -13,29 +19,45 @@ import pandas as pd
 
 HERE = pathlib.Path(__file__).resolve().parent
 
+ap = argparse.ArgumentParser(description="Run TRIAD initialisation on all datasets")
+ap.add_argument("--truth-file", help="Reference state file for validation")
+args, rest = ap.parse_known_args()
+
 # --- Run the batch processor -------------------------------------------------
 cmd = [
     sys.executable,
     str(HERE / "run_all_datasets.py"),
     "--method",
     "TRIAD",
-    *sys.argv[1:],
+    *rest,
 ]
 subprocess.run(cmd, check=True)
 
 # --- Validate results when STATE_<id>.txt exists -----------------------------
 results = HERE / "results"
+truth_arg = pathlib.Path(args.truth_file).expanduser() if args.truth_file else None
+if truth_arg and not truth_arg.exists():
+    print(f"Warning: truth file {truth_arg} not found, skipping reference overlay")
+    truth_arg = None
+
 for mat in results.glob("*_TRIAD_kf_output.mat"):
     m = re.match(r"IMU_(X\d+)(?:_small)?_.*_TRIAD_kf_output\.mat", mat.name)
     if not m:
         continue
     dataset = m.group(1)
-    candidates = [
-        HERE / f"STATE_{dataset}_small.txt",
-        HERE / f"STATE_{dataset}.txt",
-    ]
-    truth = next((c for c in candidates if c.exists()), None)
+    if truth_arg is not None:
+        truth = truth_arg
+    else:
+        candidates = [
+            HERE / f"STATE_{dataset}_small.txt",
+            HERE / f"STATE_{dataset}.txt",
+        ]
+        truth = next((c for c in candidates if c.exists()), None)
     if truth is None:
+        if args.truth_file:
+            print(f"Warning: reference file {truth_arg} not found, skipping validation")
+        else:
+            print(f"Warning: no truth file for {dataset}, skipping validation")
         continue
     vcmd = [
         sys.executable,


### PR DESCRIPTION
## Summary
- allow specifying reference state via `--truth-file` in `run_triad_only.py`
- extend `IMU_MATLAB/TRIAD.m` with optional `truthFile` argument
- forward `truthFile` to `Task_5` and support it there
- warn and skip overlay when a truth file is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68623cc516148325a2d7b0848e82857d