### PR TITLE
Fix run_triad_only Python invocation

### DIFF
--- a/MATLAB/run_triad_only.m
+++ b/MATLAB/run_triad_only.m
@@ -23,9 +23,16 @@ end
 here = fileparts(mfilename('fullpath'));
 py_dir = fullfile(here, '..', 'Python');
 
+%% Determine which Python executable to use
+py = pyenv;
+pyexe = py.Executable;
+if isempty(pyexe)
+    pyexe = 'python3';  % fallback
+end
+
 %% -- Run the Python batch processor ---------------------------------------
 py_script = fullfile(py_dir, 'run_all_datasets.py');
-cmd = sprintf('python "%s" --method TRIAD', py_script);
+cmd = sprintf('"%s" "%s" --method TRIAD', pyexe, py_script);
 status = system(cmd);
 if status ~= 0
     error('run_all_datasets.py failed');
@@ -64,8 +71,8 @@ for k = 1:numel(mat_files)
         continue
     end
     validate_py = fullfile(here, 'validate_with_truth.py');
-    vcmd = sprintf('python "%s" --est-file "%s" --truth-file "%s" --output "%s"', ...
-        validate_py, fullfile(results_dir, name), truth_file, results_dir);
+    vcmd = sprintf('"%s" "%s" --est-file "%s" --truth-file "%s" --output "%s"', ...
+        pyexe, validate_py, fullfile(results_dir, name), truth_file, results_dir);
     vstatus = system(vcmd);
     if vstatus ~= 0
         warning('Validation failed for %s', name);


### PR DESCRIPTION
## Summary
- ensure `run_triad_only.m` uses MATLAB's configured Python executable
- remove hard-coded `python` calls

## Testing
- `python3 -m pip install -r requirements-dev.txt -r requirements.txt`
- `pytest -q Python/tests` *(fails: FileNotFoundError in tests)*


------
https://chatgpt.com/codex/tasks/task_e_686409cd35408325978e8699906e5f9d