### PR TITLE
Update README for self-contained GNSS_IMU_Fusion_single

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,9 +249,11 @@ the `results/` directory you ran the script from.
 
 #### GNSS_IMU_Fusion_single(imu_file, gnss_file)
 
-The MATLAB function [`GNSS_IMU_Fusion_single`](MATLAB/GNSS_IMU_Fusion_single.m)
-performs the same steps as `run_triad_only.py` for a single dataset and writes
-the resulting plots to `results/`:
+[`GNSS_IMU_Fusion_single`](MATLAB/GNSS_IMU_Fusion_single.m) is now a
+self-contained script that implements the full Task&nbsp;1&ndash;Task&nbsp;5
+pipeline internally and writes the resulting plots to `results/`.  The
+stand‑alone `Task_*.m` files remain in the repository for workflows that call
+them individually:
 
 ```matlab
 GNSS_IMU_Fusion_single('IMU_X001.dat', 'GNSS_X001.csv')


### PR DESCRIPTION
## Summary
- clarify that `GNSS_IMU_Fusion_single` now bundles Task 1–Task 5 internally
- keep the example invocation and point out that `Task_*.m` are still available

## Testing
- `make test` *(fails: assemble_frames() positional arguments error)*

------
https://chatgpt.com/codex/tasks/task_e_686698a268908325962a93ae4955a602