### PR TITLE
Ensure dependencies before triad batch run

### DIFF
--- a/src/run_triad_only.py
+++ b/src/run_triad_only.py
@@ -8,9 +8,13 @@ from pathlib import Path
 import re
 from plot_overlay import plot_overlay
 from validate_with_truth import load_estimate, assemble_frames
+from utils import ensure_dependencies
 
 HERE = Path(__file__).resolve().parent
 ROOT = HERE.parent
+
+# Install any missing dependencies before running the batch command
+ensure_dependencies()
 
 # --- Run the batch processor -------------------------------------------------
 cmd = [


### PR DESCRIPTION
## Summary
- guarantee Python dependencies for `run_triad_only.py`
- install packages by calling `ensure_dependencies()` before running the batch command

## Testing
- `pip install -e .[tests]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866c475a6f88325a63e316018984b48