### PR TITLE
Adjust requirements default path

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -12,7 +12,10 @@ def ensure_dependencies(requirements: Optional[pathlib.Path] = None) -> None:
         import tqdm  # noqa: F401
     except ModuleNotFoundError:
         if requirements is None:
-            requirements = pathlib.Path(__file__).resolve().parent / "requirements.txt"
+            requirements = (
+                pathlib.Path(__file__).resolve().parents[1]
+                / "requirements.txt"
+            )
         else:
             requirements = pathlib.Path(requirements)
         print("Installing Python dependencies ...")


### PR DESCRIPTION
## Summary
- ensure `ensure_dependencies()` defaults to repository root's requirements

## Testing
- `ruff check .` *(fails: unrecognized style errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68645829ca2883259de76ecd2b8cef8d