### PR TITLE
Update run_all_datasets to auto-resolve paths

### DIFF
--- a/MATLAB/README.md
+++ b/MATLAB/README.md
@@ -52,7 +52,7 @@ Task_2('IMU_X001.dat','GNSS_X001.csv','TRIAD')
 
 
 ### Batch processing
-The helper script `run_all_datasets.m` iterates over every `IMU_X*.dat` and `GNSS_X*.csv` pair and runs all three methods. After each run the Task 5 results are loaded into workspace variables such as `result_IMU_X001_GNSS_X001_TRIAD` and saved in `results/` as `.mat` files.
+The helper script `run_all_datasets.m` iterates over every `IMU_X*.dat` and `GNSS_X*.csv` pair and runs all three methods. Paths are resolved with `get_data_file` so the script can be executed from any folder. After each run the Task 5 results are loaded into workspace variables such as `result_IMU_X001_GNSS_X001_TRIAD` and saved in `results/` as `.mat` files.
 
 ```matlab
 run_all_datasets

--- a/MATLAB/get_data_file.m
+++ b/MATLAB/get_data_file.m
@@ -1,23 +1,32 @@
 function path = get_data_file(filename)
     %GET_DATA_FILE Returns the full path to a data file.
-    %   Searches in Data/, MATLAB/data and repository root.
+    %   Searches in Data/, MATLAB/data and repository root. Wildcard patterns
+    %   return a cell array of all matching files.
+
     script_dir = fileparts(mfilename('fullpath'));
-    data_dir = fullfile(script_dir, '..', 'Data');
-    p0 = fullfile(data_dir, filename);
-    if exist(p0, 'file')
-        path = p0;
+    search_dirs = {fullfile(script_dir, '..', 'Data'), ...
+                   fullfile(script_dir, 'data'), ...
+                   fileparts(script_dir)};
+
+    has_wildcard = ~isempty(regexp(filename, '[*?]', 'once'));
+    matches = {};
+    for k = 1:numel(search_dirs)
+        candidate = fullfile(search_dirs{k}, filename);
+        if has_wildcard
+            d = dir(candidate);
+            matches = [matches, arrayfun(@(f) fullfile(f.folder, f.name), d, 'UniformOutput', false)]; %#ok<AGROW>
+        else
+            if exist(candidate, 'file')
+                path = candidate;
+                return;
+            end
+        end
+    end
+
+    if has_wildcard && ~isempty(matches)
+        path = matches;
         return;
     end
-    p1 = fullfile(script_dir, 'data', filename);
-    if exist(p1, 'file')
-        path = p1;
-        return;
-    end
-    root_dir = fileparts(script_dir);
-    p2 = fullfile(root_dir, filename);
-    if exist(p2, 'file')
-        path = p2;
-        return;
-    end
+
     error('Data file not found: %s', filename);
 end

--- a/MATLAB/run_all_datasets.m
+++ b/MATLAB/run_all_datasets.m
@@ -1,26 +1,36 @@
 %RUN_ALL_DATASETS Batch process all IMU/GNSS pairs with all methods
-%   RUN_ALL_DATASETS() searches for IMU_X*.dat and GNSS_X*.csv files in the
-%   current folder, pairs them by index and executes the full pipeline
+%   RUN_ALL_DATASETS() resolves all IMU_X*.dat and GNSS_X*.csv files using
+%   GET_DATA_FILE, pairs them by index and executes the full pipeline
 %   (Tasks 1--5) for the methods TRIAD, Davenport and SVD. After each run
 %   the Task 5 results structure is loaded into the base workspace under
 %   a variable named result_IMU_Xxxx_GNSS_Xxxx_METHOD and also written to
 %   results/<variable>.mat.
 
-imu_files = dir('IMU_X*.dat');
-gnss_files = dir('GNSS_X*.csv');
+% resolve dataset locations independent of the current folder
+imu_files = get_data_file('IMU_X*.dat');
+gnss_files = get_data_file('GNSS_X*.csv');
+if ischar(imu_files); imu_files = {imu_files}; end
+if ischar(gnss_files); gnss_files = {gnss_files}; end
+imu_files = sort(imu_files);
+gnss_files = sort(gnss_files);
 methods = {'TRIAD','Davenport','SVD'};
 
 if numel(imu_files) ~= numel(gnss_files)
     error('Number of IMU and GNSS files must match.');
 end
 
-if ~exist('results','dir')
-    mkdir('results');
+script_dir = fileparts(mfilename('fullpath'));
+results_dir = fullfile(script_dir, 'results');
+if ~exist(results_dir,'dir')
+    mkdir(results_dir);
 end
+orig_dir = pwd;
+cleanup = onCleanup(@() cd(orig_dir));
+cd(script_dir);
 
 for i = 1:numel(imu_files)
-    imuFile  = imu_files(i).name;
-    gnssFile = gnss_files(i).name;
+    imuFile  = imu_files{i};
+    gnssFile = gnss_files{i};
     [~, imuName, ~]  = fileparts(imuFile);
     [~, gnssName, ~] = fileparts(gnssFile);
 
@@ -29,7 +39,7 @@ for i = 1:numel(imu_files)
         fprintf('Running %s + %s with %s...\n', imuFile, gnssFile, method);
         main(imuFile, gnssFile, method);
 
-        result_file = fullfile('results', sprintf('%s_%s_%s_task5_results.mat',...
+        result_file = fullfile(results_dir, sprintf('%s_%s_%s_task5_results.mat',...
             imuName, gnssName, method));
         if ~isfile(result_file)
             warning('Missing expected output %s', result_file);
@@ -38,8 +48,8 @@ for i = 1:numel(imu_files)
         result = load(result_file);
         var_name = sprintf('result_%s_%s_%s', imuName, gnssName, method);
         assignin('base', var_name, result);
-        save(fullfile('results',[var_name '.mat']), '-struct', 'result');
-        fprintf('Saved %s\n', fullfile('results',[var_name '.mat']));
+        save(fullfile(results_dir,[var_name '.mat']), '-struct', 'result');
+        fprintf('Saved %s\n', fullfile(results_dir,[var_name '.mat']));
     end
 end
 


### PR DESCRIPTION
## Summary
- let `get_data_file` return multiple matches and support wildcards
- run all datasets using resolved file paths
- document that the helper works from any folder

## Testing
- `pytest -q Python/tests` *(fails: NameError: name 'Path' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6862fe3e8f288325b80123f454605144