### PR TITLE
Improve overlay synchronisation

### DIFF
--- a/src/run_all_datasets.py
+++ b/src/run_all_datasets.py
@@ -179,7 +179,9 @@ def main():
             ]
             subprocess.run(vcmd, check=True)
             try:
-                est = load_estimate(str(est_mat))
+                truth_data = np.loadtxt(truth_path)
+                t_truth = truth_data[:, 1]
+                est = load_estimate(str(est_mat), times=t_truth)
                 frames = assemble_frames(est, ROOT / imu, ROOT / gnss, truth_path)
                 for frame_name, data in frames.items():
                     t_i, p_i, v_i, a_i = data["imu"]

--- a/src/run_triad_only.py
+++ b/src/run_triad_only.py
@@ -47,7 +47,9 @@ for mat in results.glob("*_TRIAD_kf_output.mat"):
     ]
     subprocess.run(vcmd, check=True)
     try:
-        est = load_estimate(str(mat))
+        truth_data = np.loadtxt(truth)
+        t_truth = truth_data[:, 1]
+        est = load_estimate(str(mat), times=t_truth)
         m2 = re.match(r"(IMU_\w+)_((?:GNSS_)?\w+)_TRIAD_kf_output", mat.stem)
         if m2:
             imu_file = ROOT / f"{m2.group(1)}.dat"

--- a/src/validate_with_truth.py
+++ b/src/validate_with_truth.py
@@ -13,8 +13,18 @@ import pandas as pd
 import re
 
 
-def load_estimate(path):
-    """Return trajectory, quaternion and covariance from an NPZ or MAT file."""
+def load_estimate(path, times=None):
+    """Return trajectory, quaternion and covariance from an NPZ or MAT file.
+
+    Parameters
+    ----------
+    path : str
+        Path to ``.npz`` or ``.mat`` file containing the filter output.
+    times : array-like, optional
+        When provided, position, velocity and quaternion samples are
+        interpolated to this time vector.  The returned ``"time"`` entry will
+        match ``times``.
+    """
 
     def pick_key(keys, container, n_cols=None, default=None):
         """Return the first matching value or any array with *n_cols* columns."""
@@ -104,6 +114,39 @@ def load_estimate(path):
             ]
         except OSError:
             est["time"] = np.arange(len(est["pos"]))
+
+    if times is not None:
+        times = np.asarray(times).squeeze()
+        t_est = np.asarray(est["time"]).squeeze()
+        if len(t_est) == 0:
+            t_est = np.arange(len(est.get("pos", times)))
+        if est.get("pos") is not None:
+            pos = np.asarray(est["pos"])
+            n = min(len(t_est), len(pos))
+            pos = pos[:n]
+            t_p = t_est[:n]
+            pos_i = np.vstack(
+                [np.interp(times, t_p, pos[:, i]) for i in range(pos.shape[1])]
+            ).T
+            est["pos"] = pos_i
+        if est.get("vel") is not None:
+            vel = np.asarray(est["vel"])
+            n = min(len(t_est), len(vel))
+            vel = vel[:n]
+            t_v = t_est[:n]
+            vel_i = np.vstack(
+                [np.interp(times, t_v, vel[:, i]) for i in range(vel.shape[1])]
+            ).T
+            est["vel"] = vel_i
+        if est.get("quat") is not None:
+            quat = np.asarray(est["quat"])
+            n = min(len(t_est), len(quat))
+            t_q = t_est[:n]
+            r_q = R.from_quat(quat[:n][:, [1, 2, 3, 0]])
+            slerp = Slerp(t_q, r_q)
+            r_i = slerp(np.clip(times, t_q[0], t_q[-1]))
+            est["quat"] = r_i.as_quat()[:, [3, 0, 1, 2]]
+        est["time"] = times
 
     return est
 
@@ -209,9 +252,9 @@ def assemble_frames(est, imu_file, gnss_file, truth_file=None):
             acc_truth_ned = np.array([C @ a for a in acc_truth_ecef])
 
             def interp(arr):
