### PR TITLE
Add task prefix to plot filenames

### DIFF
--- a/gnss_imu_fusion/plots.py
+++ b/gnss_imu_fusion/plots.py
@@ -40,7 +40,7 @@ def save_zupt_variance(
     plt.ylabel("Variance")
     plt.tight_layout()
     plt.title("ZUPT Detection and Accelerometer Variance")
-    filename = f"results/IMU_{dataset_id}_ZUPT_variance.pdf"
+    filename = f"results/Task2_IMU_{dataset_id}_ZUPT_variance.pdf"
     plt.savefig(filename)
     plt.close()
 
@@ -56,7 +56,7 @@ def save_euler_angles(t: np.ndarray, euler_angles: np.ndarray, dataset_id: str) 
     plt.legend()
     plt.tight_layout()
     plt.title("Attitude Angles (Roll/Pitch/Yaw) vs. Time")
-    filename = f"results/IMU_{dataset_id}_EulerAngles_time.pdf"
+    filename = f"results/Task5_IMU_{dataset_id}_EulerAngles_time.pdf"
     plt.savefig(filename)
     plt.close()
 
@@ -80,7 +80,7 @@ def save_residual_plots(
         plt.ylabel("Position Residual [m]")
         plt.tight_layout()
         plt.title(f"Position Residuals ({label}) vs. Time")
-        fname = f"results/IMU_{dataset_id}_GNSS_{dataset_id}_pos_residuals_{label}.pdf"
+        fname = f"results/Task5_IMU_{dataset_id}_GNSS_{dataset_id}_pos_residuals_{label}.pdf"
         plt.savefig(fname)
         plt.close()
         plt.figure()
@@ -89,7 +89,7 @@ def save_residual_plots(
         plt.ylabel("Velocity Residual [m/s]")
         plt.tight_layout()
         plt.title(f"Velocity Residuals ({label}) vs. Time")
-        fname = f"results/IMU_{dataset_id}_GNSS_{dataset_id}_vel_residuals_{label}.pdf"
+        fname = f"results/Task5_IMU_{dataset_id}_GNSS_{dataset_id}_vel_residuals_{label}.pdf"
         plt.savefig(fname)
         plt.close()
 
@@ -105,7 +105,7 @@ def save_attitude_over_time(t: np.ndarray, euler_angles: np.ndarray, dataset_id:
     plt.legend()
     plt.tight_layout()
     plt.title("Attitude Angles (Roll/Pitch/Yaw) Over Time")
-    fname = f"results/IMU_{dataset_id}_GNSS_{dataset_id}_attitude_time.pdf"
+    fname = f"results/Task5_IMU_{dataset_id}_GNSS_{dataset_id}_attitude_time.pdf"
     plt.savefig(fname)
     plt.close()
 

--- a/plot_compare_all.py
+++ b/plot_compare_all.py
@@ -67,7 +67,7 @@ def plot_one(method, packs):
                      ncol=3, frameon=False)
     fig.suptitle(f"All datasets – Method: {method}", fontsize=16)
     fig.tight_layout()
-    out = RESULTS_DIR / f"all_datasets_{method}_comparison.pdf"
+    out = RESULTS_DIR / f"Task5_all_datasets_{method}_comparison.pdf"
     fig.savefig(out)
     print(f"  ➜ wrote {out}")
 

--- a/plot_overlay.py
+++ b/plot_overlay.py
@@ -60,6 +60,6 @@ def plot_overlay(
 
     fig.suptitle(f"{method} - {frame} frame comparison")
     fig.tight_layout(rect=[0, 0, 1, 0.97])
-    out_path = Path(out_dir) / f"{method}_{frame}_overlay.pdf"
+    out_path = Path(out_dir) / f"Task5_compare_{frame.upper()}.pdf"
     fig.savefig(out_path)
     plt.close(fig)

--- a/tests/test_validate_with_truth.py
+++ b/tests/test_validate_with_truth.py
@@ -88,8 +88,8 @@ def test_validate_with_truth(monkeypatch):
     vmain()
 
     for frame in ["ECEF", "NED", "BODY"]:
-        png = Path("results") / f"Task5_compare_{frame}.png"
-        assert png.exists(), f"Missing {png}"
+        pdf = Path("results") / f"Task5_compare_{frame}.pdf"
+        assert pdf.exists(), f"Missing {pdf}"
 
 
 @pytest.mark.parametrize(
@@ -155,5 +155,5 @@ def test_index_align(monkeypatch):
     vmain()
 
     for frame in ["NED", "ECEF", "BODY"]:
-        f = Path("results") / f"Task5_compare_{frame}.png"
+        f = Path("results") / f"Task5_compare_{frame}.pdf"
         assert f.exists(), f"Missing {f}"


### PR DESCRIPTION
## Summary
- include Task identifier in saved figure names in gnss_imu_fusion plotting helpers
- output comparison overlays as `Task5_compare_<FRAME>.pdf`
- prefix compare-all outputs with `Task5_`
- adjust validate-with-truth tests for new PDF names

## Testing
- `pytest tests/test_validate_with_truth.py::test_validate_with_truth -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862d06f4abc8325a654740bf73a5dbf