### PR TITLE
Fix undefined truth variables in Task_5 plotting

### DIFF
--- a/IMU_MATLAB/Task_5.m
+++ b/IMU_MATLAB/Task_5.m
@@ -335,6 +335,13 @@ else
     truth_candidates = {sprintf('STATE_%s_small.txt',dataset_id), sprintf('STATE_%s.txt',dataset_id)};
 end
 truth_data = [];
+% Pre-allocate truth arrays to avoid "undefined variable" errors when no
+% reference solution is available. These will remain empty if truth data is
+% not found and downstream plotting code will simply skip drawing the Truth
+% overlay.
+pos_t_ecef = []; vel_t_ecef = []; acc_t_ecef = [];
+pos_t_ned  = []; vel_t_ned  = []; acc_t_ned  = [];
+pos_t_body = []; vel_t_body = []; acc_t_body = [];
 for i=1:numel(truth_candidates)
     if exist(truth_candidates{i},'file')
         truth_data = load(truth_candidates{i});


### PR DESCRIPTION
## Summary
- avoid undefined variable errors when truth data is absent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686298a77af4832593c9b88c54e5893f