### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on: [push, pull_request]
 jobs:
   build-and-test:


### PR DESCRIPTION
Potential fix for [https://github.com/VimsRocz/IMU/security/code-scanning/3](https://github.com/VimsRocz/IMU/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the provided steps, the workflow primarily involves checking out the repository, installing dependencies, and running tests. These tasks only require `contents: read` permissions. No write permissions are necessary.

The `permissions` block will be added immediately after the `name` field at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
