### PR TITLE
Add MATLAB plot regeneration docs

### DIFF
--- a/MATLAB/README.md
+++ b/MATLAB/README.md
@@ -127,6 +127,24 @@ ensure you are using the `'WGS84'` string in `Task_1.m` when calling
    git push
    ```
 
+### Regenerating Plots from Saved Results
+
+After running the Python pipeline you can recreate the figures in MATLAB by
+loading the saved result file:
+
+```matlab
+plot_results('results/IMU_X001_GNSS_X001_TRIAD_kf_output.mat')
+```
+
+If `load_npz.m` is on the MATLAB path, `plot_results` also accepts the
+NumPy `.npz` archives produced by the Python code:
+
+```matlab
+plot_results('results_X001.npz')
+```
+
+You can also call `load_npz` directly to access the arrays in a struct.
+
 ## Codex Integration Notes: Gravity, Bias and Metrics
 
 The MATLAB version mirrors the Python pipeline. Use the following steps when

--- a/MATLAB/load_npz.m
+++ b/MATLAB/load_npz.m
@@ -1,0 +1,25 @@
+function S = load_npz(npzFile)
+%LOAD_NPZ Load data from a NumPy .npz archive.
+%   S = LOAD_NPZ(FILE) reads FILE using py.numpy.load and converts the
+%   contained arrays to MATLAB types. Each array becomes a field in the
+%   returned struct.
+%
+%   This helper requires Python and NumPy to be available via the MATLAB
+%   "py" interface.
+%
+%   Example:
+%       data = load_npz('results_X001.npz');
+
+    np = py.importlib.import_module('numpy');
+    loaded = np.load(npzFile);
+    keys = cell(py.list(loaded.files));
+    S = struct();
+    for i = 1:numel(keys)
+        key = string(keys{i});
+        try
+            S.(key) = double(loaded{key});
+        catch
+            S.(key) = loaded{key};
+        end
+    end
+end

--- a/MATLAB/plot_results.m
+++ b/MATLAB/plot_results.m
@@ -1,10 +1,20 @@
-function plot_results(matFile)
-% Load .mat result and recreate plots for attitude, residuals and NED
-% comparison.  Figures are saved next to the input file using the same
-% naming scheme as the Python scripts.
+function plot_results(resultFile)
+%PLOT_RESULTS Recreate plots from saved result files.
+%   PLOT_RESULTS(FILE) loads the given MAT or NPZ result file and produces
+%   the attitude, position and velocity residual plots.  Figures are saved
+%   next to the input file using the same naming scheme as the Python
+%   scripts.
 
-S = load(matFile);
-[~,name] = fileparts(matFile);
+    [~,name,ext] = fileparts(resultFile);
+    if strcmpi(ext, '.npz')
+        if exist('load_npz', 'file')
+            S = load_npz(resultFile);
+        else
+            error('NPZ file given but load_npz.m is missing.');
+        end
+    else
+        S = load(resultFile);
+    end
 
 if isfield(S, 'euler')
     figure; plot(S.euler);


### PR DESCRIPTION
## Summary
- document how to reproduce plots in `MATLAB/README.md`
- support `.npz` files in `plot_results.m`
- provide helper `load_npz.m` for importing NumPy archives

## Testing
- `pip install -r requirements-dev.txt -r requirements.txt`
- `pytest -q Python/tests` *(fails: FileNotFoundError during plots)*

------
https://chatgpt.com/codex/tasks/task_e_68640d1392b4832596cc8de6fe69a1d7