### PR TITLE
Add requirements-dev.txt for test dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest
+flake8
+ruff


### PR DESCRIPTION
## Summary
- add a `requirements-dev.txt` with pytest and linting tools
- keep `Makefile`, `scripts/setup_tests.sh` and README referencing the file

## Testing
- `make test` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68664577ac90832593e159a37bfe10f5