### PR TITLE
Add test setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,10 +276,11 @@ mandatory** before executing any tests. The suite relies on *all* entries in
 `requirements-dev.txt` – including heavier libraries such as `cartopy` that can
 take some time to build. Using a dedicated virtual environment or container is
 strongly recommended.  The `test` target in the `Makefile` installs both
-requirement files for you:
+requirement files for you. Alternatively, run the helper script
+`scripts/setup_tests.sh` before invoking `pytest`:
 
 ```bash
-pip install -r requirements.txt -r requirements-dev.txt
+./scripts/setup_tests.sh
 pytest -q
 ```
 

--- a/scripts/setup_tests.sh
+++ b/scripts/setup_tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install Python packages needed for running the tests
+pip install -r requirements.txt -r requirements-dev.txt


### PR DESCRIPTION
## Summary
- add a helper script to install test dependencies
- update README test docs to mention the script

## Testing
- `bash scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686511a6b974832587447bd77003acfb