### PR TITLE
Fix import order for Path

### DIFF
--- a/Python/validate_with_truth.py
+++ b/Python/validate_with_truth.py
@@ -9,11 +9,11 @@ from scipy.spatial.transform import Rotation as R, Slerp
 from utils import compute_C_ECEF_to_NED, ecef_to_geodetic
 from plot_overlay import plot_overlay
 from plots import plot_frame
+from pathlib import Path
 
 DATA_DIR = Path(__file__).resolve().parents[1] / "Data"
 import pandas as pd
 import re
-from pathlib import Path
 
 
 def load_estimate(path):


### PR DESCRIPTION
## Summary
- import `Path` before using it

## Testing
- `python - <<'EOF'
import importlib.util, sys
sys.path.insert(0, 'Python')
spec = importlib.util.spec_from_file_location('validate_with_truth', 'Python/validate_with_truth.py')
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)
print('import ok')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6862fded5f3c8325a17977afdbf59525