### PR TITLE
Fix GNSS_IMU_Fusion standalone execution

### DIFF
--- a/src/GNSS_IMU_Fusion.py
+++ b/src/GNSS_IMU_Fusion.py
@@ -4,6 +4,12 @@ import sys
 import os
 from pathlib import Path
 
+if __package__ is None:
+    # When executed directly, ensure the project root (the parent of this file)
+    # is on ``sys.path``.  This allows importing the ``src`` package just like
+    # the test suite does.
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    __package__ = "src"
 
 import matplotlib.pyplot as plt
 import numpy as np


### PR DESCRIPTION
## Summary
- allow running `GNSS_IMU_Fusion.py` directly
- ensure the project root is added to `sys.path` when executed as a script

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6867877859488325be36aa11229de6ab