### PR TITLE
Add ruff to dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
 pytest
+ruff

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+# Add the project root and the 'src' directory to sys.path so tests can
+# import application modules without installing the package.
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / 'src'))
+sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- include ruff in requirements-dev.txt so linting tools can be installed via pip
- add tests/conftest.py to set up package paths for imports

## Testing
- `pip install -r requirements-dev.txt -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864b22114ac83258b001794cdaa58b9