### PR TITLE
Add output directory flag

### DIFF
--- a/Python/auto_plots.py
+++ b/Python/auto_plots.py
@@ -9,6 +9,7 @@ hooked into :mod:`run_all_datasets` or another driver script.
 from __future__ import annotations
 
 import os
+import pathlib
 from typing import Iterable, Tuple
 
 import pandas as pd
@@ -25,7 +26,8 @@ from utils import compute_C_ECEF_to_NED
 # ---------------------------------------------------------------------------
 # Where figures and tables should be written
 # ---------------------------------------------------------------------------
-OUTPUT_DIR = "results/auto_plots"
+OUTPUT_BASE = pathlib.Path(os.environ.get("OUTPUT_DIR", "results"))
+OUTPUT_DIR = OUTPUT_BASE / "auto_plots"
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 # Collect metrics for the summary table

--- a/Python/run_all_datasets.py
+++ b/Python/run_all_datasets.py
@@ -82,6 +82,11 @@ def main():
     parser.add_argument('--method', choices=['TRIAD','Davenport','SVD','ALL'],
                         default='ALL')
     parser.add_argument('--config', help='YAML configuration file')
+    parser.add_argument(
+        '--output-dir',
+        default=str(HERE / 'results'),
+        help='Directory for summary.csv and other outputs',
+    )
     args = parser.parse_args()
 
     data_files = {p.name for p in DATA_DIR.iterdir()}
@@ -108,8 +113,8 @@ def main():
     cases = [(imu, gnss, m) for (imu, gnss) in datasets for m in method_list]
     fusion_results = []
 
-    results_dir = HERE / "results"
-    results_dir.mkdir(exist_ok=True)
+    results_dir = pathlib.Path(args.output_dir)
+    results_dir.mkdir(parents=True, exist_ok=True)
 
     for imu, gnss, method in tqdm(cases, desc="All cases"):
         if args.verbose:

--- a/Python/tests/test_run_all_datasets_output_dir.py
+++ b/Python/tests/test_run_all_datasets_output_dir.py
@@ -1,0 +1,25 @@
+import sys
+import importlib.util
+from pathlib import Path
+import types
+import runpy
+import pytest
+
+pytest.importorskip("numpy")
+
+
+def test_output_dir_option(tmp_path, monkeypatch):
+    repo_root = Path(__file__).resolve().parents[2]
+    script = repo_root / "Python" / "run_all_datasets.py"
+    spec = importlib.util.spec_from_file_location("run_all_datasets", script)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    def fake_run_one(*a, **k):
+        return ["method=TRIAD rmse_pos=0 final_pos=0"]
+
+    monkeypatch.setattr(mod, "run_one", fake_run_one)
+    monkeypatch.setattr(sys, "argv", ["run_all_datasets.py", "--datasets", "X001", "--method", "TRIAD", "--output-dir", str(tmp_path)])
+
+    mod.main()
+    assert (tmp_path / "summary.csv").exists()

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To run only the TRIAD method use the helper script
 python Python/run_triad_only.py
 ```
 
-Both scripts write their results to `Python/results/` and, when a reference trajectory is available, automatically validate the output.
+Both scripts write their results to `Python/results/` by default. Use `--output-dir DIR` to select a different location. When a reference trajectory is available, the output is automatically validated.
 
 ## Running the TRIAD pipeline in MATLAB
 Execute `TRIAD.m` from the `MATLAB` folder to run Tasks 1–5 on the bundled

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,8 @@
 - **Plotting helpers** (`auto_plots.py`, `summarise_runs.py`, `generate_summary.py`)
   - Automates generation of standard figures and summary tables.
   - Useful for batch processing of multiple datasets and visualising results.
+- **Batch runner output directory** (`run_all_datasets.py`, `auto_plots.py`)
+  - Results location can now be overridden with `--output-dir` or the `OUTPUT_DIR` environment variable.
 
 These utilities were added to streamline the fusion pipeline and assist with
 debugging and analysis.


### PR DESCRIPTION
## Summary
- allow changing output directory for run_all_datasets
- let auto_plots derive its base directory from the OUTPUT_DIR environment variable
- document the new flag and expose it in the changelog
- test the --output-dir option

## Testing
- `pytest Python/tests/test_utils.py::test_rotation_matrix_orthonormal Python/tests/test_run_all_datasets_output_dir.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68640d7f932c83258721d7c67138af88