### PR TITLE
Switch to test extras

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Install all Python dependencies needed for running the code and tests.
 deps:
 	pip install --upgrade pip setuptools wheel build
-	pip install -r requirements.txt -r requirements-dev.txt
+       pip install -e .[tests]
 
 # Install dependencies and run the full test suite.
 test: deps

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ For a minimal setup you can also install the packages individually:
 pip install numpy matplotlib scipy filterpy
 ```
 
-The tests, however, require **all** packages from `requirements.txt` *and* the
-development extras listed in `requirements-dev.txt`.  This pulls in heavier
-libraries such as `cartopy`.  Installing them in a virtual environment or
-container keeps your base Python setup clean.  Running `make test` installs
-both requirement files automatically before executing `pytest`.
+The tests, however, require **all** packages from `requirements.txt` together
+with the optional test extras defined in `pyproject.toml`.  These pull in
+heavier libraries such as `cartopy`.  Installing them in a virtual environment
+or container keeps your base Python setup clean.  Running `make test` installs
+the optional extras automatically before executing `pytest`.
 
 If you run into issues with filterpy on Ubuntu:
 
@@ -53,14 +53,13 @@ pip3 install filterpy
 
 #### Installing test requirements
 
-To run the unit tests you need `numpy`, `pandas`, `scipy` and `cartopy` which are all included in `requirements.txt`. Install them together with `pytest` via:
+To run the unit tests install the package in editable mode with the
+`tests` extras:
 
 ```bash
-pip install -r requirements-dev.txt -r requirements.txt
+pip install -e .[tests]
 ```
-Both requirement files **must** be installed before executing `pytest`.
-`pytest` itself is only listed in `requirements-dev.txt`, so skipping that
-file will leave the `pytest` command unavailable.
+This pulls in `pytest` and the additional dependencies such as `cartopy`.
 
 #### Offline installation
 
@@ -318,20 +317,20 @@ writes `results/summary.csv`. Each row contains:
 
 Run the unit tests with `pytest`. **Installing the required Python packages is
 mandatory** before executing any tests. The suite relies on *all* entries in
-`requirements.txt` as well as the development dependencies in
-`requirements-dev.txt` – including heavier libraries such as `cartopy` that can
-take some time to build. Using a dedicated virtual environment or container is
-strongly recommended.  The `test` target in the `Makefile` installs both
-requirement files for you. Alternatively, run the helper script
-`scripts/setup_tests.sh` before invoking `pytest`:
+`requirements.txt` together with the optional test extras defined in
+`pyproject.toml` – including heavier libraries such as `cartopy` that can take
+some time to build. Using a dedicated virtual environment or container is
+strongly recommended.  The `test` target in the `Makefile` installs these
+extras for you. Alternatively, run the helper script `scripts/setup_tests.sh`
+before invoking `pytest`:
 
 ```bash
 ./scripts/setup_tests.sh
 pytest -q
 ```
 
-You can also simply run `make test` to install both requirement files and
-execute the test suite in one command.
+You can also simply run `make test` to install the optional extras and execute
+the test suite in one command.
 
 ### Linting
 

--- a/scripts/setup_tests.sh
+++ b/scripts/setup_tests.sh
@@ -3,4 +3,4 @@ set -euo pipefail
 
 # Install Python packages needed for running the tests
 pip install --upgrade pip setuptools wheel build
-pip install -r requirements.txt -r requirements-dev.txt
+pip install -e .[tests]


### PR DESCRIPTION
## Summary
- document new way to install test requirements
- adjust references to old requirements-dev.txt approach
- use extras in Makefile and setup script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68669c017b908325b328fb6ffeca8a7b