### PR TITLE
Update minimal install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,11 @@ pip install -r requirements.txt
 For a minimal setup you can also install the packages individually:
 
 ```bash
-pip install numpy matplotlib scipy filterpy
+pip install numpy pandas matplotlib scipy filterpy pyproj
 ```
+
+Other helper scripts may rely on additional packages such as `rich` or
+`tqdm`.  Refer to `requirements.txt` for the full dependency list.
 
 If the `filterpy` wheel fails to build, force a source install:
 


### PR DESCRIPTION
## Summary
- clarify minimal install command in README
- note other helper packages in README

## Testing
- `make test` *(fails: KeyboardInterrupt after tests completed)*

------
https://chatgpt.com/codex/tasks/task_e_6869adf37a3c83259a223923ce85a365