### PR TITLE
Add dataset parameter to TRIAD runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ validate the results, run either the Python or MATLAB helper script:
 ```bash
 python run_triad_only.py
 ```
+This processes datasets `X001` and `X002`. Use `--datasets` to select a
+different subset, e.g. `python run_triad_only.py --datasets X002`.
 
 ```matlab
 run_triad_only
@@ -234,6 +236,8 @@ If you want to process all datasets using just the TRIAD initialisation method, 
 ```bash
 python run_triad_only.py
 ```
+By default this runs datasets `X001` and `X002` with the TRIAD initialisation.
+Pass `--datasets` to override the selection.
 ```matlab
 run_triad_only
 % run_triad_only('STATE_X001.txt')

--- a/run_triad_only.py
+++ b/run_triad_only.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-"""Run all datasets using only the TRIAD initialisation method.
+"""Run selected datasets using only the TRIAD initialisation method.
+
+By default datasets ``X001`` and ``X002`` are processed. Use ``--datasets``
+to override the list.
 
 Optionally validate the Kalman filter output against a reference state
 with ``--truth-file PATH``. The file is passed to ``validate_with_truth``
@@ -19,8 +22,13 @@ import pandas as pd
 
 HERE = pathlib.Path(__file__).resolve().parent
 
-ap = argparse.ArgumentParser(description="Run TRIAD initialisation on all datasets")
+ap = argparse.ArgumentParser(description="Run TRIAD initialisation on selected datasets")
 ap.add_argument("--truth-file", help="Reference state file for validation")
+ap.add_argument(
+    "--datasets",
+    default="X001,X002",
+    help="Comma separated dataset IDs (e.g. X001,X002) passed to run_all_datasets.py",
+)
 args, rest = ap.parse_known_args()
 
 # --- Run the batch processor -------------------------------------------------
@@ -29,6 +37,8 @@ cmd = [
     str(HERE / "run_all_datasets.py"),
     "--method",
     "TRIAD",
+    "--datasets",
+    args.datasets,
     *rest,
 ]
 subprocess.run(cmd, check=True)

--- a/tests/test_run_triad_only.py
+++ b/tests/test_run_triad_only.py
@@ -1,0 +1,42 @@
+import runpy
+import sys
+import subprocess
+import pathlib
+import types
+
+
+def _run_script(monkeypatch, args):
+    cmd = {}
+
+    def fake_run(c, check):
+        cmd['value'] = c
+        return subprocess.CompletedProcess(c, 0)
+
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+    monkeypatch.setattr(pathlib.Path, 'glob', lambda self, pattern: [])
+    monkeypatch.setattr(sys, 'argv', ['run_triad_only.py'] + args)
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    monkeypatch.syspath_prepend(str(repo_root))
+    # stub heavy modules
+    po = types.ModuleType('plot_overlay')
+    po.plot_overlay = lambda *a, **k: None
+    vt = types.ModuleType('validate_with_truth')
+    vt.load_estimate = lambda *a, **k: {}
+    vt.assemble_frames = lambda *a, **k: {}
+    monkeypatch.setitem(sys.modules, 'plot_overlay', po)
+    monkeypatch.setitem(sys.modules, 'validate_with_truth', vt)
+    runpy.run_path('run_triad_only.py', run_name='__main__')
+    return cmd['value']
+
+
+def test_default_datasets(monkeypatch):
+    cmd = _run_script(monkeypatch, [])
+    assert '--datasets' in cmd
+    idx = cmd.index('--datasets')
+    assert cmd[idx + 1] == 'X001,X002'
+
+
+def test_override_dataset(monkeypatch):
+    cmd = _run_script(monkeypatch, ['--datasets', 'X002'])
+    idx = cmd.index('--datasets')
+    assert cmd[idx + 1] == 'X002'


### PR DESCRIPTION
## Summary
- allow selecting datasets with `--datasets` in `run_triad_only.py`
- default to processing X001 and X002
- document dataset selection in README
- add unit tests verifying the dataset argument

## Testing
- `pytest -q tests/test_run_triad_only.py`
- `pytest -q` *(all tests)*

------
https://chatgpt.com/codex/tasks/task_e_6862ba8e28888325a46e4006c7de707e