### PR TITLE
Update truth overlay handling

### DIFF
--- a/src/plot_overlay.py
+++ b/src/plot_overlay.py
@@ -25,6 +25,7 @@ def plot_overlay(
     vel_fused: np.ndarray,
     acc_fused: np.ndarray,
     out_dir: str,
+    truth: Optional[tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]] = None,
     *,
     t_truth: Optional[np.ndarray] = None,
     pos_truth: Optional[np.ndarray] = None,
@@ -44,6 +45,9 @@ def plot_overlay(
         figure. Defaults to ``"_overlay_truth.pdf"`` if any truth arrays are
         supplied and ``"_overlay.pdf"`` otherwise.
     """
+    if truth is not None:
+        t_truth, pos_truth, vel_truth, acc_truth = truth
+
     if suffix is None:
         suffix = "_overlay_truth.pdf" if t_truth is not None else "_overlay.pdf"
     fig, axes = plt.subplots(4, 1, figsize=(8, 10), sharex=True)

--- a/src/run_all_datasets.py
+++ b/src/run_all_datasets.py
@@ -178,7 +178,7 @@ def main():
             subprocess.run(vcmd, check=True)
             try:
                 est = load_estimate(str(est_mat))
-                frames = assemble_frames(est, ROOT / gnss, truth_path)
+                frames = assemble_frames(est, ROOT / imu, ROOT / gnss, truth_path)
                 for frame_name, data in frames.items():
                     t_i, p_i, v_i, a_i = data["imu"]
                     t_g, p_g, v_g, a_g = data["gnss"]

--- a/src/run_triad_only.py
+++ b/src/run_triad_only.py
@@ -46,8 +46,9 @@ for mat in results.glob("*_TRIAD_kf_output.mat"):
         est = load_estimate(str(mat))
         m2 = re.match(r"(IMU_\w+)_((?:GNSS_)?\w+)_TRIAD_kf_output", mat.stem)
         if m2:
+            imu_file = ROOT / f"{m2.group(1)}.dat"
             gnss_file = ROOT / f"{m2.group(2)}.csv"
-            frames = assemble_frames(est, gnss_file, truth)
+            frames = assemble_frames(est, imu_file, gnss_file, truth)
             for frame_name, data in frames.items():
                 t_i, p_i, v_i, a_i = data["imu"]
                 t_g, p_g, v_g, a_g = data["gnss"]

--- a/tests/test_assemble_frames.py
+++ b/tests/test_assemble_frames.py
@@ -16,7 +16,7 @@ def test_assemble_frames_with_truth():
         "quat": np.tile([1.0, 0.0, 0.0, 0.0], (3, 1)),
     }
 
-    frames = assemble_frames(est, str(gnss_file), str(truth_file))
+    frames = assemble_frames(est, str(gnss_file), str(gnss_file), str(truth_file))
 
     for frame in ["NED", "ECEF", "Body"]:
         assert "truth" in frames[frame], f"Missing truth in {frame} frame"

--- a/tests/test_validate_with_truth.py
+++ b/tests/test_validate_with_truth.py
@@ -168,7 +168,7 @@ def test_assemble_frames_small_truth():
 
     from src.validate_with_truth import assemble_frames
 
-    frames = assemble_frames(est, str(gnss_file), str(truth_file))
+    frames = assemble_frames(est, str(gnss_file), str(gnss_file), str(truth_file))
 
     for frame in ["NED", "ECEF", "Body"]:
         assert "truth" in frames[frame], f"Missing truth in {frame} frame"


### PR DESCRIPTION
## Summary
- simplify `assemble_frames` signature to take IMU and GNSS files
- update overlay plotting to accept truth tuple
- streamline overlay plotting in `validate_with_truth`
- adapt scripts and tests to new call pattern

## Testing
- `pytest tests/test_assemble_frames.py::test_assemble_frames_with_truth -q`
- `pytest tests/test_validate_with_truth.py::test_assemble_frames_small_truth -q`
- `pytest tests/test_validate_with_truth.py::test_overlay_truth_generation -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866bf54a83883259be7aaa20244f4cf