### PR TITLE
Add regularization to Kalman update

### DIFF
--- a/MATLAB/GNSS_IMU_Fusion_Single_script.m
+++ b/MATLAB/GNSS_IMU_Fusion_Single_script.m
@@ -443,5 +443,11 @@ function S = skew(w)
 end
 
 function [x,P] = kalman_update(x,P,y,H,R)
-    S = H*P*H' + R; K = P*H'/S; x = x + K*y; P = (eye(size(P))-K*H)*P;
+    S = H*P*H' + R;
+    if isnan(rcond(S)) || rcond(S) < 1e-12
+        S = S + 1e-6 * eye(size(S));
+    end
+    K = P*H'/S;
+    x = x + K*y;
+    P = (eye(size(P))-K*H)*P;
 end


### PR DESCRIPTION
## Summary
- make Kalman filter update more robust by checking `rcond`
- add small regularisation to avoid singular matrices

## Testing
- `pytest -q`
- `python GNSS_IMU_Fusion_Single_script.py > /tmp/script.log`

------
https://chatgpt.com/codex/tasks/task_e_6867ddff59148325885b7173f3075d3d