### PR TITLE
Fix overlay module imports

### DIFF
--- a/src/run_all_datasets.py
+++ b/src/run_all_datasets.py
@@ -19,6 +19,8 @@ import yaml
 from utils import ensure_dependencies
 from tabulate import tabulate
 from tqdm import tqdm
+from validate_with_truth import load_estimate, assemble_frames
+from plot_overlay import plot_overlay
 
 ensure_dependencies()
 


### PR DESCRIPTION
## Summary
- import overlay helpers from `validate_with_truth` and `plot_overlay`
- confirm `run_all_datasets.py` runs overlays without NameError

## Testing
- `python src/run_all_datasets.py --config config_small.yml --datasets X001`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866c72fc2908325b07d69933bb12a40