### PR TITLE
Fix dataset path handling in batch scripts

### DIFF
--- a/Python/run_all_methods.py
+++ b/Python/run_all_methods.py
@@ -20,15 +20,14 @@ Run the script with ``--config config.yml`` to process those files.
 
 import argparse
 import itertools
-import os
 import pathlib
 import subprocess
 import sys
 from typing import Iterable, Tuple
 import logging
+from utils import get_data_file
 
 HERE = pathlib.Path(__file__).resolve().parent
-DATA_DIR = HERE.parent / "Data"
 try:
     import yaml
 except ModuleNotFoundError:  # allow running without PyYAML installed
@@ -86,9 +85,9 @@ def main(argv=None):
             sys.executable,
             str(HERE / "GNSS_IMU_Fusion.py"),
             "--imu-file",
-            str(DATA_DIR / imu),
+            str(get_data_file(imu)),
             "--gnss-file",
-            str(DATA_DIR / gnss),
+            str(get_data_file(gnss)),
             "--method",
             m,
         ]

--- a/Python/tests/test_missing_file.py
+++ b/Python/tests/test_missing_file.py
@@ -12,7 +12,7 @@ from GNSS_IMU_Fusion import main
 
 
 def test_missing_gnss_file(monkeypatch):
-    data_dir = Path(__file__).resolve().parents[1] / "Data"
+    data_dir = Path(__file__).resolve().parents[2] / "Data"
     args = ["--imu-file", str(data_dir / "IMU_X001.dat"), "--gnss-file", "missing.csv"]
     monkeypatch.setattr("sys.argv", ["GNSS_IMU_Fusion.py"] + args)
     with pytest.raises(FileNotFoundError):

--- a/Python/tests/test_new_plots.py
+++ b/Python/tests/test_new_plots.py
@@ -14,6 +14,7 @@ from GNSS_IMU_Fusion import main
 def test_body_frame_plots(tmp_path, monkeypatch):
     # run from a temporary working directory so plots are written under tmp_path
     monkeypatch.chdir(tmp_path)
+    Path("results").mkdir(exist_ok=True)
 
     # limit dataset size for speed
     orig_read_csv = pd.read_csv

--- a/Python/tests/test_no_plots_without_cartopy.py
+++ b/Python/tests/test_no_plots_without_cartopy.py
@@ -25,7 +25,7 @@ def test_no_plots_without_cartopy(monkeypatch):
         return df.head(5000)
     monkeypatch.setattr(pd, "read_csv", head5000)
 
