### PR TITLE
Update test instructions and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
-.PHONY: test
+.PHONY: test install-test-deps
 
-test:
-        pip install -r requirements.txt
-        PYTHONPATH=src pytest -q
+install-test-deps:
+	pip install -r requirements.txt -r requirements-dev.txt
+
+test: install-test-deps
+	PYTHONPATH=src pytest -q

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ time you run it. If you'd rather set them up beforehand, install the
 dependencies manually with:
 
 ```bash
-pip install -r requirements.txt
+pip install -r requirements.txt -r requirements-dev.txt
 ```
 
 For a minimal setup you can also install the packages individually:
@@ -265,12 +265,12 @@ writes `results/summary.csv`. Each row contains:
 
 Run the unit tests with `pytest`. **Installing the required Python packages is
 mandatory** before executing any tests. The suite relies on *all* entries in
-`requirements.txt` – including heavier libraries such as `cartopy` that can take
+`requirements.txt` **and** `requirements-dev.txt` – including heavier libraries such as `cartopy` that can take
 some time to build. Using a dedicated virtual environment or container is
 strongly recommended:
 
 ```bash
-pip install -r requirements.txt
+pip install -r requirements.txt -r requirements-dev.txt
 pytest -q
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ time you run it. If you'd rather set them up beforehand, install the
 dependencies manually with:
 
 ```bash
-pip install -r requirements.txt -r requirements-dev.txt
+pip install -r requirements.txt
 ```
 
 For a minimal setup you can also install the packages individually:
@@ -17,9 +17,10 @@ For a minimal setup you can also install the packages individually:
 pip install numpy matplotlib filterpy
 ```
 
-The tests, however, require the **full** `requirements.txt`, including hefty
-dependencies like `cartopy`. Installing them inside a virtual environment or
-a container helps keep your base Python setup clean.
+The tests, however, require the **full** `requirements.txt` together with
+`requirements-dev.txt`, including hefty dependencies like `cartopy`. Installing
+them inside a virtual environment or container helps keep your base Python
+setup clean.
 
 If you run into issues with filterpy on Ubuntu:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "imu_gnss_fusion"
+version = "0.0.0"
+dependencies = [
+    "numpy",
+    "pandas",
+    "matplotlib",
+    "cartopy",
+    "filterpy",
+    "scipy",
+    "rich",
+    "tabulate",
+    "tqdm",
+    "pyyaml",
+]
+
+[project.optional-dependencies]
+tests = [
+    "pytest",
+]
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+testpaths = ["tests"]
+


### PR DESCRIPTION
## Summary
- clarify that tests require both requirement files
- extend Makefile to install requirements-dev.txt before running tests
- add minimal pyproject.toml with pytest config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864a8cf874483259878b79597029891