### PR TITLE
Fix run_all_datasets failure

### DIFF
--- a/src/GNSS_IMU_Fusion.py
+++ b/src/GNSS_IMU_Fusion.py
@@ -87,7 +87,7 @@ def main():
     parser.add_argument(
         "--method",
         default="TRIAD",
-        choices=["TRIAD"],
+        choices=["TRIAD", "Davenport", "SVD"],
     )
     parser.add_argument("--mag-file", help="CSV file with magnetometer data")
     parser.add_argument(


### PR DESCRIPTION
## Summary
- allow `GNSS_IMU_Fusion.py` to accept `Davenport` and `SVD`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68680e2b3a088325a8dccdebbc87b8d0