### PR TITLE
Update CI workflow to set up Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- set up Python 3.11 explicitly in CI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862b69b425883258aace0b7b1e2d451