### PR TITLE
Fix unmatched end in Task_5.m

### DIFF
--- a/IMU_MATLAB/Task_5.m
+++ b/IMU_MATLAB/Task_5.m
@@ -233,7 +233,6 @@ for i = 1:num_imu_samples
     % --- Log State and Attitude ---
     x_log(:, i) = x;
     euler_log(:, i) = quat_to_euler(q_b_n);
-end
 fprintf('-> Filter loop complete. Total ZUPT applications: %d\n', zupt_count);
 
 %% ========================================================================
@@ -489,6 +488,7 @@ fprintf('Method-specific results saved to %s\n', method_file);
 % Return results structure and store in base workspace
 result = results;
 assignin('base', 'task5_results', result);
+
 
 end % end main function
 


### PR DESCRIPTION
## Summary
- remove stray `end` that closed `Task_5` early
- keep function end at original location

## Testing
- `pytest -q tests/test_matlab_tasks.py`

------
https://chatgpt.com/codex/tasks/task_e_686268c3daa083259f40ef225aed3f51