### PR TITLE
Include progress display deps in test extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ tests = [
     "scipy",
     "filterpy",
     "cartopy",
+    "tqdm",
+    "tabulate",
     "pytest",
 ]
 


### PR DESCRIPTION
## Summary
- include `tqdm` and `tabulate` in the optional test dependencies list

## Testing
- `ruff check src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866439db14c8325b2e03255e3471c10