### PR TITLE
Initialize covariance in Task_5

### DIFF
--- a/IMU_MATLAB/Task_5.m
+++ b/IMU_MATLAB/Task_5.m
@@ -145,6 +145,10 @@ x(13:15) = gyro_bias(:);
 R = eye(6) * 0.1;
 H = [eye(6), zeros(6,9)];
 
+% Covariance matrices for Kalman filter
+P = eye(15);          % initial state covariance
+Q = 1e-2 * eye(15);   % process noise covariance
+
 % --- Attitude Initialization ---
 q_b_n = rot_to_quaternion(C_B_N); % Initial attitude quaternion
 


### PR DESCRIPTION
## Summary
- initialize covariance matrices `P` and `Q` in MATLAB Task 5 implementation

## Testing
- `make test` *(fails: test_validate_with_truth.py::test_validate_with_truth, test_validate_with_truth.py::test_index_align)*

------
https://chatgpt.com/codex/tasks/task_e_6862754ff4688325af44352df791c6eb