### PR TITLE
update results path for triad

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ python src/run_triad_only.py
 run_triad_only
 ```
 
-All output files are written to the `results/` directory.  When a matching
+All batch scripts create a `results/` folder in the directory you launch them
+from. All output files are written to this directory.  When a matching
 ground truth file such as `STATE_X001.txt` is available the script
 automatically calls `validate_with_truth.py` to compare the estimated trajectory
 against it. The validation summary and plots are saved alongside the exported
@@ -209,7 +210,7 @@ After all runs complete you can compare the datasets side by side:
 python src/plot_compare_all.py
 ```
 This creates one `all_datasets_<method>_comparison.pdf` per method in
-`results/`.
+the `results/` directory you ran the script from.
 
 ## Running a single dataset
 

--- a/src/run_triad_only.py
+++ b/src/run_triad_only.py
@@ -22,7 +22,7 @@ cmd = [
 subprocess.run(cmd, check=True)
 
 # --- Validate results when STATE_<id>.txt exists -----------------------------
-results = HERE / "results"
+results = pathlib.Path.cwd() / "results"
 for mat in results.glob("*_TRIAD_kf_output.mat"):
     m = re.match(r"IMU_(X\d+)_.*_TRIAD_kf_output\.mat", mat.name)
     if not m:


### PR DESCRIPTION
## Summary
- default `run_triad_only.py` results folder to CWD
- explain in README that batch scripts create `results/` in the working dir

## Testing
- `ruff check src/run_triad_only.py`
- `pytest -q` *(fails: KeyboardInterrupt after tests run)*

------
https://chatgpt.com/codex/tasks/task_e_6864ea6c5c788325b17566394189c8d3