### PR TITLE
Fix typing for plot_overlay

### DIFF
--- a/src/plot_overlay.py
+++ b/src/plot_overlay.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -25,7 +25,7 @@ def plot_overlay(
     vel_fused: np.ndarray,
     acc_fused: np.ndarray,
     out_dir: str,
-    truth: Optional[tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]] = None,
+    truth: Optional[Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]] = None,
     *,
     t_truth: Optional[np.ndarray] = None,
     pos_truth: Optional[np.ndarray] = None,


### PR DESCRIPTION
## Summary
- use `Tuple` for truth typing in `plot_overlay`

## Testing
- `ruff check src tests` *(fails: F401, F811 in tests/test_validate_with_truth.py)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866dc8d7b888325bc40e8b452b43279