### PR TITLE
Update minimal install snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install -r requirements.txt
 For a minimal setup you can also install the packages individually:
 
 ```bash
-pip install numpy matplotlib filterpy
+pip install numpy matplotlib scipy filterpy
 ```
 
 The tests, however, require **all** packages from `requirements.txt` *and* the


### PR DESCRIPTION
## Summary
- mention `scipy` in the minimal install snippet

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: KeyboardInterrupt after tests complete)*

------
https://chatgpt.com/codex/tasks/task_e_6866439fecf08325a1bf11e155e77f51