### PR TITLE
Fix requirements for numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.26.0
+numpy>=1.24.0,<1.26
 scipy
 pandas
 matplotlib


### PR DESCRIPTION
## Summary
- restrict `numpy` to < 1.26 to match the project instructions

## Testing
- `pip install -r requirements.txt`
- `python GNSS_IMU_Fusion.py --imu-file ../IMU_X001_small.dat --gnss-file ../GNSS_X001_small.csv --method TRIAD`

------
https://chatgpt.com/codex/tasks/task_e_6868085c23c48325b944685be9fc19b6