### PR TITLE
Use script-relative results directory for MATLAB tasks

### DIFF
--- a/MATLAB/FINAL.m
+++ b/MATLAB/FINAL.m
@@ -13,7 +13,7 @@ gnss_file = 'GNSS_X001.csv';
 % Create results directory
 script_dir = fileparts(mfilename('fullpath'));
 results_dir = fullfile(script_dir, 'results');
-if ~exist(results_dir, 'dir'); mkdir(results_dir); end
+if ~exist(results_dir,'dir'); mkdir(results_dir); end
 addpath('MATLAB');
 
 %% ========================================================================

--- a/MATLAB/README.md
+++ b/MATLAB/README.md
@@ -16,7 +16,7 @@ MATLAB/
 ```
 
 Place your `.dat` and `.csv` data files inside the top-level `Data/` folder.
-The scripts look there by default and save outputs and plots in `results/`.
+The scripts look there by default and save outputs and plots in `MATLAB/results/`.
 
 Run the entire pipeline from MATLAB by executing `main.m`. The script now
 accepts optional file names **and** a list of methods so you can run:
@@ -35,11 +35,11 @@ method (TRIAD, Davenport and SVD by default). Output files include the
 method name so results are preserved for every run.
 
 `Task_4` expects the rotation matrices produced by `Task_3` to be saved as
-`results/task3_results.mat`. Make sure `Task_3` completes before running
+`MATLAB/results/task3_results.mat`. Make sure `Task_3` completes before running
 `Task_4` separately.
 
 `Task_4` also saves the NED-converted GNSS position array `gnss_pos_ned` to
-`results/task4_results.mat`.
+`MATLAB/results/task4_results.mat`.
 `Task_5` looks for this file when started or you can pass `gnss_pos_ned`
 directly as an argument.
 
@@ -52,7 +52,7 @@ Task_2('IMU_X001.dat','GNSS_X001.csv','TRIAD')
 
 
 ### Batch processing
-The helper script `run_all_datasets.m` iterates over every `IMU_X*.dat` and `GNSS_X*.csv` pair and runs all three methods. Paths are resolved with `get_data_file` so the script can be executed from any folder. After each run the Task 5 results are loaded into workspace variables such as `result_IMU_X001_GNSS_X001_TRIAD` and saved in `results/` as `.mat` files.
+The helper script `run_all_datasets.m` iterates over every `IMU_X*.dat` and `GNSS_X*.csv` pair and runs all three methods. Paths are resolved with `get_data_file` so the script can be executed from any folder. After each run the Task 5 results are loaded into workspace variables such as `result_IMU_X001_GNSS_X001_TRIAD` and saved in `MATLAB/results/` as `.mat` files.
 
 ```matlab
 run_all_datasets
@@ -95,7 +95,7 @@ TRIAD('IMU_X001.dat','GNSS_X001.csv', true)
 `TRIAD` resolves file names with `get_data_file`, so the bundled logs are
 found even if you run the command from another folder.  When more than one
 pair is processed the function returns a cell array of result structs, each
-matching the corresponding `results/Result_<IMU>_<GNSS>_TRIAD.mat` file.
+matching the corresponding `MATLAB/results/Result_<IMU>_<GNSS>_TRIAD.mat` file.
 
 ### Compatibility notes
 
@@ -135,8 +135,8 @@ modifying or extending the code so both implementations stay aligned:
    position/velocity RMSE and the final position error. Save these in a struct
    called `results` along with the biases.
 5. **Result Logging** – Write the struct to
-   `results/IMU_GNSS_bias_and_performance.mat` and optionally append the printed
-   summary to `results/IMU_GNSS_summary.txt`.
+   `MATLAB/results/IMU_GNSS_bias_and_performance.mat` and optionally append the printed
+   summary to `MATLAB/results/IMU_GNSS_summary.txt`.
 
 Add comments in the code where each step occurs (e.g. `% Task 2.3: Gravity and
 Bias`) to help future maintainers keep the MATLAB and Python versions

