### PR TITLE
Configure ruff linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,17 @@ pytest -q
 You can also simply run `make test` to install both requirement files and
 execute the test suite in one command.
 
+## Linting
+
+Static checks run with [Ruff](https://github.com/astral-sh/ruff):
+
+```bash
+ruff check src tests
+```
+
+Rule `E402` is ignored in `pyproject.toml` as some modules rely on runtime
+imports.
+
 ## MATLAB Compatibility
 
 Each run now exports a MATLAB `.mat` file alongside the NPZ results. The plotting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,12 @@ tests = [
 [tool.pytest.ini_options]
 addopts = "-ra"
 testpaths = ["tests"]
+
+[tool.ruff]
+target-version = "py38"
+line-length = 88
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+select = ["E", "F"]
+ignore = ["E402", "E501"]


### PR DESCRIPTION
## Summary
- add Ruff configuration to pyproject
- document how to run the linter in the README

## Testing
- `pytest -q`
- `ruff check src tests --config pyproject.toml`

------
https://chatgpt.com/codex/tasks/task_e_6864c776db3c83258d27608a9be8e746