### PR TITLE
Use script-relative results directory for MATLAB tasks

### DIFF
--- a/MATLAB/FINAL.m
+++ b/MATLAB/FINAL.m
@@ -11,7 +11,8 @@ imu_file  = 'IMU_X001.dat';
 gnss_file = 'GNSS_X001.csv';
 
 % Create results directory
-results_dir = 'results';
+script_dir = fileparts(mfilename('fullpath'));
+results_dir = fullfile(script_dir, 'results');
 if ~exist(results_dir, 'dir'); mkdir(results_dir); end
 addpath('MATLAB');
 

--- a/MATLAB/Task_1.m
+++ b/MATLAB/Task_1.m
@@ -20,9 +20,9 @@ end
 
 % Remove command-line side effects to behave like a normal function
 
-if ~exist('results','dir')
-    mkdir('results');
-end
+script_dir = fileparts(mfilename('fullpath'));
+results_dir = fullfile(script_dir, 'results');
+if ~exist(results_dir, 'dir'); mkdir(results_dir); end
 
 if isempty(method)
     log_tag = '';
@@ -32,7 +32,6 @@ end
 fprintf('TASK 1%s: Define reference vectors in NED frame\n', log_tag);
 
 % --- Configuration ---
-results_dir = 'results';
 [~, imu_name, ~] = fileparts(imu_path);
 [~, gnss_name, ~] = fileparts(gnss_path);
 if isempty(method)

--- a/MATLAB/Task_2.m
+++ b/MATLAB/Task_2.m
@@ -46,9 +46,9 @@ end
 fprintf('TASK 2%s: Measure the vectors in the body frame\n', log_tag);
 
 % --- Configuration ---
-if ~exist('results','dir')
-    mkdir('results');
-end
+script_dir = fileparts(mfilename('fullpath'));
+results_dir = fullfile(script_dir, 'results');
+if ~exist(results_dir, 'dir'); mkdir(results_dir); end
 [~, imu_name, ~] = fileparts(imu_path);
 [~, gnss_name, ~] = fileparts(gnss_path);
 if isempty(method)
@@ -299,8 +299,8 @@ fprintf('From accelerometer (assuming static IMU): a_measured = -g_body \n');
 fprintf('From gyroscope (assuming static IMU):     w_measured = omega_ie_body \n');
 
 % Save results for later tasks
-save(fullfile('results', ['Task2_body_' tag '.mat']), 'g_body', 'g_body_scaled', 'omega_ie_body', 'accel_bias', 'gyro_bias');
-fprintf('Body-frame vectors and biases saved to %s\n', fullfile('results', ['Task2_body_' tag '.mat']));
+save(fullfile(results_dir, ['Task2_body_' tag '.mat']), 'g_body', 'g_body_scaled', 'omega_ie_body', 'accel_bias', 'gyro_bias');
+fprintf('Body-frame vectors and biases saved to %s\n', fullfile(results_dir, ['Task2_body_' tag '.mat']));
 
 % Return results and store in base workspace
 result = struct('g_body', g_body, 'g_body_scaled', g_body_scaled, ...

--- a/MATLAB/Task_3.m
+++ b/MATLAB/Task_3.m
@@ -16,9 +16,9 @@ if nargin < 3
     method = ''; %#ok<NASGU>  % unused but kept for API compatibility
 end
 
-if ~exist('results','dir')
-    mkdir('results');
-end
+script_dir = fileparts(mfilename('fullpath'));
+results_dir = fullfile(script_dir, 'results');
+if ~exist(results_dir, 'dir'); mkdir(results_dir); end
 if ~isfile(gnss_path)
     error('Task_3:GNSSFileNotFound', ...
           'Could not find GNSS data at:\n  %s\nCheck path or filename.', ...
@@ -39,7 +39,6 @@ else
     tag = [pair_tag '_' method];
     method_tag = method;
 end
-results_dir = 'results';
 
 % Load vectors produced by Task 1 and Task 2
 task1_file = fullfile(results_dir, ['Task1_init_' tag '.mat']);

--- a/MATLAB/Task_4.m
+++ b/MATLAB/Task_4.m
@@ -16,9 +16,9 @@ if nargin < 3
     method = '';
 end
 
-if ~exist('results','dir')
-    mkdir('results');
-end
+script_dir = fileparts(mfilename('fullpath'));
+results_dir = fullfile(script_dir, 'results');
+if ~exist(results_dir, 'dir'); mkdir(results_dir); end
 if ~isfile(gnss_path)
     error('Task_4:GNSSFileNotFound', ...
           'Could not find GNSS data at:\n  %s\nCheck path or filename.', ...
@@ -29,7 +29,6 @@ if ~isfile(imu_path)
           'Could not find IMU data at:\n  %s\nCheck path or filename.', ...
           imu_path);
 end
-results_dir = 'results';
 [~, imu_name, ~] = fileparts(imu_path);
 [~, gnss_name, ~] = fileparts(gnss_path);
 pair_tag = [imu_name '_' gnss_name];

--- a/MATLAB/Task_5.m
+++ b/MATLAB/Task_5.m
@@ -16,10 +16,9 @@ function result = Task_5(imu_path, gnss_path, method, gnss_pos_ned, truthFile)
         truthFile = '';
     end
 
-    results_dir = 'results';
-    if ~exist(results_dir,'dir')
-        mkdir(results_dir);
-    end
+    script_dir = fileparts(mfilename('fullpath'));
+    results_dir = fullfile(script_dir, 'results');
+    if ~exist(results_dir,'dir'); mkdir(results_dir); end
     if ~isfile(gnss_path)
         error('Task_5:GNSSFileNotFound', ...
               'Could not find GNSS data at:\n  %s\nCheck path or filename.', ...

--- a/MATLAB/main.m
+++ b/MATLAB/main.m
@@ -56,9 +56,9 @@ end
 clc; close all;
 
 % ensure output directory exists before running tasks
-if ~exist('results','dir')
-    mkdir('results');
-end
+script_dir = fileparts(mfilename('fullpath'));
+results_dir = fullfile(script_dir, 'results');
+if ~exist(results_dir, 'dir'); mkdir(results_dir); end
 
 fprintf('Running IMU+GNSS Initialization Pipeline (MATLAB Version)\n');
 


### PR DESCRIPTION
## Summary
- parameterize results_dir using `fileparts(mfilename('fullpath'))` in MATLAB tasks and scripts
- update Task_2 file saving to use the results_dir variable

## Testing
- `pytest -q Python/tests` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68639ab8eec883258da528d7c0cd4368