### PR TITLE
Generate run summaries and method comparison

### DIFF
--- a/config_small_all.yml
+++ b/config_small_all.yml
@@ -1,0 +1,8 @@
+datasets:
+  - imu: IMU_X001_small.dat
+    gnss: GNSS_X001_small.csv
+  - imu: IMU_X002_small.dat
+    gnss: GNSS_X002_small.csv
+  - imu: IMU_X003_small.dat
+    gnss: GNSS_X002_small.csv
+methods: [TRIAD, Davenport, SVD]

--- a/docs/method_comparison.md
+++ b/docs/method_comparison.md
@@ -1,0 +1,17 @@
+# Method Comparison
+
+The table below summarises the fusion results produced by `run_all_datasets.py`.
+Values are extracted from `results/summary.csv` via `summarise_runs.py`.
+The best method per dataset is marked with a check mark.
+
+| Dataset | Method | RMSE Position [m] | Final Error [m] | Best |
+|---------|--------|------------------|-----------------|------|
+| IMU_X001_small | Davenport | 0.00 | 0.00 | ✓ |
+| IMU_X001_small | SVD | 0.00 | 0.00 |  |
+| IMU_X001_small | TRIAD | 0.00 | 0.00 |  |
+| IMU_X002_small | Davenport | 0.04 | 0.05 |  |
+| IMU_X002_small | SVD | 0.04 | 0.05 |  |
+| IMU_X002_small | TRIAD | 0.04 | 0.05 | ✓ |
+| IMU_X003_small | Davenport | 0.04 | 0.05 |  |
+| IMU_X003_small | SVD | 0.04 | 0.05 | ✓ |
+| IMU_X003_small | TRIAD | 0.04 | 0.05 |  |

--- a/results/summary.csv
+++ b/results/summary.csv
@@ -1,0 +1,10 @@
+dataset,method,imu,gnss,rmse_pos,final_pos,best
+IMU_X003_small,SVD,IMU_X003_small.dat,GNSS_X002_small.csv,0.04,0.05,✓
+IMU_X003_small,Davenport,IMU_X003_small.dat,GNSS_X002_small.csv,0.04,0.05,
+IMU_X001_small,Davenport,IMU_X001_small.dat,GNSS_X001_small.csv,0.0,0.0,✓
+IMU_X002_small,TRIAD,IMU_X002_small.dat,GNSS_X002_small.csv,0.04,0.05,✓
+IMU_X003_small,TRIAD,IMU_X003_small.dat,GNSS_X002_small.csv,0.04,0.05,
+IMU_X002_small,SVD,IMU_X002_small.dat,GNSS_X002_small.csv,0.04,0.05,
+IMU_X001_small,SVD,IMU_X001_small.dat,GNSS_X001_small.csv,0.0,0.0,
+IMU_X001_small,TRIAD,IMU_X001_small.dat,GNSS_X001_small.csv,0.0,0.0,
+IMU_X002_small,Davenport,IMU_X002_small.dat,GNSS_X002_small.csv,0.04,0.05,

--- a/results/summary.md
+++ b/results/summary.md
@@ -1,0 +1,11 @@
+dataset | method | imu | gnss | rmse_pos | final_pos | best
+--- | --- | --- | --- | --- | --- | ---
+IMU_X003_small | SVD | IMU_X003_small.dat | GNSS_X002_small.csv | 0.04 | 0.05 | ✓
+IMU_X003_small | Davenport | IMU_X003_small.dat | GNSS_X002_small.csv | 0.04 | 0.05 | 
+IMU_X001_small | Davenport | IMU_X001_small.dat | GNSS_X001_small.csv | 0.00 | 0.00 | ✓
+IMU_X002_small | TRIAD | IMU_X002_small.dat | GNSS_X002_small.csv | 0.04 | 0.05 | ✓
+IMU_X003_small | TRIAD | IMU_X003_small.dat | GNSS_X002_small.csv | 0.04 | 0.05 | 
+IMU_X002_small | SVD | IMU_X002_small.dat | GNSS_X002_small.csv | 0.04 | 0.05 | 
+IMU_X001_small | SVD | IMU_X001_small.dat | GNSS_X001_small.csv | 0.00 | 0.00 | 
+IMU_X001_small | TRIAD | IMU_X001_small.dat | GNSS_X001_small.csv | 0.00 | 0.00 | 
+IMU_X002_small | Davenport | IMU_X002_small.dat | GNSS_X002_small.csv | 0.04 | 0.05 | 

