### PR TITLE
Add CodeQL disable instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,8 @@ These utilities are optional and not exercised by the unit tests.
   request.
 - **Debugging:** If the MATLAB pipeline produces kilometre-scale drift,
   consult `docs/DebuggingDrift.md` for troubleshooting steps.
+- **Security:** Disable GitHub's default CodeQL scanner as described in
+  [docs/disable-default-codeql.md](docs/disable-default-codeql.md).
 
 
 See [docs/CHANGELOG.md](docs/CHANGELOG.md) for a list of recent features.

--- a/docs/disable-default-codeql.md
+++ b/docs/disable-default-codeql.md
@@ -1,0 +1,8 @@
+# Disable the Default CodeQL Setup
+
+This repository already runs CodeQL via a custom GitHub Actions workflow. To avoid duplicate scans, administrators should disable GitHub's automatic setup:
+
+1. Open **Settings → Security → Code security and analysis → Code scanning**.
+2. Under **Default setup**, click **Disable**.
+
+Disabling the default scanner ensures only the custom workflow executes.


### PR DESCRIPTION
## Summary
- add a short snippet explaining how to disable GitHub's default CodeQL scanner
- link to the snippet from README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864edd6bb248325b9297be7c257ce11