-                return np.vstack([
-                    np.interp(t_est, t_truth, arr[:, i]) for i in range(3)
-                ]).T
+                return np.vstack(
+                    [np.interp(t_est, t_truth, arr[:, i]) for i in range(3)]
+                ).T
 
             pos_truth_ecef_i = interp(pos_truth_ecef)
             vel_truth_ecef_i = interp(vel_truth_ecef)
@@ -281,8 +324,18 @@ def assemble_frames(est, imu_file, gnss_file, truth_file=None):
     }
 
     if truth_file is not None:
-        frames["NED"]["truth"] = (t_est, pos_truth_ned_i, vel_truth_ned_i, acc_truth_ned_i)
-        frames["ECEF"]["truth"] = (t_est, pos_truth_ecef_i, vel_truth_ecef_i, acc_truth_ecef_i)
+        frames["NED"]["truth"] = (
+            t_est,
+            pos_truth_ned_i,
+            vel_truth_ned_i,
+            acc_truth_ned_i,
+        )
+        frames["ECEF"]["truth"] = (
+            t_est,
+            pos_truth_ecef_i,
+            vel_truth_ecef_i,
+            acc_truth_ecef_i,
+        )
         if truth_body is not None:
             frames["Body"]["truth"] = (t_est, *truth_body)
 
@@ -469,7 +522,10 @@ def main():
         gnss_file = dataset_dir / f"{m.group(2)}.csv"
         method = m.group(3)
         try:
-            frames = assemble_frames(est, imu_file, gnss_file, truth_file=args.truth_file)
+            est_overlay = load_estimate(args.est_file, times=t_truth)
+            frames = assemble_frames(
+                est_overlay, imu_file, gnss_file, truth_file=args.truth_file
+            )
             for frame_name, data in frames.items():
                 t_i, p_i, v_i, a_i = data["imu"]
                 t_g, p_g, v_g, a_g = data["gnss"]

--- a/tests/test_validate_with_truth.py
+++ b/tests/test_validate_with_truth.py
@@ -35,13 +35,13 @@ def test_validate_with_truth(monkeypatch):
     assert mat_path.exists(), f"Missing {mat_path}"
 
     est = load_estimate(str(mat_path))
-    from utils import compute_C_ECEF_to_NED
+    from utils import compute_C_ECEF_to_NED, ecef_to_geodetic
 
     truth = np.loadtxt("STATE_X001.txt")
-    C = compute_C_ECEF_to_NED(np.deg2rad(-32.026554), np.deg2rad(133.455801))
-    truth_pos_ned = np.array(
-        [C @ (p - np.array([-3729051, 3935676, -3348394])) for p in truth[:, 2:5]]
-    )
+    ref_ecef = truth[0, 2:5]
+    lat_deg, lon_deg, _ = ecef_to_geodetic(*ref_ecef)
+    C = compute_C_ECEF_to_NED(np.deg2rad(lat_deg), np.deg2rad(lon_deg))
+    truth_pos_ned = np.array([C @ (p - ref_ecef) for p in truth[:, 2:5]])
     n = min(len(est["pos"]), truth.shape[0])
     err = est["pos"][:n] - truth_pos_ned[:n]
 

--- a/tests/test_validate_with_truth.py
+++ b/tests/test_validate_with_truth.py
@@ -40,10 +40,7 @@ def test_validate_with_truth(monkeypatch):
     truth = np.loadtxt("STATE_X001.txt")
     C = compute_C_ECEF_to_NED(np.deg2rad(-32.026554), np.deg2rad(133.455801))
     truth_pos_ned = np.array(
-        [
-            C @ (p - np.array([-3729051, 3935676, -3348394]))
-            for p in truth[:, 2:5]
-        ]
+        [C @ (p - np.array([-3729051, 3935676, -3348394])) for p in truth[:, 2:5]]
     )
     n = min(len(est["pos"]), truth.shape[0])
     err = est["pos"][:n] - truth_pos_ned[:n]
