### PR TITLE
Ensure assemble_frames test matches new API

### DIFF
--- a/tests/test_assemble_frames.py
+++ b/tests/test_assemble_frames.py
@@ -16,7 +16,7 @@ def test_assemble_frames_with_truth():
         "quat": np.tile([1.0, 0.0, 0.0, 0.0], (3, 1)),
     }
 
-    frames = assemble_frames(est, "imu.dat", str(gnss_file), str(truth_file))
+    frames = assemble_frames(est, str(gnss_file), str(truth_file))
 
     for frame in ["NED", "ECEF", "Body"]:
         assert "truth" in frames[frame], f"Missing truth in {frame} frame"


### PR DESCRIPTION
## Summary
- fix test_assemble_frames to use current assemble_frames API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686693a1cd948325a90b5e655b3311f8