### PR TITLE
Stop auto-installing dependencies

### DIFF
--- a/Python/FINAL.py
+++ b/Python/FINAL.py
@@ -21,10 +21,6 @@ import yaml
 
 HERE = pathlib.Path(__file__).resolve().parent
 
-from utils import ensure_dependencies
-
-ensure_dependencies()
-
 from tabulate import tabulate
 from tqdm import tqdm
 

--- a/Python/run_all_datasets.py
+++ b/Python/run_all_datasets.py
@@ -19,10 +19,6 @@ import yaml
 
 HERE = pathlib.Path(__file__).resolve().parent
 
-from utils import ensure_dependencies
-
-ensure_dependencies()
-
 from tabulate import tabulate
 from tqdm import tqdm
 

--- a/Python/utils.py
+++ b/Python/utils.py
@@ -1,30 +1,27 @@
 import numpy as np
 from typing import Tuple, Optional
 import pathlib
-import subprocess
-import sys
+
 import os
 
 
 def ensure_dependencies(requirements: Optional[pathlib.Path] = None) -> None:
-    """Install packages from ``requirements.txt`` if key deps are missing."""
+    """Verify that ``tabulate`` and ``tqdm`` are installed.
+
+    If either package is missing an ``ImportError`` is raised suggesting the
+    user run ``pip install -r requirements.txt``.
+    """
     try:
         import tabulate  # noqa: F401
         import tqdm  # noqa: F401
-    except ModuleNotFoundError:
+    except ModuleNotFoundError as e:
         if requirements is None:
             requirements = pathlib.Path(__file__).resolve().parent / "requirements.txt"
         else:
             requirements = pathlib.Path(requirements)
-        print("Installing Python dependencies ...")
-        subprocess.check_call([
-            sys.executable,
-            "-m",
-            "pip",
-            "install",
-            "-r",
-            str(requirements),
-        ])
+        raise ImportError(
+            f"Required packages missing ({e.name}). Please run 'pip install -r {requirements}'."
+        )
 
 
 


### PR DESCRIPTION
## Summary
- raise an ImportError when dependencies are missing
- drop auto-install logic from run_all_datasets.py and FINAL.py

## Testing
- `pip install -r requirements-dev.txt -r requirements.txt`
- `pytest -q Python/tests` *(fails: FileNotFoundError in test_new_plots.py)*

------
https://chatgpt.com/codex/tasks/task_e_6863c48e82c883259a3314fab472a4af