@@ -56,9 +53,7 @@ def test_validate_with_truth(monkeypatch):
     except Exception:
         final_pos = np.linalg.norm(err[-1])
 
-    assert (
-        final_pos < 0.05
-    ), f"final position error {final_pos:.3f} m >= 0.05 m"
+    assert final_pos < 0.05, f"final position error {final_pos:.3f} m >= 0.05 m"
 
     if est["P"] is not None:
         sigma = 3 * np.sqrt(np.diagonal(est["P"], axis1=1, axis2=2)[:, :3])
@@ -68,6 +63,7 @@ def test_validate_with_truth(monkeypatch):
     assert npz_path.exists(), f"Missing {npz_path}"
     npz = np.load(npz_path, allow_pickle=True)
     from scipy.io import loadmat
+
     mat = loadmat(mat_path)
     for key in ["fused_pos", "fused_vel"]:
         assert key in npz, f"{key} missing from npz"
@@ -95,6 +91,35 @@ def test_load_estimate_alt_names(tmp_path, pos_key, vel_key):
     assert np.allclose(est["vel"], data[vel_key])
     assert np.allclose(est["quat"], data["attitude_q"])
     assert np.allclose(est["P"], data["P_hist"])
+
+
+def test_load_estimate_interpolation(tmp_path):
+    np = pytest.importorskip("numpy")
+    scipy = pytest.importorskip("scipy.io")
+
+    data = {
+        "fused_pos": np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]]),
+        "fused_vel": np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 0.0, 0.0]]),
+        "quat_log": np.tile([1.0, 0.0, 0.0, 0.0], (3, 1)),
+        "time": np.array([0.0, 1.0, 2.0]),
+    }
+    f = tmp_path / "est.mat"
+    scipy.savemat(f, data)
+
+    times = np.linspace(0.0, 2.0, 5)
+    est = load_estimate(str(f), times=times)
+
+    expected_pos = np.vstack(
+        [np.interp(times, data["time"], data["fused_pos"][:, i]) for i in range(3)]
+    ).T
+    expected_vel = np.vstack(
+        [np.interp(times, data["time"], data["fused_vel"][:, i]) for i in range(3)]
+    ).T
+
+    assert np.allclose(est["time"], times)
+    assert np.allclose(est["pos"], expected_pos)
+    assert np.allclose(est["vel"], expected_vel)
+    assert np.allclose(est["quat"], np.tile([1.0, 0.0, 0.0, 0.0], (5, 1)))
 
 
 def test_overlay_truth_generation(tmp_path, monkeypatch):
@@ -126,6 +151,7 @@ def test_overlay_truth_generation(tmp_path, monkeypatch):
     assert est_file.exists()
 
     from src.validate_with_truth import main as validate_main
+
     monkeypatch.setattr(
         sys,
         "argv",
@@ -157,12 +183,8 @@ def test_assemble_frames_small_truth():
 
     est = {
         "time": np.array([0.0, 1.0, 2.0]),
-        "pos": np.array(
-            [[0.0, 0.0, 0.0], [0.1, 0.0, 0.0], [0.2, 0.0, 0.0]]
-        ),
-        "vel": np.array(
-            [[0.0, 0.0, 0.0], [0.1, 0.0, 0.0], [0.1, 0.0, 0.0]]
-        ),
+        "pos": np.array([[0.0, 0.0, 0.0], [0.1, 0.0, 0.0], [0.2, 0.0, 0.0]]),
+        "vel": np.array([[0.0, 0.0, 0.0], [0.1, 0.0, 0.0], [0.1, 0.0, 0.0]]),
         "quat": np.tile([1.0, 0.0, 0.0, 0.0], (3, 1)),
     }
 


### PR DESCRIPTION
## Summary
- interpolate estimates to arbitrary timestamps in `load_estimate`
- call `load_estimate` with truth time vector when creating overlays
- test interpolation support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866ca6422008325bc9112373a3d71f2