### PR TITLE
Clarify MATLAB TRIAD scripts

### DIFF
--- a/MATLAB/README.md
+++ b/MATLAB/README.md
@@ -58,7 +58,19 @@ The helper script `run_all_datasets.m` iterates over every `IMU_X*.dat` and `GNS
 run_all_datasets
 ```
 
-To run only the TRIAD method use:
+To reproduce the Python helper `run_triad_only.py`, use `run_triad_only.m`:
+
+```matlab
+run_triad_only
+```
+
+This MATLAB script calls the Python batch processor with the TRIAD method and
+validates the generated MAT files when reference logs are present.
+
+The `TRIAD` function described below is a simplified single-pair demonstration
+and **not** the batch runner.
+
+For a simplified single-pair demonstration call `TRIAD` directly:
 
 ```matlab
 % process all bundled datasets (paths resolved with get_data_file)

--- a/MATLAB/TRIAD.m
+++ b/MATLAB/TRIAD.m
@@ -19,6 +19,10 @@ end
 %       TRIAD('IMU_X001.dat','GNSS_X001.csv');
 %
 %   See docs/TRIAD_Task*.md for a detailed description of the algorithm.
+%
+%   This function demonstrates the algorithm on a single dataset. For
+%   batch processing across all logs use ``run_triad_only.m`` or
+%   ``run_all_datasets.m``.
 
 % Detect accidental execution as a script. When run with the `run` command
 % the file is evaluated line-by-line and `nargin` cannot be called,


### PR DESCRIPTION
## Summary
- clarify that `run_triad_only.m` mirrors the Python helper
- note that `TRIAD.m` only runs a single dataset

## Testing
- `pytest -q` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68637547c324832590642acba2a2d833