### PR TITLE
Add truth overlay plotting

### DIFF
--- a/src/plot_overlay.py
+++ b/src/plot_overlay.py
@@ -23,6 +23,11 @@ def plot_overlay(
     vel_fused: np.ndarray,
     acc_fused: np.ndarray,
     out_dir: str,
+    t_truth: np.ndarray | None = None,
+    pos_truth: np.ndarray | None = None,
+    vel_truth: np.ndarray | None = None,
+    acc_truth: np.ndarray | None = None,
+    suffix: str = "_overlay.pdf",
 ) -> None:
     """Save a 4x1 overlay plot comparing IMU-only, GNSS and fused tracks."""
     fig, axes = plt.subplots(4, 1, figsize=(8, 10), sharex=True)
@@ -51,8 +56,14 @@ def plot_overlay(
     axes[3].set_title("Trajectory")
     axes[3].axis("equal")
 
+    if t_truth is not None and pos_truth is not None:
+        axes[0].plot(t_truth, _norm(pos_truth), "k-", label="Truth")
+        axes[1].plot(t_truth, _norm(vel_truth), "k-") if vel_truth is not None else None
+        axes[2].plot(t_truth, _norm(acc_truth), "k-") if acc_truth is not None else None
+        axes[3].plot(pos_truth[:, 0], pos_truth[:, 1], "k-", label="Truth")
+
     fig.suptitle(f"{method} - {frame} frame comparison")
     fig.tight_layout(rect=[0, 0, 1, 0.97])
-    out_path = Path(out_dir) / f"{method}_{frame}_overlay.pdf"
+    out_path = Path(out_dir) / f"{method}_{frame}{suffix}"
     fig.savefig(out_path)
     plt.close(fig)

--- a/src/validate_with_truth.py
+++ b/src/validate_with_truth.py
@@ -271,6 +271,11 @@ def main():
 
     t_truth = truth[:, 1]
     truth_pos_ned = np.array([C @ (p - ref_r0) for p in truth[:, 2:5]])
+    truth_vel_ned = np.array([C @ v for v in truth[:, 5:8]])
+    truth_acc_ned = np.zeros_like(truth_vel_ned)
+    if len(t_truth) > 1:
+        dt_truth = np.diff(t_truth, prepend=t_truth[0])
+        truth_acc_ned[1:] = np.diff(truth_vel_ned, axis=0) / dt_truth[1:, None]
 
     # ensure estimate arrays use the same length for time and states
     t_est = np.asarray(est["time"]).squeeze()
@@ -288,7 +293,6 @@ def main():
     err_quat = None
 
     if est.get("vel") is not None:
-        truth_vel_ned = np.array([C @ v for v in truth[:, 5:8]])
         vel_est = np.asarray(est["vel"])
         n_vel = min(len(t_est), len(vel_est))
         t_vel = t_est[:n_vel]
@@ -418,6 +422,11 @@ def main():
                     v_f,
                     a_f,
                     args.output,
+                    t_truth,
+                    truth_pos_ned,
+                    truth_vel_ned,
+                    truth_acc_ned,
+                    suffix="_overlay_truth.pdf",
                 )
         except Exception as e:
             print(f"Overlay plot failed: {e}")


### PR DESCRIPTION
## Summary
- extend `plot_overlay` with optional truth data and suffix
- include truth data in overlay plots in `validate_with_truth`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866469050ec8325a11c593d9544459f