### PR TITLE
Add MATLAB TRIAD instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,17 @@ python Python/run_triad_only.py
 
 Both scripts write their results to `Python/results/` and, when a reference trajectory is available, automatically validate the output.
 
+## Running the TRIAD pipeline in MATLAB
+Execute `TRIAD.m` from the `MATLAB` folder to run Tasks 1–5 on the bundled
+data. The script prints the same log messages as the Python version and validates
+the results automatically.
+
 ## MATLAB usage
 
-A MATLAB implementation of the same pipeline lives under `MATLAB/`. See [MATLAB/README.md](MATLAB/README.md) for instructions on running `main.m` and the individual task scripts.
+A MATLAB implementation of the same pipeline lives under `MATLAB/`. All example
+datasets reside in the top-level `Data/` folder, and the plotting scripts write
+their PDFs to `results/`. See [MATLAB/README.md](MATLAB/README.md) for
+instructions on running `main.m` and the individual task scripts.
 
 ## Further documentation
 

--- a/docs/PlottingChecklist.md
+++ b/docs/PlottingChecklist.md
@@ -39,6 +39,8 @@ Store short summaries for each figure in `results/plot_summary.md` or similar:
 
 ## 5. Documentation & Reproducibility
 - Document dataset-specific parameters and any script flags in the README.
+- All datasets live in `Data/` and the updated plotting scripts write PDFs to
+  `results/`.
 - If `filterpy` fails to install on Ubuntu:
 ```bash
 sudo apt-get install python3-pip


### PR DESCRIPTION
## Summary
- describe how to run the MATLAB-only TRIAD pipeline
- mention where the datasets live and updated plotting output

## Testing
- `pip install -r requirements-dev.txt -r requirements.txt`
- `pytest -q Python/tests` *(fails: KeyError and accuracy tests)*

------
https://chatgpt.com/codex/tasks/task_e_6863708db3b4832595ef5587c4126e05