### PR TITLE
Add test dependencies target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
-.PHONY: test
-test:
+.PHONY: deps-test test
+
+# Install all packages needed for running the tests
+deps-test:
 	pip install -r requirements-dev.txt -r requirements.txt
+
+# Install dependencies and execute the test suite
+test: deps-test
 	pytest -q
 

--- a/README.md
+++ b/README.md
@@ -288,15 +288,22 @@ writes `results/summary.csv`. Each row contains:
 
 Run the unit tests with `pytest`. **Installing the required Python packages is
 mandatory** before executing any tests. The suite relies on all packages listed
-in both requirement files:
+in both requirement files.
+
+Install the dependencies first:
 
 ```bash
 pip install -r requirements-dev.txt -r requirements.txt
+```
+
+Then run the tests:
+
+```bash
 pytest -q
 ```
 
-Once the Makefile defines a `test` target you can instead run `make test` to
-install the dependencies and execute the suite in one command.
+If you prefer `make`, invoke `make deps-test` to install the requirements or
+`make test` to install them and execute the suite in one command.
 
 ## MATLAB Compatibility
 


### PR DESCRIPTION
## Summary
- clarify test instructions in README
- add a `deps-test` target in the Makefile for installing packages

## Testing
- `pip install -r requirements-dev.txt -r requirements.txt`
- `pytest -q` *(fails: test_validate_with_truth)*

------
https://chatgpt.com/codex/tasks/task_e_68628cc482588325ae55e8306d47ffb4