### PR TITLE
Fix assemble_frames test after parameter removal

### DIFF
--- a/tests/test_assemble_frames.py
+++ b/tests/test_assemble_frames.py
@@ -16,7 +16,7 @@ def test_assemble_frames_with_truth():
         "quat": np.tile([1.0, 0.0, 0.0, 0.0], (3, 1)),
     }
 
-    frames = assemble_frames(est, "imu.dat", str(gnss_file), str(truth_file))
+    frames = assemble_frames(est, str(gnss_file), str(truth_file))
 
     for frame in ["NED", "ECEF", "Body"]:
         assert "truth" in frames[frame], f"Missing truth in {frame} frame"


### PR DESCRIPTION
## Summary
- update test to match new `assemble_frames` signature

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686693a380e083259ffc8e4665b95e76