### PR TITLE
Improve reference docs for tasks 1 and 2

### DIFF
--- a/Report/task1_reference_vectors.md
+++ b/Report/task1_reference_vectors.md
@@ -4,30 +4,40 @@ This page summarises **Task\u00a01** as executed by `run_triad_only.py`. It deri
 
 ## Data file format
 
-`GNSS_Xnnn.csv` contains twenty comma-separated columns. The header lists the timestamp, geodetic position, ECEF coordinates and GNSS quality metrics:
+`GNSS_Xnnn.csv` contains twenty comma-separated columns. The header lists the
+timestamp, geodetic position, ECEF coordinates and GNSS quality metrics. The
+table below spells out the column names and units for clarity.
 
-```text
-UTC_yyyy, UTC_MM, UTC_dd, UTC_HH, UTC_mm, UTC_ss,
-Posix_Time,
-Latitude_deg, Longitude_deg, Height_deg,
-X_ECEF_m, Y_ECEF_m, Z_ECEF_m,
-VX_ECEF_mps, VY_ECEF_mps, VZ_ECEF_mps,
-HDOP, VDOP, PDOP, TDOP
-```
+| Column          | Unit  | Description                            |
+|-----------------|------|----------------------------------------|
+| `UTC_yyyy`      | year | Calendar year (UTC)                    |
+| `UTC_MM`        | month| Calendar month (UTC)                   |
+| `UTC_dd`        | day  | Day of month (UTC)                     |
+| `UTC_HH`        | hour | Hour of day (UTC)                      |
+| `UTC_mm`        | min  | Minute of hour (UTC)                   |
+| `UTC_ss`        | s    | Second of minute (UTC)                 |
+| `Posix_Time`    | s    | Continuous Unix time                   |
+| `Latitude_deg`  | deg  | Geodetic latitude                      |
+| `Longitude_deg` | deg  | Geodetic longitude                     |
+| `Height_deg`    | m    | Altitude above the ellipsoid           |
+| `X_ECEF_m`      | m    | ECEF X position                        |
+| `Y_ECEF_m`      | m    | ECEF Y position                        |
+| `Z_ECEF_m`      | m    | ECEF Z position                        |
+| `VX_ECEF_mps`   | m/s  | ECEF X velocity                        |
+| `VY_ECEF_mps`   | m/s  | ECEF Y velocity                        |
+| `VZ_ECEF_mps`   | m/s  | ECEF Z velocity                        |
+| `HDOP`          | –    | Horizontal dilution of precision       |
+| `VDOP`          | –    | Vertical dilution of precision         |
+| `PDOP`          | –    | Position dilution of precision         |
+| `TDOP`          | –    | Time dilution of precision             |
 
-* **UTC_yyyy \u2013 UTC_ss** \u2013 calendar time components.
-* **Posix_Time** \u2013 continuous Unix time in seconds.
-* **Latitude/Longitude** \u2013 geodetic coordinates in degrees.
-* **Height** \u2013 altitude above the ellipsoid in metres (despite the `deg` suffix).
-* **X/Y/Z_ECEF_m** \u2013 ECEF position in metres.
-* **VX/VY/VZ_ECEF_mps** \u2013 ECEF velocity in metres per second.
-* **HDOP/VDOP/PDOP/TDOP** \u2013 dimensionless GNSS DOP values.
-
-The `UTC_ss` column resets every minute, whereas `Posix_Time` increases monotonically. Each sample log contains 1\u202f250 rows plus the header.
+The `UTC_ss` column resets every minute, whereas `Posix_Time` increases
+monotonically. Each sample log contains 1\u202f250 rows plus the header.
 
 ## Steps
 
-1. Load the first valid ECEF position and velocity from the GNSS file.
+1. Load the GNSS CSV into memory and keep it available for later tasks. From
+   this dataset read the first valid ECEF position and velocity.
 2. Convert the position to geodetic latitude $\varphi$ and longitude $\lambda$ (see [ECEF_to_Geodetic.md](../docs/ECEF_to_Geodetic.md)).
 3. Rotate the velocity to NED with `compute_C_ECEF_to_NED(\varphi, \lambda)`.
 4. Define

--- a/Report/task2_body_vectors.md
+++ b/Report/task2_body_vectors.md
@@ -4,27 +4,30 @@ This page summarises **Task\u00a02**, which measures the reference vectors in th
 
 ## Data file format
 
-`IMU_Xnnn.dat` is a whitespace-separated table with ten columns:
+`IMU_Xnnn.dat` is a whitespace-separated table with ten columns.  The column
+names and units are listed below.
 
-```text
-index, time_s,
-dtheta_x, dtheta_y, dtheta_z,
-dv_x, dv_y, dv_z,
-temperature_C, status
-```
+| Column          | Unit | Description                                     |
+|-----------------|-----|-------------------------------------------------|
+| `index`         | –   | Sample counter starting at 0                    |
+| `time_s`        | s   | Time stamp (increments of `0.0025` s)           |
+| `dtheta_x`      | rad | Angular increment about X                       |
+| `dtheta_y`      | rad | Angular increment about Y                       |
+| `dtheta_z`      | rad | Angular increment about Z                       |
+| `dv_x`          | m/s | Velocity increment along X                      |
+| `dv_y`          | m/s | Velocity increment along Y                      |
+| `dv_z`          | m/s | Velocity increment along Z                      |
+| `temperature_C` | °C  | Sensor temperature (`22.5` in example files)    |
+| `status`        | –   | Data validity flag (`1` for valid samples)      |
 
-* **index** \u2013 sample counter starting at 0.
-* **time_s** \u2013 time stamp in seconds, increasing by `0.0025\u202fs` (400 Hz).
-* **dtheta_x,y,z** \u2013 angular increments in radians.
-* **dv_x,y,z** \u2013 velocity increments in metres per second.
-* **temperature_C** \u2013 sensor temperature (constant `22.5 °C` in the example files).
-* **status** \u2013 data validity flag (`1` for valid samples).
-
-The time column increases monotonically and does not wrap. `IMU_X001.dat` contains 500 000 rows, whereas the `_small` variants hold only the first 1 000 samples for quick tests.
+The time column increases monotonically and does not wrap. `IMU_X001.dat`
+contains 500 000 rows, whereas the `_small` variants hold only the first
+1 000 samples for quick tests.
 
 ## Steps
 
-1. Load the IMU file and extract the increment columns.
+1. Load the IMU file into memory so the full dataset is available for later
+   tasks, then extract the increment columns.
 2. Estimate the sampling period from the time values.
 3. Convert increments to rates and apply a low-pass filter.
 4. Detect a static interval with `detect_static_interval` and compute the mean accelerometer and gyroscope vectors.


### PR DESCRIPTION
## Summary
- add per-column tables to `task1_reference_vectors.md` and `task2_body_vectors.md`
- explain that GNSS/IMU data is kept in memory for later tasks
- clarify instructions in task steps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68660bbd9d2083258648ba42d93da349