### PR TITLE
Update results path usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,8 @@ python src/run_triad_only.py
 run_triad_only
 ```
 
-All batch scripts create a `results/` folder in the directory you launch them
-from. All output files are written to this directory.  When a matching
-ground truth file such as `STATE_X001.txt` is available the script
+All the batch scripts (for example `src/run_triad_only.py` and
+`src/run_all_datasets.py`) create a `results/` folder in the directory you launch them from. All output files are written to this directory. When a matching ground truth file such as `STATE_X001.txt` is available the script
 automatically calls `validate_with_truth.py` to compare the estimated trajectory
 against it. The validation summary and plots are saved alongside the exported
 `.mat` files in `results/`.

--- a/src/run_triad_only.py
+++ b/src/run_triad_only.py
@@ -4,12 +4,12 @@ validate results when ground truth data is available."""
 
 import subprocess
 import sys
-import pathlib
+from pathlib import Path
 import re
 from plot_overlay import plot_overlay
 from validate_with_truth import load_estimate, assemble_frames
 
-HERE = pathlib.Path(__file__).resolve().parent
+HERE = Path(__file__).resolve().parent
 
 # --- Run the batch processor -------------------------------------------------
 cmd = [
@@ -22,7 +22,7 @@ cmd = [
 subprocess.run(cmd, check=True)
 
 # --- Validate results when STATE_<id>.txt exists -----------------------------
-results = pathlib.Path.cwd() / "results"
+results = Path.cwd() / "results"
 for mat in results.glob("*_TRIAD_kf_output.mat"):
     m = re.match(r"IMU_(X\d+)_.*_TRIAD_kf_output\.mat", mat.name)
     if not m:


### PR DESCRIPTION
## Summary
- use `Path.cwd()` in `run_triad_only.py`
- clarify in README that batch scripts create the `results/` folder where launched

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864f2f300e883259d73642292d6a609