### PR TITLE
Add MATLAB batch and hybrid runners

### DIFF
--- a/MATLAB/run_all_datasets_matlab.m
+++ b/MATLAB/run_all_datasets_matlab.m
@@ -1,0 +1,61 @@
+function run_all_datasets_matlab()
+%RUN_ALL_DATASETS_MATLAB  Pure MATLAB batch runner for all datasets
+%   Enumerates the IMU/GNSS pairs in the repository and executes
+%   Task_1 through Task_5 for the TRIAD method. The final Task 5
+%   results are saved as <IMU>_<GNSS>_TRIAD_kf_output.mat in the
+%   results directory. plot_results is called on each file to
+%   recreate the standard figures.
+
+here = fileparts(mfilename('fullpath'));
+root = fileparts(here);
+
+% Prefer a dedicated Data folder if present
+dataDir = fullfile(root, 'Data');
+if ~exist(dataDir, 'dir')
+    dataDir = root;
+end
+
+pairs = {
+    'IMU_X001.dat', 'GNSS_X001.csv';
+    'IMU_X002.dat', 'GNSS_X002.csv';
+    'IMU_X003.dat', 'GNSS_X002.csv';
+};
+
+resultsDir = fullfile(root, 'results');
+if ~exist(resultsDir, 'dir')
+    mkdir(resultsDir);
+end
+
+for k = 1:size(pairs,1)
+    imu  = fullfile(dataDir, pairs{k,1});
+    gnss = fullfile(dataDir, pairs{k,2});
+
+    % Fallback to helper search if file not in dataDir
+    if ~isfile(imu);  imu  = get_data_file(pairs{k,1});  end
+    if ~isfile(gnss); gnss = get_data_file(pairs{k,2}); end
+
+    fprintf('Processing %s with %s...\n', pairs{k,1}, pairs{k,2});
+
+    Task_1(imu, gnss, 'TRIAD');
+    Task_2(imu, gnss, 'TRIAD');
+    Task_3(imu, gnss, 'TRIAD');
+    Task_4(imu, gnss, 'TRIAD');
+    Task_5(imu, gnss, 'TRIAD');
+
+    [~, imuStem, ~]  = fileparts(pairs{k,1});
+    [~, gnssStem, ~] = fileparts(pairs{k,2});
+    task5File = fullfile(resultsDir, sprintf('%s_%s_TRIAD_task5_results.mat', ...
+        imuStem, gnssStem));
+    outFile  = fullfile(resultsDir, sprintf('%s_%s_TRIAD_kf_output.mat', ...
+        imuStem, gnssStem));
+    if isfile(task5File)
+        S = load(task5File);
+        save(outFile, '-struct', 'S');
+        plot_results(outFile);
+    else
+        warning('Missing %s', task5File);
+    end
+end
+
+fprintf('All datasets processed.\n');
+end

--- a/MATLAB/run_all_datasets_with_python.m
+++ b/MATLAB/run_all_datasets_with_python.m
@@ -1,0 +1,43 @@
+function run_all_datasets_with_python()
+%RUN_ALL_DATASETS_WITH_PYTHON  Run the Python batch pipeline from MATLAB
+%   Checks for a Python interpreter via pyenv and executes
+%   src/run_all_datasets.py. After completion each generated
+%   *_kf_output.mat file is loaded and passed to plot_results to
+%   reproduce the standard figures in MATLAB.
+
+here = fileparts(mfilename('fullpath'));
+root = fileparts(here);
+
+py = pyenv;
+if py.Status == "NotLoaded"
+    try
+        py = pyenv("Version","python3");
+    catch
+        try
+            py = pyenv("Version","python");
+        catch
+            error(["No usable Python interpreter found. " ...
+                   "Install Python 3 and configure pyenv."]);
+        end
+    end
+end
+
+pyScript = fullfile(root,'src','run_all_datasets.py');
+cmd = sprintf('"%s" "%s"', py.Executable, pyScript);
+status = system(cmd);
+if status ~= 0
+    error('run_all_datasets.py failed');
+end
+
+resultsDir = fullfile(root,'results');
+matFiles = dir(fullfile(resultsDir,'*_kf_output.mat'));
+for k = 1:numel(matFiles)
+    try
+        plot_results(fullfile(resultsDir, matFiles(k).name));
+    catch ME
+        warning('Plotting failed for %s: %s', matFiles(k).name, ME.message);
+    end
+end
+
+fprintf('Python pipeline complete.\n');
+end

--- a/README.md
+++ b/README.md
@@ -400,6 +400,36 @@ expects `Task4_results_<pair>.mat` to initialise the filter. Running the
 commands above reproduces the Python `main` results while letting you inspect
 each stage individually.
 
+### MATLAB-only pipeline
+
+Run the entire pipeline directly in MATLAB:
+
+```matlab
+run_all_datasets_matlab
+```
+
+The script scans `Data/` (or the repository root if that folder is missing)
+for matching IMU and GNSS logs, executes `Task_1` through `Task_5` for each
+pair and saves the results as `IMU_<id>_GNSS_<id>_TRIAD_kf_output.mat` in
+`results/`. `plot_results` is invoked automatically to export the standard
+PDF figures.
+
+Prerequisites: MATLAB R2023a or newer with the Signal Processing and
+Navigation Toolboxes.
+
+### MATLAB+Python hybrid pipeline
+
+When Python (with `numpy`, `pandas` and `scipy`) is available you can drive
+the Python batch runner from MATLAB:
+
+```matlab
+run_all_datasets_with_python
+```
+
+The wrapper calls `src/run_all_datasets.py` and afterwards loads each
+`*_kf_output.mat` file to generate the plots in MATLAB.
+Install Python 3.x along with `numpy`, `pandas` and `scipy` (or simply `pip install -r requirements.txt`).
+
 ## Export to MATLAB (.mat) files
 To convert the saved Python results into MATLAB `.mat` files, run from the repo root:
 


### PR DESCRIPTION
## Summary
- add `run_all_datasets_matlab.m` for a full MATLAB-only workflow
- add `run_all_datasets_with_python.m` to wrap the Python batch script
- document the MATLAB-only and hybrid pipelines in the README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686522416eb48325a0774782bf54f229