### PR TITLE
Clarify which GNSS file matches IMU_X003

### DIFF
--- a/MATLAB/README.md
+++ b/MATLAB/README.md
@@ -17,7 +17,7 @@ MATLAB/
 
 Place your `.dat` and `.csv` data files inside the top-level `Data/` folder.
 The scripts look there by default and save outputs and plots in `MATLAB/results/`.
-`IMU_X003.dat` is bundled without a matching `GNSS_X003.csv`; use `GNSS_X002.csv` instead.
+Note that `IMU_X003.dat` is bundled without a matching `GNSS_X003.csv`; use `GNSS_X002.csv` instead.
 
 Run the entire pipeline from MATLAB by executing `main.m`. The script now
 accepts optional file names **and** a list of methods so you can run:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pip install -e .
 ## Running the Python pipeline
 
 The repository bundles three IMU logs (`IMU_X001.dat`–`IMU_X003.dat`) and two GNSS traces (`GNSS_X001.csv`, `GNSS_X002.csv`) under the `Data/` folder.
-`IMU_X003.dat` pairs with the second GNSS file (`GNSS_X002.csv`).
+Note that `IMU_X003.dat` pairs with `GNSS_X002.csv`; there is no separate `GNSS_X003.csv`.
 
 If your data resides in a different location, set the environment variable
 `IMU_DATA_PATH` to point to that directory and the helper scripts will search it


### PR DESCRIPTION
## Summary
- update README to clarify `IMU_X003.dat` pairs with `GNSS_X002.csv`
- mention the same pairing note in MATLAB documentation

## Testing
- `pytest -q Python/tests` *(fails: FileNotFoundError for data files)*

------
https://chatgpt.com/codex/tasks/task_e_6863c47b0be483259b2f1c07de740a1e