--- a/src/summarise_runs.py
+++ b/src/summarise_runs.py
@@ -15,28 +15,59 @@ RESULTS_DIR.mkdir(exist_ok=True)
 LOG_DIR = pathlib.Path("logs")
 SUMMARY = re.compile(r"\[SUMMARY\]\s+(.*)")
 
-rows = []
+rows = {}
 for log in LOG_DIR.glob("*.log"):
     for line in log.read_text().splitlines():
         m = SUMMARY.search(line)
         if m:
-            kv = dict(pair.split("=", 1) for pair in m.group(1).split())
-            rows.append(kv)
+            pairs = re.findall(r"(\w+)=\s*([^\s]+)", m.group(1))
+            kv = {k: v for k, v in pairs}
+            key = (kv.get("imu"), kv.get("method"))
+            rows[key] = kv
+
+rows = list(rows.values())
+
+# normalise values and compute dataset name
+for r in rows:
+    r["dataset"] = pathlib.Path(r["imu"]).stem
+    r["rmse_pos"] = float(r["rmse_pos"].replace("m", ""))
+    r["final_pos"] = float(r["final_pos"].replace("m", ""))
+
+# determine best method per dataset based on final_pos
+best_map = {}
+for r in rows:
+    ds = r["dataset"]
+    best = best_map.get(ds)
+    if best is None or r["final_pos"] < best["final_pos"]:
+        best_map[ds] = r
+for r in rows:
+    r["best"] = "\u2713" if best_map[r["dataset"]] is r else ""
 
 # CSV -------------------------------------------------------------------------
 with open(RESULTS_DIR / "summary.csv", "w", newline="") as fh:
-    writer = csv.DictWriter(
-        fh, fieldnames=["method", "imu", "gnss", "rmse_pos", "final_pos"]
-    )
+    fieldnames = [
+        "dataset",
+        "method",
+        "imu",
+        "gnss",
+        "rmse_pos",
+        "final_pos",
+        "best",
+    ]
+    writer = csv.DictWriter(fh, fieldnames=fieldnames)
     writer.writeheader()
-    writer.writerows(rows)
+    for r in rows:
+        writer.writerow({k: r.get(k, "") for k in fieldnames})
 
 # Markdown table --------------------------------------------------------------
 with open(RESULTS_DIR / "summary.md", "w") as fh:
-    hdr = " | ".join(["method", "imu", "gnss", "rmse_pos", "final_pos"])
-    sep = " | ".join("---" for _ in range(5))
+    hdr_cols = ["dataset", "method", "imu", "gnss", "rmse_pos", "final_pos", "best"]
+    hdr = " | ".join(hdr_cols)
+    sep = " | ".join("---" for _ in hdr_cols)
     fh.write(hdr + "\n" + sep + "\n")
     for r in rows:
-        fh.write(" | ".join(r.values()) + "\n")
+        fh.write(
+            f"{r['dataset']} | {r['method']} | {r['imu']} | {r['gnss']} | {r['rmse_pos']:.2f} | {r['final_pos']:.2f} | {r['best']}\n"
+        )
 
 print("Created results/summary.csv and results/summary.md")

--- a/src/validate_filter.py
+++ b/src/validate_filter.py
@@ -102,7 +102,6 @@ def plot_residuals(res_df: pd.DataFrame, out_dir: str) -> None:
 
     t = res_df.index.to_numpy()
     vel = res_df['vel'][['X', 'Y', 'Z']].to_numpy()
-    dt = np.gradient(t)
     acc = np.gradient(vel, t, axis=0)
 
     fig, axes = plt.subplots(3, 3, figsize=(12, 9), sharex=True)


### PR DESCRIPTION
## Summary
- add config for small datasets with all methods
- summarize logs into `results/summary.csv`
- mark best method per dataset in the summary files
- document comparison results in `docs/method_comparison.md`
- fix unused variable reported by ruff

## Testing
- `ruff check src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868430e35888325bb4ab8b0b74ab2d8