### PR TITLE
Ensure frame plots are always saved

### DIFF
--- a/plots.py
+++ b/plots.py
@@ -75,6 +75,8 @@ def plot_frame(
 
     fig.suptitle(f"{method} comparison in {frame} frame")
     fig.tight_layout(rect=[0, 0, 1, 0.95])
-    out_path = Path(out_dir) / f"Task5_compare_{frame.upper()}.png"
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"Task5_compare_{frame.upper()}.png"
     fig.savefig(out_path, dpi=200)
     plt.close(fig)

--- a/validate_with_truth.py
+++ b/validate_with_truth.py
@@ -598,57 +598,31 @@ def main():
                 vel_body_est = vel_est_i
                 acc_body_est = acc_est_i
 
-            plot_frame(
-                "NED",
-                method,
-                t_true,
-                pos_est_i,
-                vel_est_i,
-                acc_est_i,
-                t_true,
-                pos_ned_true,
-                vel_ned_true,
-                acc_ned_true,
-                t_true,
-                pos_est_i,
-                vel_est_i,
-                acc_est_i,
-                args.output,
-            )
-            plot_frame(
-                "ECEF",
-                method,
-                t_true,
-                pos_ecef_est,
-                vel_ecef_est,
-                acc_ecef_est,
-                t_true,
-                pos_ecef_true,
-                vel_ecef_true,
-                acc_ecef_true,
-                t_true,
-                pos_ecef_est,
-                vel_ecef_est,
-                acc_ecef_est,
-                args.output,
-            )
-            plot_frame(
-                "BODY",
-                method,
-                t_true,
-                pos_body_est,
-                vel_body_est,
-                acc_body_est,
-                t_true,
-                pos_body_true,
-                vel_body_true,
-                acc_body_true,
-                t_true,
-                pos_body_est,
-                vel_body_est,
-                acc_body_est,
-                args.output,
-            )
+            frames_data = {
+                "NED": (pos_est_i, vel_est_i, acc_est_i, pos_ned_true, vel_ned_true, acc_ned_true),
+                "ECEF": (pos_ecef_est, vel_ecef_est, acc_ecef_est, pos_ecef_true, vel_ecef_true, acc_ecef_true),
+                "BODY": (pos_body_est, vel_body_est, acc_body_est, pos_body_true, vel_body_true, acc_body_true),
+            }
+
+            for frame_name, data in frames_data.items():
+                est_p, est_v, est_a, tru_p, tru_v, tru_a = data
+                plot_frame(
+                    frame_name,
+                    method,
+                    t_true,
+                    est_p,
+                    est_v,
+                    est_a,
+                    t_true,
+                    tru_p,
+                    tru_v,
+                    tru_a,
+                    t_true,
+                    est_p,
+                    est_v,
+                    est_a,
+                    args.output,
+                )
         except Exception as e:
             print(f"Frame plot failed: {e}")
 


### PR DESCRIPTION
## Summary
- guarantee output directory exists before saving Task5 comparison frames
- simplify frame plotting in `validate_with_truth.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68628cc3aad083258cbd9c91cf1b6805