### PR TITLE
Improve attitude initialization

### DIFF
--- a/src/gnss_imu_fusion/__init__.py
+++ b/src/gnss_imu_fusion/__init__.py
@@ -3,6 +3,7 @@
 from .init_vectors import (
     average_rotation_matrices,
     svd_alignment,
+    triad_svd,
     butter_lowpass_filter,
     angle_between,
     compute_wahba_errors,
@@ -17,6 +18,7 @@ from .plots import (
 __all__ = [
     "average_rotation_matrices",
     "svd_alignment",
+    "triad_svd",
     "butter_lowpass_filter",
     "angle_between",
     "compute_wahba_errors",

--- a/src/gnss_imu_fusion/init_vectors.py
+++ b/src/gnss_imu_fusion/init_vectors.py
@@ -30,6 +30,22 @@ def svd_alignment(
     return U @ M @ Vt
 
 
+def triad_svd(
+    body_vec1: np.ndarray,
+    body_vec2: np.ndarray,
+    ref_vec1: np.ndarray,
+    ref_vec2: np.ndarray,
+    w1: float = 0.9999,
+    w2: float = 0.0001,
+) -> np.ndarray:
+    """Return body->NED rotation from two vector pairs using SVD."""
+    return svd_alignment(
+        [body_vec1, body_vec2],
+        [ref_vec1, ref_vec2],
+        [w1, w2],
+    )
+
+
 def butter_lowpass_filter(data: np.ndarray, cutoff: float = 5.0, fs: float = 400.0, order: int = 4) -> np.ndarray:
     """Apply a zero-phase Butterworth low-pass filter to the data."""
     nyq = 0.5 * fs


### PR DESCRIPTION
## Summary
- implement `triad_svd` for SVD-based Wahba solution
- export new helper from package
- use `triad_svd` for TRIAD attitude initialization
- extend Kalman filter with quaternion state and propagate it

## Testing
- `pytest tests/test_average_rotation.py tests/test_python_accuracy.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866ca602a78832597315f60fe995ceb