### PR TITLE
Fix Task_5 closing

### DIFF
--- a/IMU_MATLAB/Task_5.m
+++ b/IMU_MATLAB/Task_5.m
@@ -489,6 +489,8 @@ fprintf('Method-specific results saved to %s\n', method_file);
 result = results;
 assignin('base', 'task5_results', result);
 
+end % end main function
+
 %% ========================================================================
 %  LOCAL HELPER FUNCTIONS
 % =========================================================================


### PR DESCRIPTION
## Summary
- properly close the Task_5 function before helper definitions

## Testing
- `pip install -q -r requirements-dev.txt -r requirements.txt`
- `pytest -q` *(fails: Missing results/Task5_compare_ECEF.png)*
- `octave -qf --eval "addpath('IMU_MATLAB'); which('Task_5')"` *(fails: parse error near line 492)*

------
https://chatgpt.com/codex/tasks/task_e_68624e7ea3f483259453b2073f7d39a8