### PR TITLE
Add truth overlay plotting

### DIFF
--- a/src/plot_overlay.py
+++ b/src/plot_overlay.py
@@ -28,19 +28,22 @@ def plot_overlay(
     pos_truth: np.ndarray | None = None,
     vel_truth: np.ndarray | None = None,
     acc_truth: np.ndarray | None = None,
-    suffix: str = "_overlay.pdf",
+    suffix: str | None = None,
 ) -> None:
     """Save a 4x1 overlay plot comparing IMU-only, GNSS and fused tracks.
 
     When ``t_truth`` and corresponding arrays are provided, the ground truth is
-    plotted with a solid black line and the figure is saved using ``suffix``.
+    plotted with a solid green line and the figure is saved using
+    ``suffix`` or ``"_overlay_truth.pdf"`` when ``suffix`` is ``None``.
     """
+    if suffix is None:
+        suffix = "_overlay_truth.pdf" if t_truth is not None else "_overlay.pdf"
     fig, axes = plt.subplots(4, 1, figsize=(8, 10), sharex=True)
 
     axes[0].plot(t_imu, _norm(pos_imu), "b--", label="IMU only")
     axes[0].plot(t_gnss, _norm(pos_gnss), "k.", label="GNSS")
     if t_truth is not None and pos_truth is not None:
-        axes[0].plot(t_truth, _norm(pos_truth), "k-", label="Truth")
+        axes[0].plot(t_truth, _norm(pos_truth), "g-", label="Truth")
     axes[0].plot(t_fused, _norm(pos_fused), "r-", label="Fused")
     axes[0].set_ylabel("Position [m]")
     axes[0].legend()
@@ -48,21 +51,21 @@ def plot_overlay(
     axes[1].plot(t_imu, _norm(vel_imu), "b--")
     axes[1].plot(t_gnss, _norm(vel_gnss), "k.")
     if t_truth is not None and vel_truth is not None:
-        axes[1].plot(t_truth, _norm(vel_truth), "k-")
+        axes[1].plot(t_truth, _norm(vel_truth), "g-")
     axes[1].plot(t_fused, _norm(vel_fused), "r-")
     axes[1].set_ylabel("Velocity [m/s]")
 
     axes[2].plot(t_imu, _norm(acc_imu), "b--")
     axes[2].plot(t_gnss, _norm(acc_gnss), "k.")
     if t_truth is not None and acc_truth is not None:
-        axes[2].plot(t_truth, _norm(acc_truth), "k-")
+        axes[2].plot(t_truth, _norm(acc_truth), "g-")
     axes[2].plot(t_fused, _norm(acc_fused), "r-")
     axes[2].set_ylabel("Acceleration [m/s$^2$]")
 
     axes[3].plot(pos_imu[:, 0], pos_imu[:, 1], "b--", label="IMU only")
     axes[3].plot(pos_gnss[:, 0], pos_gnss[:, 1], "k.", label="GNSS")
     if pos_truth is not None:
-        axes[3].plot(pos_truth[:, 0], pos_truth[:, 1], "k-", label="Truth")
+        axes[3].plot(pos_truth[:, 0], pos_truth[:, 1], "g-", label="Truth")
     axes[3].plot(pos_fused[:, 0], pos_fused[:, 1], "r-", label="Fused")
     axes[3].set_xlabel(f"{frame} X")
     axes[3].set_ylabel(f"{frame} Y")

--- a/src/run_all_datasets.py
+++ b/src/run_all_datasets.py
@@ -186,10 +186,8 @@ def main():
                     truth = data.get("truth")
                     if truth is not None:
                         t_t, p_t, v_t, a_t = truth
-                        suffix = "_overlay_truth.pdf"
                     else:
                         t_t = p_t = v_t = a_t = None
-                        suffix = "_overlay.pdf"
                     plot_overlay(
                         frame_name,
                         method,
@@ -210,7 +208,6 @@ def main():
                         pos_truth=p_t,
                         vel_truth=v_t,
                         acc_truth=a_t,
-                        suffix=suffix,
                     )
             except Exception as e:
                 print(f"Truth overlay failed: {e}")

--- a/src/run_triad_only.py
+++ b/src/run_triad_only.py
@@ -56,10 +56,8 @@ for mat in results.glob("*_TRIAD_kf_output.mat"):
                 truth_data = data.get("truth")
                 if truth_data is not None:
                     t_t, p_t, v_t, a_t = truth_data
-                    suffix = "_overlay_truth.pdf"
                 else:
                     t_t = p_t = v_t = a_t = None
-                    suffix = "_overlay.pdf"
                 plot_overlay(
                     frame_name,
                     "TRIAD",
@@ -80,7 +78,6 @@ for mat in results.glob("*_TRIAD_kf_output.mat"):
                     pos_truth=p_t,
                     vel_truth=v_t,
                     acc_truth=a_t,
-                    suffix=suffix,
                 )
     except Exception as e:
         print(f"Overlay plot failed: {e}")

--- a/src/validate_with_truth.py
+++ b/src/validate_with_truth.py
@@ -477,10 +477,8 @@ def main():
                 truth = data.get("truth")
                 if truth is not None:
                     t_t, p_t, v_t, a_t = truth
-                    suffix = "_overlay_truth.pdf"
                 else:
                     t_t = p_t = v_t = a_t = None
-                    suffix = "_overlay.pdf"
                 plot_overlay(
                     frame_name,
                     method,
@@ -501,7 +499,6 @@ def main():
                     pos_truth=p_t,
                     vel_truth=v_t,
                     acc_truth=a_t,
-                    suffix=suffix,
                 )
         except Exception as e:
             print(f"Overlay plot failed: {e}")

--- a/tests/test_plot_overlay.py
+++ b/tests/test_plot_overlay.py
@@ -1,0 +1,31 @@
+import numpy as np
+from src.plot_overlay import plot_overlay
+
+
+def test_plot_overlay_with_truth(tmp_path):
+    t = np.linspace(0, 1, 5)
+    pos = np.vstack([t, t, t]).T
+    vel = pos * 0
+    acc = pos * 0
+    plot_overlay(
+        "ECEF",
+        "TEST",
+        t,
+        pos,
+        vel,
+        acc,
+        t,
+        pos,
+        vel,
+        acc,
+        t,
+        pos,
+        vel,
+        acc,
+        tmp_path,
+        t_truth=t,
+        pos_truth=pos,
+        vel_truth=vel,
+        acc_truth=acc,
+    )
+    assert (tmp_path / "TEST_ECEF_overlay_truth.pdf").exists()


### PR DESCRIPTION
## Summary
- show truth curves on overlay plots
- default to `_overlay_truth.pdf` output when truth is provided
- pass truth data from `validate_with_truth` and related drivers
- test that overlay plotting with truth works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68668b03ddd88325973b20a0c4c396e5