### PR TITLE
Ensure ground truth reference is passed to validation

### DIFF
--- a/MATLAB/README_pipeline.md
+++ b/MATLAB/README_pipeline.md
@@ -92,9 +92,18 @@ GNSS_IMU_Fusion_single('IMU_X001.dat','GNSS_X001.csv')
 
 Run `python src/validate_with_truth.py` or call the MATLAB helper
 `overlay_truth_task4` to overlay the fused trajectory with a
-`STATE_*.txt` reference.  The comparison figures
-`<method>_<frame>_overlay_truth.pdf` are stored in the `results/` directory
-next to the Kalman filter output.
+`STATE_*.txt` reference. Before launching the script read the first row of
+the state file to determine the reference ECEF coordinate and convert it to
+latitude and longitude. Pass these values via `--ref-lat`, `--ref-lon` and
+`--ref-r0` so that all transformations use the same origin:
+
+```bash
+python src/validate_with_truth.py --est-file <kf.mat> --truth-file STATE_X001.txt \
+    --output results --ref-lat <lat> --ref-lon <lon> --ref-r0 <x> <y> <z>
+```
+
+The comparison figures `<method>_<frame>_overlay_truth.pdf` are stored in the
+`results/` directory next to the Kalman filter output.
 
 ### Compatibility notes
 

--- a/MATLAB/run_triad_only.m
+++ b/MATLAB/run_triad_only.m
@@ -56,8 +56,13 @@ for k = 1:numel(mat_files)
         continue
     end
     validate_py = fullfile(root, 'src', 'validate_with_truth.py');
-    vcmd = sprintf('"%s" "%s" --est-file "%s" --truth-file "%s" --output "%s"', ...
-        py.Executable, validate_py, fullfile(results_dir, name), truth_file, results_dir);
+    first = readmatrix(truth_file, 'CommentStyle', '#');
+    r0 = first(1,3:5);
+    [lat_deg, lon_deg, ~] = ecef_to_geodetic(r0(1), r0(2), r0(3));
+    vcmd = sprintf(['"%s" "%s" --est-file "%s" --truth-file "%s" --output "%s" ' ...
+        '--ref-lat %.8f --ref-lon %.8f --ref-r0 %.3f %.3f %.3f'], ...
+        py.Executable, validate_py, fullfile(results_dir, name), truth_file, results_dir, ...
+        lat_deg, lon_deg, r0(1), r0(2), r0(3));
     vstatus = system(vcmd);
     if vstatus ~= 0
         warning('Validation failed for %s', name);

--- a/docs/MATLAB/Task4_MATLAB.md
+++ b/docs/MATLAB/Task4_MATLAB.md
@@ -36,7 +36,13 @@ GNSS ECEF → NED → comparison plots
 ### 4.13 Validate and Plot
 - Plot GNSS, raw IMU and integrated IMU data in NED, body and ECEF frames.
 - Save the PDFs as `results/<tag>_task4_*.pdf` and list them in `plot_summary.md`.
-- When a `STATE_*.txt` reference trajectory is available you can run the Python script `src/validate_with_truth.py` or call the MATLAB helper `overlay_truth_task4` to overlay the fused output with the ground truth.  The resulting PDF files `<method>_<frame>_overlay_truth.pdf` are written to the `results/` directory alongside the Kalman filter results.
+- When a `STATE_*.txt` reference trajectory is available you can run the Python
+  script `src/validate_with_truth.py` or call the MATLAB helper
+  `overlay_truth_task4` to overlay the fused output with the ground truth. Before
+  running the Python script read the first ECEF row of the state file and supply
+  the latitude, longitude and reference point via `--ref-lat`, `--ref-lon` and
+  `--ref-r0`. The resulting PDF files `<method>_<frame>_overlay_truth.pdf` are
+  written to the `results/` directory alongside the Kalman filter results.
 
 ## Result
 

--- a/tests/test_validate_with_truth.py
+++ b/tests/test_validate_with_truth.py
@@ -152,6 +152,10 @@ def test_overlay_truth_generation(tmp_path, monkeypatch):
 
     from src.validate_with_truth import main as validate_main
 
+    first = np.loadtxt(repo / "STATE_X001_small.txt", comments="#", max_rows=1)
+    r0 = first[2:5]
+    lat_deg, lon_deg, _ = ecef_to_geodetic(*r0)
+
     monkeypatch.setattr(
         sys,
         "argv",
@@ -163,6 +167,14 @@ def test_overlay_truth_generation(tmp_path, monkeypatch):
             str(repo / "STATE_X001_small.txt"),
             "--output",
             str(Path("results")),
+            "--ref-lat",
+            str(lat_deg),
+            "--ref-lon",
+            str(lon_deg),
+            "--ref-r0",
+            str(r0[0]),
+            str(r0[1]),
+            str(r0[2]),
         ],
     )
     validate_main()


### PR DESCRIPTION
## Summary
- pass reference coordinates to `validate_with_truth.py` in tests
- make `run_triad_only.m` supply reference latitude, longitude and ECEF origin
- document the recommended command-line options for validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866dcc933648325b48d242b4191d7a2