### PR TITLE
Fix overlay plotting docs

### DIFF
--- a/MATLAB/README_pipeline.md
+++ b/MATLAB/README_pipeline.md
@@ -90,10 +90,11 @@ GNSS_IMU_Fusion_single('IMU_X001.dat','GNSS_X001.csv')
 
 ### Overlay comparison with ground truth
 
-Use `plot_overlay_with_truth` (or the wrapper `overlay_truth_task4`) to generate
-4×1 comparison plots between the fused trajectory and a `STATE_*.txt` reference
-track.  The PDF figures `<method>_<frame>_overlay_truth.pdf` are written next to
-the Kalman filter results in the `results/` folder.
+Run `python src/validate_with_truth.py` or call the MATLAB helper
+`overlay_truth_task4` to overlay the fused trajectory with a
+`STATE_*.txt` reference.  The comparison figures
+`<method>_<frame>_overlay_truth.pdf` are stored in the `results/` directory
+next to the Kalman filter output.
 
 ### Compatibility notes
 

--- a/docs/MATLAB/Task4_MATLAB.md
+++ b/docs/MATLAB/Task4_MATLAB.md
@@ -36,10 +36,7 @@ GNSS ECEF → NED → comparison plots
 ### 4.13 Validate and Plot
 - Plot GNSS, raw IMU and integrated IMU data in NED, body and ECEF frames.
 - Save the PDFs as `results/<tag>_task4_*.pdf` and list them in `plot_summary.md`.
-- When a `STATE_*.txt` reference trajectory is available the helper
-  `plot_overlay_with_truth` overlays the fused output with the ground truth and
-  stores comparison PDFs named `<method>_<frame>_overlay_truth.pdf` in the same
-  folder as the Kalman filter results.
+- When a `STATE_*.txt` reference trajectory is available you can run the Python script `src/validate_with_truth.py` or call the MATLAB helper `overlay_truth_task4` to overlay the fused output with the ground truth.  The resulting PDF files `<method>_<frame>_overlay_truth.pdf` are written to the `results/` directory alongside the Kalman filter results.
 
 ## Result
 


### PR DESCRIPTION
## Summary
- fix references to the non-existent `plot_overlay_with_truth` script
- clarify that Python `validate_with_truth.py` or MATLAB `overlay_truth_task4` should be run
- remind readers that `<method>_<frame>_overlay_truth.pdf` files are saved in `results/`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68669e51a6dc8325803633ebfcdb433a