### PR TITLE
Fix GitHub Actions by dropping container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
-    container:
-      image: mcr.microsoft.com/vscode/devcontainers/python:0-3.11
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- stop using container image in CI workflow

## Testing
- `pip install -r requirements-dev.txt -r requirements.txt`
- `pytest -q` *(fails: missing results/Task5_compare_ECEF.png)*

------
https://chatgpt.com/codex/tasks/task_e_6862b075c6a08325b60b4d6540084b1c