### PR TITLE
Implement ground truth overlay

### DIFF
--- a/MATLAB/overlay_truth_task4.m
+++ b/MATLAB/overlay_truth_task4.m
@@ -1,0 +1,32 @@
+function overlay_truth_task4(kfFile, stateFile, method)
+%OVERLAY_TRUTH_TASK4 Overlay ground truth on Task 4 figures.
+%   OVERLAY_TRUTH_TASK4(KFFILE, STATEFILE, METHOD) loads the Kalman filter
+%   output MAT file and the matching STATE_X*.txt trajectory and saves
+%   figures with "_overlay_truth.pdf" suffix next to KFFILE.
+
+S = load(kfFile);
+truth = load(stateFile);
+if isfield(S,'ref_lat'); ref_lat = S.ref_lat; else; ref_lat = deg2rad(-32.026554); end
+if isfield(S,'ref_lon'); ref_lon = S.ref_lon; else; ref_lon = deg2rad(133.455801); end
+if isfield(S,'ref_r0');  ref_r0 = S.ref_r0;  else;  ref_r0 = [-3729051 3935676 -3348394]; end
+C = compute_C_ECEF_to_NED(ref_lat, ref_lon);
+
+pos_truth = (C*(truth(:,3:5)'-ref_r0(:)))';
+vel_truth = (C*truth(:,6:8)')';
+t_truth   = truth(:,2);
+acc_truth = [zeros(1,3); diff(vel_truth)./diff(t_truth)];
+
+t_est = S.time_residuals;
+if isempty(t_est); t_est = S.time; end
+pos_truth_i = interp1(t_truth, pos_truth, t_est);
+vel_truth_i = interp1(t_truth, vel_truth, t_est);
+acc_truth_i = interp1(t_truth, acc_truth, t_est);
+
+acc_imu = [zeros(1,3); diff(S.vel_ned)./diff(t_est)];
+
+plot_overlay('NED', method, t_est, S.pos_ned, S.vel_ned, acc_imu, ...
+             S.gnss_time, S.gnss_pos_ned, S.gnss_vel_ned, S.gnss_accel_ned, ...
+             t_est, S.pos_ned, S.vel_ned, acc_imu, fileparts(kfFile), ...
+             't_truth', t_est, 'pos_truth', pos_truth_i, 'vel_truth', vel_truth_i, ...
+             'acc_truth', acc_truth_i, 'suffix', '_overlay_truth.pdf');
+end

--- a/MATLAB/validate_all_methods.m
+++ b/MATLAB/validate_all_methods.m
@@ -120,6 +120,7 @@ for i = 1:numel(methods)
     if isfield(S,'gnss_pos_ned') && isfield(S,'vel_ned')
         t = 1:size(S.vel_ned,1);
         plot_overlay(t, pos, vel, diff([zeros(1,3);vel]), t, S.gnss_pos_ned, S.gnss_vel_ned, diff([zeros(1,3);S.gnss_vel_ned]), t, pos, vel, diff([zeros(1,3);vel]), 'NED', method, resultsDir);
+        overlay_truth_task4(kfFile, 'STATE_X001.txt', method);
     end
 end
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ against it. The validation summary and plots are saved alongside the exported
 `.mat` files in `results/`.
 The input data files are looked up relative to the repository root, so you can
 run the scripts from any directory.
+When a `STATE_*.txt` reference track is present additional figures named
+`<method>_<frame>_overlay_truth.pdf` are generated showing the fused trajectory
+against the ground truth.
 ### Sample Processing Report
 
 A sample run of `run_triad_only.py` is documented in [Report/](Report/index.md). Each page lists the equations and the PDF figures generated in the `results/` directory.

--- a/plot_summary.md
+++ b/plot_summary.md
@@ -12,3 +12,5 @@
 - **task5_all_body.pdf**: Kalman filter results in body frame
 - **davenport_residuals.pdf**: Position and velocity residuals
 - **davenport_attitude_angles.pdf**: Attitude angles over time
+- **<method>_<frame>_overlay_truth.pdf**: IMU/GNSS/fused comparison with
+  ground truth overlay

--- a/src/plot_overlay.py
+++ b/src/plot_overlay.py
@@ -23,29 +23,47 @@ def plot_overlay(
     vel_fused: np.ndarray,
     acc_fused: np.ndarray,
     out_dir: str,
+    *,
+    t_truth: np.ndarray | None = None,
+    pos_truth: np.ndarray | None = None,
+    vel_truth: np.ndarray | None = None,
+    acc_truth: np.ndarray | None = None,
+    suffix: str = "_overlay.pdf",
 ) -> None:
-    """Save a 4x1 overlay plot comparing IMU-only, GNSS and fused tracks."""
+    """Save a 4x1 overlay plot comparing IMU-only, GNSS and fused tracks.
+
+    When ``t_truth`` and corresponding arrays are provided, the ground truth is
+    plotted with a solid black line and the figure is saved using ``suffix``.
+    """
     fig, axes = plt.subplots(4, 1, figsize=(8, 10), sharex=True)
 
     axes[0].plot(t_imu, _norm(pos_imu), "b--", label="IMU only")
     axes[0].plot(t_gnss, _norm(pos_gnss), "k.", label="GNSS")
+    if t_truth is not None and pos_truth is not None:
+        axes[0].plot(t_truth, _norm(pos_truth), "k-", label="Truth")
     axes[0].plot(t_fused, _norm(pos_fused), "r-", label="Fused")
     axes[0].set_ylabel("Position [m]")
     axes[0].legend()
 
     axes[1].plot(t_imu, _norm(vel_imu), "b--")
     axes[1].plot(t_gnss, _norm(vel_gnss), "k.")
+    if t_truth is not None and vel_truth is not None:
+        axes[1].plot(t_truth, _norm(vel_truth), "k-")
     axes[1].plot(t_fused, _norm(vel_fused), "r-")
     axes[1].set_ylabel("Velocity [m/s]")
 
     axes[2].plot(t_imu, _norm(acc_imu), "b--")
     axes[2].plot(t_gnss, _norm(acc_gnss), "k.")
+    if t_truth is not None and acc_truth is not None:
+        axes[2].plot(t_truth, _norm(acc_truth), "k-")
     axes[2].plot(t_fused, _norm(acc_fused), "r-")
     axes[2].set_ylabel("Acceleration [m/s$^2$]")
 
-    axes[3].plot(pos_imu[:, 0], pos_imu[:, 1], "b--")
-    axes[3].plot(pos_gnss[:, 0], pos_gnss[:, 1], "k.")
-    axes[3].plot(pos_fused[:, 0], pos_fused[:, 1], "r-")
+    axes[3].plot(pos_imu[:, 0], pos_imu[:, 1], "b--", label="IMU only")
+    axes[3].plot(pos_gnss[:, 0], pos_gnss[:, 1], "k.", label="GNSS")
+    if pos_truth is not None:
+        axes[3].plot(pos_truth[:, 0], pos_truth[:, 1], "k-", label="Truth")
+    axes[3].plot(pos_fused[:, 0], pos_fused[:, 1], "r-", label="Fused")
     axes[3].set_xlabel(f"{frame} X")
     axes[3].set_ylabel(f"{frame} Y")
     axes[3].set_title("Trajectory")
@@ -53,6 +71,6 @@ def plot_overlay(
 
     fig.suptitle(f"{method} - {frame} frame comparison")
     fig.tight_layout(rect=[0, 0, 1, 0.97])
-    out_path = Path(out_dir) / f"{method}_{frame}_overlay.pdf"
+    out_path = Path(out_dir) / f"{method}_{frame}{suffix}"
     fig.savefig(out_path)
     plt.close(fig)

--- a/src/run_triad_only.py
+++ b/src/run_triad_only.py
@@ -48,11 +48,18 @@ for mat in results.glob("*_TRIAD_kf_output.mat"):
         if m2:
             imu_file = ROOT / f"{m2.group(1)}.dat"
             gnss_file = ROOT / f"{m2.group(2)}.csv"
-            frames = assemble_frames(est, imu_file, gnss_file)
+            frames = assemble_frames(est, imu_file, gnss_file, truth)
             for frame_name, data in frames.items():
                 t_i, p_i, v_i, a_i = data["imu"]
                 t_g, p_g, v_g, a_g = data["gnss"]
                 t_f, p_f, v_f, a_f = data["fused"]
+                truth_data = data.get("truth")
+                if truth_data is not None:
+                    t_t, p_t, v_t, a_t = truth_data
+                    suffix = "_overlay_truth.pdf"
+                else:
+                    t_t = p_t = v_t = a_t = None
+                    suffix = "_overlay.pdf"
                 plot_overlay(
                     frame_name,
                     "TRIAD",
@@ -69,6 +76,11 @@ for mat in results.glob("*_TRIAD_kf_output.mat"):
                     v_f,
                     a_f,
                     results,
+                    t_truth=t_t,
+                    pos_truth=p_t,
+                    vel_truth=v_t,
+                    acc_truth=a_t,
+                    suffix=suffix,
                 )
     except Exception as e:
         print(f"Overlay plot failed: {e}")


### PR DESCRIPTION
## Summary
- support optional ground‑truth in `assemble_frames`
- plot truth data in `plot_overlay`
- propagate truth data through `validate_with_truth`
- generate overlay with truth in batch scripts
- add MATLAB helper for truth overlay
- document new overlay PDFs
- test creation of `_overlay_truth` figures

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68663c3148d88325b628810705f2a1e1