### PR TITLE
Improve truth file fallback

### DIFF
--- a/GNSS_IMU_Fusion.py
+++ b/GNSS_IMU_Fusion.py
@@ -1476,7 +1476,10 @@ def main():
     # --- Build data sets ---------------------------------------------------
     dataset_id = imu_stem.split("_")[1]
     truth_path = None
-    for cand in [f"STATE_{dataset_id}_small.txt", f"STATE_{dataset_id}.txt"]:
+    candidates = [f"STATE_{dataset_id}_small.txt", f"STATE_{dataset_id}.txt"]
+    if not any(os.path.exists(c) for c in candidates):
+        candidates += ["STATE_X001_small.txt", "STATE_X001.txt"]
+    for cand in candidates:
         if os.path.exists(cand):
             truth_path = cand
             break

--- a/IMU_MATLAB/Task_5.m
+++ b/IMU_MATLAB/Task_5.m
@@ -323,6 +323,9 @@ if ~isempty(truthFile)
     truth_candidates = {truthFile};
 else
     truth_candidates = {sprintf('STATE_%s_small.txt',dataset_id), sprintf('STATE_%s.txt',dataset_id)};
+    if ~any(cellfun(@(f) exist(f,'file'), truth_candidates))
+        truth_candidates = [truth_candidates, {'STATE_X001_small.txt','STATE_X001.txt'}];
+    end
 end
 truth_data = [];
 for i=1:numel(truth_candidates)
@@ -333,6 +336,8 @@ for i=1:numel(truth_candidates)
 end
 if ~isempty(truthFile) && isempty(truth_data)
     warning('Reference file %s not found. Skipping overlay.', truthFile);
+elseif isempty(truthFile) && isempty(truth_data)
+    warning('No truth file for %s. Skipping overlay.', dataset_id);
 end
 if ~isempty(truth_data)
     t_truth = truth_data(:,2) + gnss_time(1);

--- a/run_triad_only.m
+++ b/run_triad_only.m
@@ -31,8 +31,21 @@ for k = 1:numel(mat_files)
         continue
     end
     ds = tokens{1}{1};
-    truth_file = fullfile(here, ['STATE_' ds '.txt']);
-    if ~isfile(truth_file)
+    candidates = {fullfile(here, ['STATE_' ds '_small.txt']), ...
+                  fullfile(here, ['STATE_' ds '.txt'])};
+    if ~any(cellfun(@(f) isfile(f), candidates))
+        candidates = [candidates, {fullfile(here,'STATE_X001_small.txt'), ...
+                                   fullfile(here,'STATE_X001.txt')}];
+    end
+    truth_file = '';
+    for c = candidates
+        if isfile(c{1})
+            truth_file = c{1};
+            break
+        end
+    end
+    if isempty(truth_file)
+        warning('No truth file for %s, skipping validation', ds);
         continue
     end
     validate_py = fullfile(here, 'validate_with_truth.py');

--- a/run_triad_only.py
+++ b/run_triad_only.py
@@ -52,6 +52,10 @@ for mat in results.glob("*_TRIAD_kf_output.mat"):
             HERE / f"STATE_{dataset}_small.txt",
             HERE / f"STATE_{dataset}.txt",
         ]
+        if not any(c.exists() for c in candidates):
+            candidates.extend(
+                [HERE / "STATE_X001_small.txt", HERE / "STATE_X001.txt"]
+            )
         truth = next((c for c in candidates if c.exists()), None)
     if truth is None:
         if args.truth_file:


### PR DESCRIPTION
## Summary
- extend truth file lookup with STATE_X001 fallback
- update GNSS_IMU_Fusion truth search
- apply fallback logic in MATLAB Task_5 and run_triad_only

## Testing
- `pytest -q` *(fails: Missing results/Task5_compare_ECEF.png)*

------
https://chatgpt.com/codex/tasks/task_e_68627916f8148325b4cc9188e7656ba6