### PR TITLE
Fix run_all_methods dataset lookup

### DIFF
--- a/src/run_all_methods.py
+++ b/src/run_all_methods.py
@@ -26,6 +26,9 @@ import subprocess
 import sys
 from typing import Iterable, Tuple
 
+HERE = pathlib.Path(__file__).resolve().parent
+ROOT = HERE.parent
+
 try:
     import yaml
 except ModuleNotFoundError:  # allow running without PyYAML installed
@@ -96,11 +99,11 @@ def main(argv=None):
         print(f"\u25B6 {tag}")
         cmd = [
             sys.executable,
-            str(pathlib.Path(__file__).resolve().parent / "GNSS_IMU_Fusion.py"),
+            str(HERE / "GNSS_IMU_Fusion.py"),
             "--imu-file",
-            imu,
+            str(ROOT / imu),
             "--gnss-file",
-            gnss,
+            str(ROOT / gnss),
             "--method",
             m,
         ]


### PR DESCRIPTION
## Summary
- resolve dataset paths relative to repo root

## Testing
- `ruff check src/run_all_methods.py`
- `make test` *(fails: KeyboardInterrupt after tests complete)*

------
https://chatgpt.com/codex/tasks/task_e_6867f658d7c083259499f99afe8938ab