--- a/MATLAB/TRIAD.m
+++ b/MATLAB/TRIAD.m
@@ -62,8 +62,9 @@ if verbose && (nargin < 1 || isempty(imu_path) || nargin < 2 || isempty(gnss_pat
     fprintf('[INFO] Using default files: %s, %s\n', imu_list{1}, gnss_list{1});
 end
 
-resultsDir = 'results';
-if verbose && ~exist(resultsDir, 'dir')
+script_dir = fileparts(mfilename('fullpath'));
+resultsDir = fullfile(script_dir, 'results');
+if ~exist(resultsDir,'dir')
     mkdir(resultsDir);
 end
 

--- a/MATLAB/Task_1.m
+++ b/MATLAB/Task_1.m
@@ -22,7 +22,7 @@ end
 
 script_dir = fileparts(mfilename('fullpath'));
 results_dir = fullfile(script_dir, 'results');
-if ~exist(results_dir, 'dir'); mkdir(results_dir); end
+if ~exist(results_dir,'dir'); mkdir(results_dir); end
 
 if isempty(method)
     log_tag = '';

--- a/MATLAB/Task_2.m
+++ b/MATLAB/Task_2.m
@@ -48,7 +48,7 @@ fprintf('TASK 2%s: Measure the vectors in the body frame\n', log_tag);
 % --- Configuration ---
 script_dir = fileparts(mfilename('fullpath'));
 results_dir = fullfile(script_dir, 'results');
-if ~exist(results_dir, 'dir'); mkdir(results_dir); end
+if ~exist(results_dir,'dir'); mkdir(results_dir); end
 [~, imu_name, ~] = fileparts(imu_path);
 [~, gnss_name, ~] = fileparts(gnss_path);
 if isempty(method)

--- a/MATLAB/Task_3.m
+++ b/MATLAB/Task_3.m
@@ -18,7 +18,7 @@ end
 
 script_dir = fileparts(mfilename('fullpath'));
 results_dir = fullfile(script_dir, 'results');
-if ~exist(results_dir, 'dir'); mkdir(results_dir); end
+if ~exist(results_dir,'dir'); mkdir(results_dir); end
 if ~isfile(gnss_path)
     error('Task_3:GNSSFileNotFound', ...
           'Could not find GNSS data at:\n  %s\nCheck path or filename.', ...

--- a/MATLAB/Task_4.m
+++ b/MATLAB/Task_4.m
@@ -18,7 +18,7 @@ end
 
 script_dir = fileparts(mfilename('fullpath'));
 results_dir = fullfile(script_dir, 'results');
-if ~exist(results_dir, 'dir'); mkdir(results_dir); end
+if ~exist(results_dir,'dir'); mkdir(results_dir); end
 if ~isfile(gnss_path)
     error('Task_4:GNSSFileNotFound', ...
           'Could not find GNSS data at:\n  %s\nCheck path or filename.', ...

--- a/MATLAB/main.m
+++ b/MATLAB/main.m
@@ -58,7 +58,7 @@ clc; close all;
 % ensure output directory exists before running tasks
 script_dir = fileparts(mfilename('fullpath'));
 results_dir = fullfile(script_dir, 'results');
-if ~exist(results_dir, 'dir'); mkdir(results_dir); end
+if ~exist(results_dir,'dir'); mkdir(results_dir); end
 
 fprintf('Running IMU+GNSS Initialization Pipeline (MATLAB Version)\n');
 

--- a/MATLAB/validate_all_methods.m
+++ b/MATLAB/validate_all_methods.m
@@ -6,7 +6,9 @@ function validate_all_methods()
 
 methods = {'TRIAD','Davenport','SVD'};
 truth = load(fullfile('..', 'Data', 'STATE_X001.txt'));
-resultsDir = 'results';
+script_dir = fileparts(mfilename('fullpath'));
+resultsDir = fullfile(script_dir, 'results');
+if ~exist(resultsDir,'dir'); mkdir(resultsDir); end
 
 summary = cell(numel(methods),4);
 

--- a/MATLAB/validate_pipeline_summary.m
+++ b/MATLAB/validate_pipeline_summary.m
@@ -12,6 +12,10 @@ metrics  = {'RMSEpos','EndError','RMSresidPos','MaxresidPos', ...
             'ZUPTcnt','Runtime','Pxx','Pyy','Pzz'};
 tol = 1e-2;
 
+script_dir = fileparts(mfilename('fullpath'));
+results_dir = fullfile(script_dir, 'results');
+if ~exist(results_dir,'dir'); mkdir(results_dir); end
+
 % Python reference summary values
 PythonRef = nan(numel(datasets), numel(metrics), numel(methods));
 % PythonRef(:,:,1) corresponds to TRIAD:
@@ -32,7 +36,7 @@ for mi = 1:numel(methods)
     method = methods{mi};
     for di = 1:numel(datasets)
         ds = datasets{di};
-        fname = sprintf('results/IMU_%s_GNSS_%s_%s_task5_results.mat', ds, ds, method);
+        fname = fullfile(results_dir, sprintf('IMU_%s_GNSS_%s_%s_task5_results.mat', ds, ds, method));
         if ~isfile(fname)
             error('Missing result file: %s', fname);
         end
@@ -88,8 +92,8 @@ for mi = 1:numel(methods)
     for di = 1:numel(datasets)
         ds = datasets{di};
         validate_3sigma( ...
-            sprintf('results/IMU_%s_GNSS_%s_%s_kf_output.mat', ds, ds, method), ...
-            fullfile('..', 'Data', 'STATE_X001.txt')); 
+            fullfile(results_dir, sprintf('IMU_%s_GNSS_%s_%s_kf_output.mat', ds, ds, method)), ...
+            fullfile('..', 'Data', 'STATE_X001.txt'));
     end
 end
 

--- a/MATLAB/validate_triad_summary.m
+++ b/MATLAB/validate_triad_summary.m
@@ -15,11 +15,15 @@ PythonRef = [
 
 MySummary = nan(numel(datasets), numel(metrics));
 
+script_dir = fileparts(mfilename('fullpath'));
+results_dir = fullfile(script_dir, 'results');
+if ~exist(results_dir,'dir'); mkdir(results_dir); end
+
 for k = 1:numel(datasets)
     ds = datasets{k};
     tag = sprintf('IMU_%s_GNSS_%s_TRIAD', ds, ds);
-    resFile = fullfile('results', [tag '_task5_results.mat']);
-    t2File  = fullfile('results', ['Task2_body_' tag '.mat']);
+    resFile = fullfile(results_dir, [tag '_task5_results.mat']);
+    t2File  = fullfile(results_dir, ['Task2_body_' tag '.mat']);
     if ~isfile(resFile)
         error('Missing result file: %s', resFile);
     end

--- a/Python/tests/test_matlab_accuracy.py
+++ b/Python/tests/test_matlab_accuracy.py
@@ -18,7 +18,7 @@ def test_matlab_accuracy(tmp_path):
         "main(imu_path, gnss_path, 'TRIAD');"
     )
     subprocess.run([matlab, "-batch", cmd], check=True)
-    mat_file = Path("results/Task5_results_IMU_X001_GNSS_X001.mat")
+    mat_file = Path("MATLAB/results") / "Task5_results_IMU_X001_GNSS_X001.mat"
     assert mat_file.exists(), f"Missing {mat_file}"
     data = scipy.io.loadmat(mat_file)
     x_log = data["x_log"]

--- a/Python/tests/test_matlab_tasks.py
+++ b/Python/tests/test_matlab_tasks.py
@@ -21,7 +21,7 @@ def test_matlab_tasks(tmp_path):
         "Task_4(imu, gnss, 'TRIAD');"
     )
     subprocess.run([matlab, "-batch", cmd], check=True)
-    mat_file = Path('results/Task3_results_IMU_X001_GNSS_X001.mat')
+    mat_file = Path('MATLAB/results') / 'Task3_results_IMU_X001_GNSS_X001.mat'
     assert mat_file.exists(), f"Missing {mat_file}"
     data = scipy.io.loadmat(mat_file, struct_as_record=False, squeeze_me=True)
     task3 = data['task3_results']
@@ -31,7 +31,7 @@ def test_matlab_tasks(tmp_path):
     assert R.shape == (3, 3)
     assert np.isfinite(R).all()
 
-    mat_file4 = Path('results/Task4_results_IMU_X001_GNSS_X001.mat')
+    mat_file4 = Path('MATLAB/results') / 'Task4_results_IMU_X001_GNSS_X001.mat'
     assert mat_file4.exists(), f"Missing {mat_file4}"
     data4 = scipy.io.loadmat(mat_file4)
     assert 'gnss_pos_ned' in data4

--- a/Python/tests/test_pipeline_smoke.py
+++ b/Python/tests/test_pipeline_smoke.py
@@ -18,8 +18,8 @@ def test_pipeline_smoke(tmp_path):
         "main(imu_path, gnss_path);"
     )
     subprocess.run([matlab, "-batch", cmd], check=True)
-    out4 = Path("results/task4_results.mat")
-    out5 = Path("results/task5_results.mat")
+    out4 = Path("MATLAB/results") / "task4_results.mat"
+    out5 = Path("MATLAB/results") / "task5_results.mat"
     assert out4.exists(), f"Missing {out4}"
     assert out5.exists(), f"Missing {out5}"
     data4 = scipy.io.loadmat(out4)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ the results automatically.
 
 A MATLAB implementation of the same pipeline lives under `MATLAB/`. All example
 datasets reside in the top-level `Data/` folder, and the plotting scripts write
-their PDFs to `results/`. See [MATLAB/README.md](MATLAB/README.md) for
+their PDFs to `MATLAB/results/`. See [MATLAB/README.md](MATLAB/README.md) for
 instructions on running `main.m` and the individual task scripts.
 
 ## Further documentation


### PR DESCRIPTION
## Summary
- write MATLAB results in `MATLAB/results/` rather than the working directory
- update helper scripts and validation scripts to use `results_dir`
- expect MATLAB output in `MATLAB/results/` in Python tests
- mention new results folder in documentation

## Testing
- `pip install numpy`
- `pytest -q Python/tests` *(fails: FileNotFoundError in several tests)*

------
https://chatgpt.com/codex/tasks/task_e_6863a016c328832590cb393e34ffb897