### PR TITLE
Add tunable noise parameters to fusion prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,10 @@ pipeline but can be handy for quick experiments:
 
 - `fusion_single.py` &ndash; early stand‑alone prototype of the IMU&ndash;GNSS
   fusion routine. It exposes the full bias estimation and Kalman logic in a
-  single file and is useful for debugging or exploring tuning options.
+  single file and is useful for debugging or exploring tuning options. The
+  script now allows custom process and measurement noise values for the Kalman
+  filter via command-line flags (see `--pos_noise`, `--vel_noise`,
+  `--pos_meas_noise` and `--vel_meas_noise`).
 - `validate_filter.py` &ndash; command&ndash;line tool to compare a saved filter
   state history against GNSS measurements and plot the residuals.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@
 - **Kalman filter with GNSS updates** (`kalman.py`, `src/GNSS_IMU_Fusion.py`)
   - Adds a bias-aware Kalman filter for fusing IMU data with GNSS measurements.
   - Provides helper functions to run the filter and to tune process noise.
+- **Tunable noise parameters** (`kalman.py`, `fusion_single.py`)
+  - Position/velocity process and measurement noise can now be set via
+    arguments for easier experimentation.
 
 - **Plotting helpers** (`auto_plots.py`, `summarise_runs.py`, `generate_summary.py`)
   - Automates generation of standard figures and summary tables.

--- a/src/fusion_single.py
+++ b/src/fusion_single.py
@@ -55,6 +55,14 @@ def main():
     parser.add_argument('--accel_bias_noise', type=float, default=1e-5)
     parser.add_argument('--gyro_bias_noise', type=float, default=1e-5)
     parser.add_argument('--accel_noise', type=float, default=0.1)
+    parser.add_argument('--pos_noise', type=float, default=0.0,
+                        help='Process noise for position states')
+    parser.add_argument('--vel_noise', type=float, default=0.0,
+                        help='Additional process noise for velocity states')
+    parser.add_argument('--pos_meas_noise', type=float, default=1.0,
+                        help='Measurement noise for GNSS position')
+    parser.add_argument('--vel_meas_noise', type=float, default=1.0,
+                        help='Measurement noise for GNSS velocity')
     parser.add_argument('--static_window', type=int, default=400)
     parser.add_argument('--smoother', action='store_true')
     args = parser.parse_args()
@@ -131,6 +139,10 @@ def main():
         accel_noise=args.accel_noise,
         accel_bias_noise=args.accel_bias_noise,
         gyro_bias_noise=args.gyro_bias_noise,
+        pos_proc_noise=args.pos_noise,
+        vel_proc_noise=args.vel_noise,
+        pos_meas_noise=args.pos_meas_noise,
+        vel_meas_noise=args.vel_meas_noise,
     )
     kf.init_state(pos_ned[0], vel_ned[0], acc_bias, gyro_bias)
 

--- a/src/kalman.py
+++ b/src/kalman.py
@@ -14,6 +14,14 @@ class GNSSIMUKalman:
         Random-walk noise for accelerometer bias states.
     gyro_bias_noise : float
         Random-walk noise for gyroscope bias states.
+    pos_proc_noise : float
+        Process noise standard deviation applied to the position states.
+    vel_proc_noise : float
+        Additional process noise for the velocity states.
+    pos_meas_noise : float
+        Measurement noise standard deviation for position updates.
+    vel_meas_noise : float
+        Measurement noise standard deviation for velocity updates.
     """
 
     def __init__(
@@ -22,11 +30,19 @@ class GNSSIMUKalman:
         accel_noise: float = 0.1,
         accel_bias_noise: float = 1e-5,
         gyro_bias_noise: float = 1e-5,
+        pos_proc_noise: float = 0.0,
+        vel_proc_noise: float = 0.0,
+        pos_meas_noise: float = 1.0,
+        vel_meas_noise: float = 1.0,
     ) -> None:
         self.gnss_weight = gnss_weight
         self.accel_noise = accel_noise
         self.accel_bias_noise = accel_bias_noise
         self.gyro_bias_noise = gyro_bias_noise
+        self.pos_proc_noise = pos_proc_noise
+        self.vel_proc_noise = vel_proc_noise
+        self.pos_meas_noise = pos_meas_noise
+        self.vel_meas_noise = vel_meas_noise
         self.kf = KalmanFilter(dim_x=12, dim_z=6)
 
     def init_state(self, position, velocity, acc_bias, gyro_bias):
@@ -35,15 +51,24 @@ class GNSSIMUKalman:
         self.kf.H = np.zeros((6, 12))
         self.kf.H[0:3, 0:3] = np.eye(3)
         self.kf.H[3:6, 3:6] = np.eye(3)
-        self.kf.R = np.eye(6) * 1.0 / self.gnss_weight
+        R = np.zeros((6, 6))
+        R[0:3, 0:3] = np.eye(3) * (self.pos_meas_noise ** 2) / self.gnss_weight
+        R[3:6, 3:6] = np.eye(3) * (self.vel_meas_noise ** 2) / self.gnss_weight
+        self.kf.R = R
 
     def predict(self, dt, R_bn, acc_meas):
         F = np.eye(12)
         F[0:3, 3:6] = np.eye(3) * dt
         F[3:6, 6:9] = -R_bn * dt
         Q = np.zeros((12, 12))
+        q_pos = (self.pos_proc_noise ** 2) * dt
+        if q_pos:
+            Q[0:3, 0:3] = np.eye(3) * q_pos
         q_acc = (self.accel_noise ** 2) * dt
         Q[3:6, 3:6] = np.eye(3) * q_acc
+        q_vel = (self.vel_proc_noise ** 2) * dt
+        if q_vel:
+            Q[3:6, 3:6] += np.eye(3) * q_vel
         q_abias = (self.accel_bias_noise ** 2) * dt
         q_gbias = (self.gyro_bias_noise ** 2) * dt
         Q[6:9, 6:9] = np.eye(3) * q_abias
@@ -60,6 +85,10 @@ class GNSSIMUKalman:
     def update_gnss(self, pos_meas, vel_meas):
         """Update state with GNSS measurement and return residual."""
         z = np.hstack([pos_meas, vel_meas])
+        R = np.zeros((6, 6))
+        R[0:3, 0:3] = np.eye(3) * (self.pos_meas_noise ** 2) / self.gnss_weight
+        R[3:6, 3:6] = np.eye(3) * (self.vel_meas_noise ** 2) / self.gnss_weight
+        self.kf.R = R
         pred = self.kf.H @ self.kf.x
         residual = z - pred
         S = self.kf.H @ self.kf.P @ self.kf.H.T + self.kf.R

--- a/tests/test_validate_with_truth.py
+++ b/tests/test_validate_with_truth.py
@@ -99,7 +99,6 @@ def test_load_estimate_alt_names(tmp_path, pos_key, vel_key):
 
 def test_overlay_truth_generation(tmp_path, monkeypatch):
     pd = pytest.importorskip("pandas")
-    np = pytest.importorskip("numpy")
     monkeypatch.chdir(tmp_path)
 
     orig_read_csv = pd.read_csv


### PR DESCRIPTION
## Summary
- expose position/velocity process noise and measurement noise in `GNSSIMUKalman`
- allow setting these via command line in `fusion_single.py`
- document new flags and update changelog
- fix unused import in overlay truth test

## Testing
- `ruff check src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866ca6216388325ab5c7ae2f2a71f7a