### PR TITLE
Update CI workflow to Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,12 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/vscode/devcontainers/python:0-3.10
+      image: mcr.microsoft.com/vscode/devcontainers/python:0-3.11
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
       - name: Install dependencies
         run: pip install -r requirements-dev.txt -r requirements.txt
       - name: Run tests


### PR DESCRIPTION
## Summary
- run CI in a Python 3.11 container
- explicitly install Python 3.11 in the `build-and-test` job

## Testing
- `pytest -q` *(fails: AssertionError in `tests/test_validate_with_truth.py`)*
- `pytest -q tests/test_pipeline_smoke.py`

------
https://chatgpt.com/codex/tasks/task_e_6862a95967848325b8799a5227292738