### PR TITLE
Fix Makefile test target indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
 .PHONY: test
 
-
+test:
+	pip install -r requirements.txt -r requirements-dev.txt
+	PYTHONPATH=src pytest -q


### PR DESCRIPTION
## Summary
- restore the `test` target in the Makefile
- use TABs for the test commands

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_6864bea7cc608325b2fd0a1f679e55ae