### PR TITLE
Fix regex in validate_with_truth

### DIFF
--- a/src/validate_with_truth.py
+++ b/src/validate_with_truth.py
@@ -481,12 +481,12 @@ def main():
         plot_err(t_truth, err_quat, sigma_quat, ["q0", "q1", "q2", "q3"], "att_err")
 
     m = re.match(
-        r"(IMU_\w+)_GNSS_(\w+)_([A-Za-z]+)_kf_output",
+        r"(IMU_\w+)_(GNSS_\w+)_([A-Za-z]+)_kf_output",
         os.path.basename(args.est_file),
     )
     if m:
         dataset_dir = Path(args.truth_file).resolve().parent
-        gnss_file = dataset_dir / f"GNSS_{m.group(2)}.csv"
+        gnss_file = dataset_dir / f"{m.group(2)}.csv"
         method = m.group(3)
         try:
             frames = assemble_frames(est, gnss_file, args.truth_file)

--- a/tests/test_validate_with_truth.py
+++ b/tests/test_validate_with_truth.py
@@ -141,7 +141,13 @@ def test_overlay_truth_generation(tmp_path, monkeypatch):
     )
     validate_main()
 
-    assert list(Path("results").glob("*_overlay_truth.pdf"))
+    expected = {
+        "TRIAD_NED_overlay_truth.pdf",
+        "TRIAD_ECEF_overlay_truth.pdf",
+        "TRIAD_Body_overlay_truth.pdf",
+    }
+    produced = {p.name for p in Path("results").glob("*_overlay_truth.pdf")}
+    assert expected.issubset(produced), f"Missing overlays: {expected - produced}"
 
 
 def test_assemble_frames_small_truth():


### PR DESCRIPTION
## Summary
- match GNSS prefix when parsing output file names
- use captured GNSS name when building path
- verify overlay PDFs are produced for all frames

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68669e542614832587852fbf73aaabde