### PR TITLE
Fix relative paths for data and results

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ All the batch scripts (for example `src/run_triad_only.py` and
 automatically calls `validate_with_truth.py` to compare the estimated trajectory
 against it. The validation summary and plots are saved alongside the exported
 `.mat` files in `results/`.
+The input data files are looked up relative to the repository root, so you can
+run the scripts from any directory.
 
 ## 🚀 Developing & Debugging in GitHub Codespaces
 

--- a/src/FINAL.py
+++ b/src/FINAL.py
@@ -23,6 +23,7 @@ from tabulate import tabulate
 from tqdm import tqdm
 
 HERE = pathlib.Path(__file__).resolve().parent
+ROOT = HERE.parent
 
 ensure_dependencies()
 LOG_DIR  = HERE / "logs"
@@ -47,8 +48,8 @@ def run_one(imu, gnss, method, verbose=False):
     fusion = importlib.import_module("GNSS_IMU_Fusion")
     argv = [
         "GNSS_IMU_Fusion.py",
-        "--imu-file", imu,
-        "--gnss-file", gnss,
+        "--imu-file", str(ROOT / imu),
+        "--gnss-file", str(ROOT / gnss),
         "--method", method,
     ]
     summary_lines = []
@@ -81,7 +82,7 @@ def main():
     parser.add_argument('--config', help='YAML configuration file')
     args = parser.parse_args()
 
-    here_files = {p.name for p in HERE.iterdir()}
+    root_files = {p.name for p in ROOT.iterdir()}
 
     if args.config:
         with open(args.config) as fh:
@@ -105,7 +106,7 @@ def main():
     cases = [(imu, gnss, m) for (imu, gnss) in datasets for m in method_list]
     fusion_results = []
 
-    results_dir = HERE / "results"
+    results_dir = pathlib.Path.cwd() / "results"
     results_dir.mkdir(exist_ok=True)
 
     for imu, gnss, method in tqdm(cases, desc="All cases"):
@@ -125,8 +126,8 @@ def main():
             print("GNSS Head:\n", gnss_df.head())
             print("IMU Head:\n", imu_data[:5])
             print("============================")
-        if imu not in here_files or gnss not in here_files:
-            raise FileNotFoundError(f"Missing {imu} or {gnss} in {HERE}")
+        if imu not in root_files or gnss not in root_files:
+            raise FileNotFoundError(f"Missing {imu} or {gnss} in {ROOT}")
         start = time.time()
         summaries = run_one(imu, gnss, method, verbose=args.verbose)
         runtime = time.time() - start

--- a/src/run_all_datasets.py
+++ b/src/run_all_datasets.py
@@ -23,6 +23,7 @@ from tqdm import tqdm
 ensure_dependencies()
 
 HERE = pathlib.Path(__file__).resolve().parent
+ROOT = HERE.parent
 SCRIPT   = HERE / "GNSS_IMU_Fusion.py"
 LOG_DIR  = HERE / "logs"
 LOG_DIR.mkdir(exist_ok=True)
@@ -47,9 +48,9 @@ def run_one(imu, gnss, method, verbose=False):
         sys.executable,
         SCRIPT,
         "--imu-file",
-        imu,
+        str(ROOT / imu),
         "--gnss-file",
-        gnss,
+        str(ROOT / gnss),
         "--method",
         method,
     ]
@@ -83,7 +84,7 @@ def main():
     parser.add_argument('--config', help='YAML configuration file')
     args = parser.parse_args()
 
-    here_files = {p.name for p in HERE.iterdir()}
+    root_files = {p.name for p in ROOT.iterdir()}
 
     if args.config:
         with open(args.config) as fh:
@@ -107,7 +108,7 @@ def main():
     cases = [(imu, gnss, m) for (imu, gnss) in datasets for m in method_list]
     fusion_results = []
 
-    results_dir = HERE / "results"
+    results_dir = pathlib.Path.cwd() / "results"
     results_dir.mkdir(exist_ok=True)
 
     for imu, gnss, method in tqdm(cases, desc="All cases"):
@@ -127,8 +128,8 @@ def main():
             print("GNSS Head:\n", gnss_df.head())
             print("IMU Head:\n", imu_data[:5])
             print("============================")
-        if imu not in here_files or gnss not in here_files:
-            raise FileNotFoundError(f"Missing {imu} or {gnss} in {HERE}")
+        if imu not in root_files or gnss not in root_files:
+            raise FileNotFoundError(f"Missing {imu} or {gnss} in {ROOT}")
         start = time.time()
         summaries = run_one(imu, gnss, method, verbose=args.verbose)
         runtime = time.time() - start

--- a/src/run_triad_only.py
+++ b/src/run_triad_only.py
@@ -10,6 +10,7 @@ from plot_overlay import plot_overlay
 from validate_with_truth import load_estimate, assemble_frames
 
 HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
 
 # --- Run the batch processor -------------------------------------------------
 cmd = [
@@ -45,8 +46,8 @@ for mat in results.glob("*_TRIAD_kf_output.mat"):
         est = load_estimate(str(mat))
         m2 = re.match(r"(IMU_\w+)_((?:GNSS_)?\w+)_TRIAD_kf_output", mat.stem)
         if m2:
-            imu_file = HERE / f"{m2.group(1)}.dat"
-            gnss_file = HERE / f"{m2.group(2)}.csv"
+            imu_file = ROOT / f"{m2.group(1)}.dat"
+            gnss_file = ROOT / f"{m2.group(2)}.csv"
             frames = assemble_frames(est, imu_file, gnss_file)
             for frame_name, data in frames.items():
                 t_i, p_i, v_i, a_i = data["imu"]


### PR DESCRIPTION
## Summary
- load data files from repository root in `run_all_datasets.py` and `FINAL.py`
- ensure results are written to `<cwd>/results`
- adjust `run_triad_only.py` to use repository root when assembling frames
- mention repository root data lookup in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864f88a43a8832596c228add960ad24