### PR TITLE
Derive NED origin from truth file

### DIFF
--- a/src/validate_with_truth.py
+++ b/src/validate_with_truth.py
@@ -333,9 +333,11 @@ def main():
             ref_r0 = np.asarray(v).squeeze()
 
     if ref_lat is None or ref_lon is None or ref_r0 is None:
-        ref_lat = np.deg2rad(-32.026554)
-        ref_lon = np.deg2rad(133.455801)
-        ref_r0 = np.array([-3729051, 3935676, -3348394])
+        first_ecef = truth[0, 2:5]
+        lat_deg, lon_deg, _ = ecef_to_geodetic(*first_ecef)
+        ref_lat = np.deg2rad(lat_deg)
+        ref_lon = np.deg2rad(lon_deg)
+        ref_r0 = first_ecef
 
     C = compute_C_ECEF_to_NED(ref_lat, ref_lon)
 

--- a/tests/test_validate_with_truth.py
+++ b/tests/test_validate_with_truth.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 from src.GNSS_IMU_Fusion import main
 from src.validate_with_truth import load_estimate
+from src.utils import ecef_to_geodetic
 
 np = pytest.importorskip("numpy")
 pd = pytest.importorskip("pandas")
@@ -38,13 +39,10 @@ def test_validate_with_truth(monkeypatch):
     from utils import compute_C_ECEF_to_NED
 
     truth = np.loadtxt("STATE_X001.txt")
-    C = compute_C_ECEF_to_NED(np.deg2rad(-32.026554), np.deg2rad(133.455801))
-    truth_pos_ned = np.array(
-        [
-            C @ (p - np.array([-3729051, 3935676, -3348394]))
-            for p in truth[:, 2:5]
-        ]
-    )
+    ref_ecef = truth[0, 2:5]
+    lat_deg, lon_deg, _ = ecef_to_geodetic(*ref_ecef)
+    C = compute_C_ECEF_to_NED(np.deg2rad(lat_deg), np.deg2rad(lon_deg))
+    truth_pos_ned = np.array([C @ (p - ref_ecef) for p in truth[:, 2:5]])
     n = min(len(est["pos"]), truth.shape[0])
     err = est["pos"][:n] - truth_pos_ned[:n]
 


### PR DESCRIPTION
## Summary
- compute reference latitude, longitude, and origin from the first row of the truth file in `validate_with_truth.py`
- update `test_validate_with_truth` to derive the reference origin from the truth dataset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866ca5990b0832588bbe98e6d510008