### PR TITLE
Handle plotting when only one fusion method runs

### DIFF
--- a/Python/GNSS_IMU_Fusion.py
+++ b/Python/GNSS_IMU_Fusion.py
@@ -1484,7 +1484,13 @@ def main():
         for i in range(3)
     ]).T
 
-    methods_plot = ["TRIAD", "Davenport", "SVD"]
+    # Use the same set of methods that were processed above. When the script is
+    # executed with a single method (e.g. via ``run_triad_only.py``) the lists
+    # ``fused_pos``/``fused_vel``/``fused_acc`` only contain that entry.  Using
+    # a fixed list here would therefore raise ``KeyError`` when accessing the
+    # missing results.  Reuse ``methods`` instead so the plotting logic adapts
+    # automatically to the selected method(s).
+    methods_plot = methods
     directions = ["North", "East", "Down"]
     components = ["Position", "Velocity", "Acceleration"]
 


### PR DESCRIPTION
## Summary
- avoid KeyError in GNSS_IMU_Fusion plotting stage
- install Python deps for tests

## Testing
- `pytest -q` *(fails: FileNotFoundError: results files missing)*

------
https://chatgpt.com/codex/tasks/task_e_686371cd46a883258b2ede8f4385a792