### PR TITLE
Read reference logs with readmatrix

### DIFF
--- a/MATLAB/README.md
+++ b/MATLAB/README.md
@@ -43,6 +43,13 @@ method name so results are preserved for every run.
 `MATLAB/results/task4_results.mat`.
 `Task_5` looks for this file when started or you can pass `gnss_pos_ned`
 directly as an argument.
+If a reference state log such as `STATE_X001.txt` is available,
+`Task_5` reads it using
+```matlab
+readmatrix(path, 'CommentStyle','#')
+```
+to skip the header comments. Provide the path as the optional
+`truthFile` argument when running the task.
 
 `Task_1` and `Task_2` are now functions that accept an optional method name,
 so you can call them directly as

--- a/MATLAB/Task_5.m
+++ b/MATLAB/Task_5.m
@@ -343,7 +343,7 @@ pos_t_ned  = []; vel_t_ned  = []; acc_t_ned  = [];
 pos_t_body = []; vel_t_body = []; acc_t_body = [];
 for i=1:numel(truth_candidates)
     if exist(truth_candidates{i},'file')
-        truth_data = load(truth_candidates{i});
+        truth_data = readmatrix(truth_candidates{i}, 'CommentStyle','#');
         break;
     end
 end


### PR DESCRIPTION
## Summary
- load reference state logs in MATLAB with `readmatrix`
- document reference log handling in MATLAB README

## Testing
- `pip install -r requirements-dev.txt -r requirements.txt`
- `pytest -q Python/tests` *(fails: FileNotFoundError in test_body_frame_plots)*

------
https://chatgpt.com/codex/tasks/task_e_6863c472df7c8325b5011e8991c6884f