### PR TITLE
Fix Task_2 reference in changelog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Recent Updates
 
-- **Bias estimation fix** (`MATLAB/Task_2.m`, `fusion_single.py`)
+- **Bias estimation fix** (`Task_2` function, `fusion_single.py`)
   - Detects a low-motion segment to compute accelerometer and gyroscope biases.
   - Scales the accelerometer magnitude to match 9.81 m/s² for more stable attitude initialisation.
 


### PR DESCRIPTION
## Summary
- remove the .m extension when referencing Task 2 in the changelog

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68645817ad9c83259c589a9d2fb7fbb0