### PR TITLE
Insert upgrade step for deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 
 # Install all Python dependencies needed for running the code and tests.
 deps:
+	pip install --upgrade pip setuptools wheel build
 	pip install -r requirements.txt -r requirements-dev.txt
 
 # Install dependencies and run the full test suite.


### PR DESCRIPTION
## Summary
- install pip, setuptools, wheel and build before installing other dependencies in the `deps` target

## Testing
- `ruff check src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866439f4c488325b39ab1d516592b98