### PR TITLE
Ensure results directory across scripts

### DIFF
--- a/src/FINAL.py
+++ b/src/FINAL.py
@@ -17,10 +17,14 @@ import time
 import pandas as pd
 import numpy as np
 import yaml
+import os
 
 from utils import ensure_dependencies
 from tabulate import tabulate
 from tqdm import tqdm
+
+os.makedirs('results', exist_ok=True)
+print("Ensured 'results/' directory exists.")
 
 HERE = pathlib.Path(__file__).resolve().parent
 ROOT = HERE.parent

--- a/src/GNSS_IMU_Fusion.py
+++ b/src/GNSS_IMU_Fusion.py
@@ -24,6 +24,9 @@ from utils import (
 from constants import GRAVITY, EARTH_RATE
 from scripts.validate_filter import compute_residuals, plot_residuals
 from scipy.spatial.transform import Rotation as R
+
+os.makedirs('results', exist_ok=True)
+print("Ensured 'results/' directory exists.")
 from .gnss_imu_fusion.init_vectors import (
     average_rotation_matrices,
     svd_alignment,

--- a/src/compare_python_matlab.py
+++ b/src/compare_python_matlab.py
@@ -6,6 +6,10 @@ from typing import Tuple
 import numpy as np
 import pandas as pd
 import scipy.io
+import os
+
+os.makedirs('results', exist_ok=True)
+print("Ensured 'results/' directory exists.")
 
 
 def run_python_pipeline(imu_file: str, gnss_file: str, method: str) -> Path:

--- a/src/fusion_single.py
+++ b/src/fusion_single.py
@@ -9,6 +9,9 @@ from kalman import GNSSIMUKalman, rts_smoother
 from utils import compute_C_ECEF_to_NED
 from constants import GRAVITY, EARTH_RATE
 
+os.makedirs('results', exist_ok=True)
+print("Ensured 'results/' directory exists.")
+
 
 def butter_lowpass_filter(data, cutoff=5.0, fs=400.0, order=4):
     nyq = 0.5 * fs
@@ -66,8 +69,6 @@ def main():
     parser.add_argument('--static_window', type=int, default=400)
     parser.add_argument('--smoother', action='store_true')
     args = parser.parse_args()
-
-    os.makedirs('results', exist_ok=True)
 
     gnss = pd.read_csv(args.gnss_file)
     imu = np.loadtxt(args.imu_file)

--- a/src/generate_summary.py
+++ b/src/generate_summary.py
@@ -2,6 +2,9 @@ import os
 import pandas as pd
 from fpdf import FPDF
 
+os.makedirs('results', exist_ok=True)
+print("Ensured 'results/' directory exists.")
+
 # Load run results produced by ``summarise_runs.py``
 DF_PATH = "results/summary.csv"
 

--- a/src/plot_compare_all.py
+++ b/src/plot_compare_all.py
@@ -9,7 +9,10 @@ import gzip
 import pickle
 import matplotlib.pyplot as plt
 import numpy as np
+import os
 
+os.makedirs('results', exist_ok=True)
+print("Ensured 'results/' directory exists.")
 RESULTS_DIR = pathlib.Path("results")
 COLOURS     = {"X001": "tab:blue", "X002": "tab:orange", "X003": "tab:green"}
 LABEL_MAP   = {"N": "North", "E": "East", "D": "Down"}

--- a/src/run_all_datasets.py
+++ b/src/run_all_datasets.py
@@ -15,6 +15,7 @@ import time
 import pandas as pd
 import numpy as np
 import yaml
+import os
 
 from utils import ensure_dependencies, ecef_to_geodetic
 from tabulate import tabulate
@@ -22,6 +23,9 @@ from tqdm import tqdm
 # Overlay helper functions
 from validate_with_truth import load_estimate, assemble_frames
 from plot_overlay import plot_overlay
+
+os.makedirs('results', exist_ok=True)
+print("Ensured 'results/' directory exists.")
 
 ensure_dependencies()
 
@@ -117,7 +121,6 @@ def main():
     fusion_results = []
 
     results_dir = pathlib.Path.cwd() / "results"
-    results_dir.mkdir(exist_ok=True)
 
     for imu, gnss, method in tqdm(cases, desc="All cases"):
         if args.verbose:

--- a/src/run_all_methods.py
+++ b/src/run_all_methods.py
@@ -26,6 +26,9 @@ import subprocess
 import sys
 from typing import Iterable, Tuple
 
+os.makedirs('results', exist_ok=True)
+print("Ensured 'results/' directory exists.")
+
 HERE = pathlib.Path(__file__).resolve().parent
 ROOT = HERE.parent
 
@@ -89,8 +92,6 @@ def main(argv=None):
         cases, methods = load_config(args.config)
     else:
         cases, methods = list(DEFAULT_DATASETS), list(DEFAULT_METHODS)
-
-    os.makedirs("results", exist_ok=True)
 
     for (imu, gnss), m in itertools.product(cases, methods):
         tag = f"{pathlib.Path(imu).stem}_{pathlib.Path(gnss).stem}_{m}"

--- a/src/run_triad_only.py
+++ b/src/run_triad_only.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 import re
 import logging
+import os
 
 import numpy as np
 import pandas as pd
@@ -16,6 +17,9 @@ from plot_overlay import plot_overlay
 from validate_with_truth import load_estimate, assemble_frames
 from utils import ensure_dependencies
 from pyproj import Transformer
+
+os.makedirs('results', exist_ok=True)
+print("Ensured 'results/' directory exists.")
 
 HERE = Path(__file__).resolve().parent
 ROOT = HERE.parent

--- a/src/summarise_runs.py
+++ b/src/summarise_runs.py
@@ -8,9 +8,11 @@ Parse logs/* for lines that start with [SUMMARY] and emit:
 import csv
 import pathlib
 import re
+import os
 
+os.makedirs('results', exist_ok=True)
+print("Ensured 'results/' directory exists.")
 RESULTS_DIR = pathlib.Path("results")
-RESULTS_DIR.mkdir(exist_ok=True)
 
 LOG_DIR = pathlib.Path("logs")
 SUMMARY = re.compile(r"\[SUMMARY\]\s+(.*)")

--- a/src/validate_3sigma.py
+++ b/src/validate_3sigma.py
@@ -12,11 +12,15 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+import os
 
 import numpy as np
 from scipy.io import loadmat
 from scipy.spatial.transform import Rotation as R, Slerp
 import matplotlib.pyplot as plt
+
+os.makedirs('results', exist_ok=True)
+print("Ensured 'results/' directory exists.")
 
 
 def pick(container, names):

--- a/src/validate_filter.py
+++ b/src/validate_filter.py
@@ -18,6 +18,9 @@ import pandas as pd
 from matplotlib import pyplot as plt
 from scipy.spatial.transform import Rotation as R
 
+os.makedirs('results', exist_ok=True)
+print("Ensured 'results/' directory exists.")
+
 
 def _find_cols(df: pd.DataFrame, options: Sequence[Sequence[str]]) -> Sequence[str]:
     """Return the first column set that is fully present in *df*."""

--- a/src/validate_with_truth.py
+++ b/src/validate_with_truth.py
@@ -12,6 +12,9 @@ from plot_overlay import plot_overlay
 import pandas as pd
 import re
 
+os.makedirs('results', exist_ok=True)
+print("Ensured 'results/' directory exists.")
+
 __all__ = ["load_estimate", "assemble_frames", "validate_with_truth"]
 
 


### PR DESCRIPTION
## Summary
- create `results/` upfront in all result-writing scripts
- remove duplicate directory creation inside functions

## Testing
- `pip install -e .[tests]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686882e682d88325b5883070baeda852