### PR TITLE
Fix TRIAD Kalman vector orientation

### DIFF
--- a/MATLAB/TRIAD.m
+++ b/MATLAB/TRIAD.m
@@ -118,12 +118,13 @@ end
 % Simplified constant-position Kalman filter just for demonstration
 KF.x = [pos(1,:) vel(1,:)];
 KF.P = eye(6);
+KF.x = KF.x';
 Q = 1e-3 * eye(6);
 R = 1e-2 * eye(6);
 for k = 2:N
     % predict
     A = [eye(3) eye(3)*dt; zeros(3) eye(3)];
-    KF.x = A * KF.x';
+    KF.x = A * KF.x;
     KF.P = A*KF.P*A' + Q;
     % update with pseudo-measurement of position & velocity from integration
     z = [pos(k,:) vel(k,:)];


### PR DESCRIPTION
## Summary
- initialize Kalman filter state as a column vector
- update prediction step to use column state

## Testing
- `pip install -r requirements-dev.txt -r requirements.txt`
- `pytest -q Python/tests` *(fails: NameError: Path is not defined)*


------
https://chatgpt.com/codex/tasks/task_e_6862fdeabaec832594651db20d6a1002