### PR TITLE
Fix Task_5 logging placement

### DIFF
--- a/IMU_MATLAB/Task_5.m
+++ b/IMU_MATLAB/Task_5.m
@@ -228,11 +228,11 @@ for i = 1:num_imu_samples
             x = x + K_z * y_z;
             P = (eye(15) - K_z * H_z) * P;
         end
-    end
 
     % --- Log State and Attitude ---
     x_log(:, i) = x;
     euler_log(:, i) = quat_to_euler(q_b_n);
+end  % end of main filter loop
 fprintf('-> Filter loop complete. Total ZUPT applications: %d\n', zupt_count);
 
 %% ========================================================================


### PR DESCRIPTION
## Summary
- move logging lines inside filter loop so they run each iteration
- close the loop with a descriptive comment

## Testing
- `pytest -q` *(fails: Missing results/Task5_compare_ECEF.png)*

------
https://chatgpt.com/codex/tasks/task_e_68627554e6588325a14bab00ba8377d6