-    data_dir = Path(__file__).resolve().parents[1] / "Data"
+    data_dir = Path(__file__).resolve().parents[2] / "Data"
     args = [
         "--imu-file",
         str(data_dir / "IMU_X001.dat"),

--- a/Python/tests/test_python_accuracy.py
+++ b/Python/tests/test_python_accuracy.py
@@ -6,7 +6,7 @@ pd = pytest.importorskip("pandas")
 
 from GNSS_IMU_Fusion import main
 
-DATA_DIR = Path(__file__).resolve().parents[1] / "Data"
+DATA_DIR = Path(__file__).resolve().parents[2] / "Data"
 DATASETS = {
     'X001': (DATA_DIR / "IMU_X001.dat", DATA_DIR / "GNSS_X001.csv"),
     'X002': (DATA_DIR / "IMU_X002.dat", DATA_DIR / "GNSS_X002.csv"),
@@ -28,7 +28,7 @@ def test_python_accuracy(monkeypatch, imu_file, gnss_file):
     main()
 
     tag = f"{Path(imu_file).stem}_{Path(gnss_file).stem}_TRIAD"
-    npz_path = Path("results") / f"{tag}_kf_output.npz"
+    npz_path = Path(__file__).resolve().parents[1] / "results" / f"{tag}_kf_output.npz"
     data = np.load(npz_path, allow_pickle=True)
     final_pos = data["summary"].item()["final_pos"]
     assert final_pos < 0.05, f"final position error {final_pos:.3f} m >= 0.05 m"

--- a/Python/tests/test_run_triad_only.py
+++ b/Python/tests/test_run_triad_only.py
@@ -19,7 +19,7 @@ def _run_script(monkeypatch, args):
     monkeypatch.setattr(pathlib.Path, 'glob', lambda self, pattern: [])
     monkeypatch.setattr(sys, 'argv', ['run_triad_only.py'] + args)
     repo_root = pathlib.Path(__file__).resolve().parents[2]
-    monkeypatch.syspath_prepend(str(repo_root))
+    monkeypatch.syspath_prepend(str(repo_root / 'Python'))
     # stub heavy modules
     po = types.ModuleType('plot_overlay')
     po.plot_overlay = lambda *a, **k: None

--- a/Python/tests/test_truth_alignment.py
+++ b/Python/tests/test_truth_alignment.py
@@ -18,7 +18,7 @@ from utils import ecef_to_geodetic, compute_C_ECEF_to_NED
 
 
 def test_truth_alignment():
-    data_dir = Path(__file__).resolve().parents[1] / "Data"
+    data_dir = Path(__file__).resolve().parents[2] / "Data"
     gnss = pd.read_csv(data_dir / "GNSS_X001.csv")
     start = gnss["Posix_Time"].iloc[0]
     gnss = gnss[gnss["Posix_Time"] - start <= 2]

--- a/Python/tests/test_validate_with_truth.py
+++ b/Python/tests/test_validate_with_truth.py
@@ -22,7 +22,7 @@ def test_validate_with_truth(monkeypatch):
 
     monkeypatch.setattr(pd, "read_csv", head5000)
 
-    data_dir = Path(__file__).resolve().parents[1] / "Data"
+    data_dir = Path(__file__).resolve().parents[2] / "Data"
     args = [
         "--imu-file",
         str(data_dir / "IMU_X001.dat"),
@@ -32,10 +32,12 @@ def test_validate_with_truth(monkeypatch):
         "TRIAD",
     ]
     monkeypatch.setattr(sys, "argv", ["GNSS_IMU_Fusion.py"] + args)
+    Path("results").mkdir(exist_ok=True)
     main()
 
     tag = "IMU_X001_GNSS_X001_TRIAD"
-    mat_path = Path("results") / f"{tag}_kf_output.mat"
+    results_dir = Path(__file__).resolve().parents[1] / "results"
+    mat_path = results_dir / f"{tag}_kf_output.mat"
     assert mat_path.exists(), f"Missing {mat_path}"
 
     est = load_estimate(str(mat_path))
@@ -68,7 +70,8 @@ def test_validate_with_truth(monkeypatch):
         sigma = 3 * np.sqrt(np.diagonal(est["P"], axis1=1, axis2=2)[:, :3])
         assert np.all(np.abs(err) <= sigma[: len(err)])
 
-    npz_path = Path("results") / f"{tag}_kf_output.npz"
+    results_dir = Path(__file__).resolve().parents[1] / "results"
+    npz_path = results_dir / f"{tag}_kf_output.npz"
     assert npz_path.exists(), f"Missing {npz_path}"
     npz = np.load(npz_path, allow_pickle=True)
     from scipy.io import loadmat
@@ -89,7 +92,7 @@ def test_validate_with_truth(monkeypatch):
     vmain()
 
     for frame in ["ECEF", "NED", "BODY"]:
-        pdf = Path("results") / f"Task5_compare_{frame}.pdf"
+        pdf = results_dir / f"Task5_compare_{frame}.pdf"
         assert pdf.exists(), f"Missing {pdf}"
 
 
@@ -125,7 +128,7 @@ def test_index_align(monkeypatch):
 
     monkeypatch.setattr(pd, "read_csv", head5000)
 
-    data_dir = Path(__file__).resolve().parents[1] / "Data"
+    data_dir = Path(__file__).resolve().parents[2] / "Data"
     run_args = [
         "--imu-file",
         str(data_dir / "IMU_X001.dat"),
@@ -135,11 +138,13 @@ def test_index_align(monkeypatch):
         "TRIAD",
     ]
     monkeypatch.setattr(sys, "argv", ["GNSS_IMU_Fusion.py"] + run_args)
+    Path("results").mkdir(exist_ok=True)
     main()
 
+    results_dir = Path(__file__).resolve().parents[1] / "results"
     args = [
         "--est-file",
-        "results/IMU_X001_GNSS_X001_TRIAD_kf_output.mat",
+        str(results_dir / "IMU_X001_GNSS_X001_TRIAD_kf_output.mat"),
         "--truth-file",
         str(data_dir / "STATE_X001.txt"),
         "--ref-lat",
@@ -157,5 +162,5 @@ def test_index_align(monkeypatch):
     vmain()
 
     for frame in ["NED", "ECEF", "BODY"]:
-        f = Path("results") / f"Task5_compare_{frame}.pdf"
+        f = results_dir / f"Task5_compare_{frame}.pdf"
         assert f.exists(), f"Missing {f}"


### PR DESCRIPTION
## Summary
- resolve IMU and GNSS paths through `utils.get_data_file`
- adjust tests for new path logic
- fix `run_triad_only` test helper path handling

## Testing
- `pytest -k 'get_data_file_env or run_triad_only' -q`

------
https://chatgpt.com/codex/tasks/task_e_68640d7d33588325a7ae1c953bd91f23