### PR TITLE
Improve validation scripts and docs

### DIFF
--- a/MATLAB/README_pipeline.md
+++ b/MATLAB/README_pipeline.md
@@ -107,8 +107,8 @@ GNSS_IMU_Fusion_single('IMU_X001.dat','GNSS_X001.csv')
 ### Overlay comparison with ground truth
 
 Run `python src/validate_with_truth.py` or call the MATLAB helper
-`overlay_truth_task4` to overlay the fused trajectory with a
-`STATE_*.txt` reference. Before launching the script read the first row of
+`overlay_truth_task4` to overlay the fused trajectory with the
+`STATE_X001.txt` reference. Before launching the script read the first row of
 the state file to determine the reference ECEF coordinate and convert it to
 latitude and longitude. Pass these values via `--ref-lat`, `--ref-lon` and
 `--ref-r0` so that all transformations use the same origin:

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ python src/validate_all_outputs.py
 ```
 
 The validator searches the `results/` folder for saved outputs, compares them
-to any matching `STATE_*.txt` ground truth and writes overlay figures and a CSV
+to the common `STATE_X001.txt` ground truth and writes overlay figures and a CSV
 summary alongside the logs. All figures and summaries are therefore found in
 `results/`.
 ### Sample Processing Report
@@ -175,8 +175,7 @@ Typical result PDFs:
 - `task5_all_body.pdf` – Kalman filter results in body frame
 - `<method>_residuals.pdf` – position and velocity residuals
 - `<method>_attitude_angles.pdf` – attitude angles over time
-- `<method>_<frame>_overlay_truth.pdf` – fused output vs reference when a matching
-  `STATE_<id>.txt` file is found (e.g. `SVD_ecef_overlay_truth.pdf`)
+- `<method>_<frame>_overlay_truth.pdf` – fused output vs reference using `STATE_X001.txt` (e.g. `SVD_ecef_overlay_truth.pdf`)
 
 ### Notes
 
@@ -248,8 +247,8 @@ python src/run_triad_only.py
 run_triad_only
 ```
 This is equivalent to running `python src/run_all_datasets.py --method TRIAD`.
-The script also validates the fused trajectory against available
-`STATE_*.txt` files and writes an extended summary to
+The script also validates the fused trajectory against the common
+`STATE_X001.txt` file and writes an extended summary to
 `results/summary_truth.csv`.
 
 

--- a/docs/MATLAB/Task4_MATLAB.md
+++ b/docs/MATLAB/Task4_MATLAB.md
@@ -37,7 +37,7 @@ GNSS ECEF → NED → comparison plots
 - Plot GNSS, raw IMU and integrated IMU data in NED, body and ECEF frames.
 - Save the PDFs as `results/<tag>_task4_*.pdf` and list them in `plot_summary.md`.
 - Use the [standardized legend terms](../PlottingChecklist.md#standardized-legend-terms) when naming GNSS, IMU and fused series.
-- When a `STATE_*.txt` reference trajectory is available you can run the Python
+- When the `STATE_X001.txt` reference trajectory is available you can run the Python
   script `src/validate_with_truth.py` or call the MATLAB helper
   `overlay_truth_task4` to overlay the fused output with the ground truth. Before
   running the Python script read the first ECEF row of the state file and supply

--- a/src/run_all_datasets.py
+++ b/src/run_all_datasets.py
@@ -192,8 +192,7 @@ def main():
                 mat_out,
             )
 
-        ds_id = pathlib.Path(imu).stem.split("_")[1]
-        truth_path = (ROOT / imu).with_name(f"STATE_{ds_id}.txt")
+        truth_path = ROOT / "STATE_X001.txt"
         est_mat = results_dir / f"{pathlib.Path(imu).stem}_{pathlib.Path(gnss).stem}_{method}_kf_output.mat"
         if truth_path.exists():
             first = np.loadtxt(truth_path, comments="#", max_rows=1)

--- a/src/validate_with_truth.py
+++ b/src/validate_with_truth.py
@@ -382,7 +382,7 @@ def assemble_frames(est, imu_file, gnss_file, truth_file=None):
     imu_file, gnss_file : str
         Raw data files used to generate *est*.
     truth_file : str or None, optional
-        Path to ``STATE_*.txt`` containing the reference trajectory. When
+        Path to ``STATE_X001.txt`` containing the reference trajectory. When
         provided, the returned frames include an additional ``"truth"``
         entry interpolated to the fused time vector.
     """

--- a/validate_all_outputs.py
+++ b/validate_all_outputs.py
@@ -2,8 +2,8 @@
 """Validate all estimator outputs in a directory.
 
 This helper looks for files ending in ``_kf_output.mat`` or ``_kf_output.npz``
-inside the results folder and runs :mod:`validate_and_plot` for each one when a
-matching ``STATE_*.txt`` truth file is available.
+inside the results folder and runs :mod:`validate_and_plot` for each one using
+the common ``STATE_X001.txt`` truth file.
 """
 
 from __future__ import annotations
@@ -30,7 +30,7 @@ def main(argv: list[str] | None = None) -> None:
         "--truth-dir",
         type=Path,
         default=Path("."),
-        help="directory with STATE_*.txt files",
+        help="directory containing STATE_X001.txt",
     )
     parser.add_argument(
         "--output",
@@ -50,7 +50,7 @@ def main(argv: list[str] | None = None) -> None:
         m = re.search(r"IMU_(X\d+)", est_file.name)
         if not m:
             continue
-        truth_file = args.truth_dir / f"STATE_{m.group(1)}.txt"
+        truth_file = args.truth_dir / "STATE_X001.txt"
         if not truth_file.exists():
             print(f"Truth file '{truth_file}' not found, skipping {est_file.name}.")
             continue


### PR DESCRIPTION
## Summary
- default `validate_3sigma.py` to use `STATE_X001.txt`
- reuse `load_estimate` output for estimator field access
- always use `STATE_X001.txt` in `run_all_datasets.py`
- update `validate_all_outputs.py` and documentation for common truth file

## Testing
- `python -m py_compile src/validate_3sigma.py src/run_all_datasets.py validate_all_outputs.py src/validate_with_truth.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6869a0d866988325a53b5e3854164668