### PR TITLE
Fix tests requiring comparison plots

### DIFF
--- a/tests/test_validate_with_truth.py
+++ b/tests/test_validate_with_truth.py
@@ -29,7 +29,6 @@ def test_validate_with_truth(monkeypatch):
         "GNSS_X001.csv",
         "--method",
         "TRIAD",
-        "--no-plots",
     ]
     monkeypatch.setattr(sys, "argv", ["GNSS_IMU_Fusion.py"] + args)
     main()
@@ -132,7 +131,6 @@ def test_index_align(monkeypatch):
         "GNSS_X001.csv",
         "--method",
         "TRIAD",
-        "--no-plots",
     ]
     monkeypatch.setattr(sys, "argv", ["GNSS_IMU_Fusion.py"] + run_args)
     main()


### PR DESCRIPTION
## Summary
- enable plot creation in tests that validate output plots

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68626559b09c8325a908ba69b9be66a5