### PR TITLE
Update MATLAB TRIAD docs

### DIFF
--- a/MATLAB/README.md
+++ b/MATLAB/README.md
@@ -67,8 +67,17 @@ results = TRIAD();
 % or run a specific pair
 % result = TRIAD('IMU_X001.dat','GNSS_X001.csv');
 
+% enable verbose output for step-by-step messages
+% result = TRIAD('IMU_X001.dat','GNSS_X001.csv', true);
+
 % multiple pairs can be given as cell arrays
 % results = TRIAD({'IMU_X001.dat','IMU_X002.dat'}, {'GNSS_X001.csv','GNSS_X002.csv'});
+```
+
+Passing a third `verbose` argument toggles step-by-step output:
+
+```matlab
+TRIAD('IMU_X001.dat','GNSS_X001.csv', true)
 ```
 
 `TRIAD` resolves file names with `get_data_file`, so the bundled logs are


### PR DESCRIPTION
## Summary
- document the optional `verbose` argument in `MATLAB/README.md`
- show example `TRIAD('IMU_X001.dat','GNSS_X001.csv', true)` call

## Testing
- `pip install -r requirements-dev.txt -r requirements.txt`
- `pytest -q Python/tests` *(fails: FileNotFoundError for data files)*

------
https://chatgpt.com/codex/tasks/task_e_6863621f84f083258f334602feacfa23