### PR TITLE
Use logging for results dir setup

### DIFF
--- a/src/FINAL.py
+++ b/src/FINAL.py
@@ -18,13 +18,15 @@ import pandas as pd
 import numpy as np
 import yaml
 import os
+import logging
 
 from utils import ensure_dependencies
 from tabulate import tabulate
 from tqdm import tqdm
 
+logging.basicConfig(level=logging.INFO, format="%(message)s")
 os.makedirs('results', exist_ok=True)
-print("Ensured 'results/' directory exists.")
+logging.info("Ensured 'results/' directory exists.")
 
 HERE = pathlib.Path(__file__).resolve().parent
 ROOT = HERE.parent

--- a/src/GNSS_IMU_Fusion.py
+++ b/src/GNSS_IMU_Fusion.py
@@ -26,7 +26,6 @@ from scripts.validate_filter import compute_residuals, plot_residuals
 from scipy.spatial.transform import Rotation as R
 
 os.makedirs('results', exist_ok=True)
-print("Ensured 'results/' directory exists.")
 from .gnss_imu_fusion.init_vectors import (
     average_rotation_matrices,
     svd_alignment,
@@ -76,6 +75,7 @@ logging.basicConfig(
     format="%(message)s",
     handlers=[logging.StreamHandler(sys.stdout)]
 )
+logging.info("Ensured 'results/' directory exists.")
 
 # Minimum number of samples required from a static interval for bias estimation
 MIN_STATIC_SAMPLES = 500

--- a/src/compare_python_matlab.py
+++ b/src/compare_python_matlab.py
@@ -7,9 +7,11 @@ import numpy as np
 import pandas as pd
 import scipy.io
 import os
+import logging
 
+logging.basicConfig(level=logging.INFO, format="%(message)s")
 os.makedirs('results', exist_ok=True)
-print("Ensured 'results/' directory exists.")
+logging.info("Ensured 'results/' directory exists.")
 
 
 def run_python_pipeline(imu_file: str, gnss_file: str, method: str) -> Path:

--- a/src/fusion_single.py
+++ b/src/fusion_single.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import logging
 import numpy as np
 import pandas as pd
 from scipy.signal import butter, filtfilt
@@ -9,8 +10,9 @@ from kalman import GNSSIMUKalman, rts_smoother
 from utils import compute_C_ECEF_to_NED
 from constants import GRAVITY, EARTH_RATE
 
+logging.basicConfig(level=logging.INFO, format="%(message)s")
 os.makedirs('results', exist_ok=True)
-print("Ensured 'results/' directory exists.")
+logging.info("Ensured 'results/' directory exists.")
 
 
 def butter_lowpass_filter(data, cutoff=5.0, fs=400.0, order=4):

--- a/src/generate_summary.py
+++ b/src/generate_summary.py
@@ -1,9 +1,11 @@
 import os
+import logging
 import pandas as pd
 from fpdf import FPDF
 
+logging.basicConfig(level=logging.INFO, format="%(message)s")
 os.makedirs('results', exist_ok=True)
-print("Ensured 'results/' directory exists.")
+logging.info("Ensured 'results/' directory exists.")
 
 # Load run results produced by ``summarise_runs.py``
 DF_PATH = "results/summary.csv"

--- a/src/plot_compare_all.py
+++ b/src/plot_compare_all.py
@@ -10,9 +10,11 @@ import pickle
 import matplotlib.pyplot as plt
 import numpy as np
 import os
+import logging
 
+logging.basicConfig(level=logging.INFO, format="%(message)s")
 os.makedirs('results', exist_ok=True)
-print("Ensured 'results/' directory exists.")
+logging.info("Ensured 'results/' directory exists.")
 RESULTS_DIR = pathlib.Path("results")
 COLOURS     = {"X001": "tab:blue", "X002": "tab:orange", "X003": "tab:green"}
 LABEL_MAP   = {"N": "North", "E": "East", "D": "Down"}

--- a/src/run_all_datasets.py
+++ b/src/run_all_datasets.py
@@ -16,6 +16,7 @@ import pandas as pd
 import numpy as np
 import yaml
 import os
+import logging
 from scipy.io import savemat
 
 from utils import ensure_dependencies, ecef_to_geodetic
@@ -25,8 +26,9 @@ from tqdm import tqdm
 from validate_with_truth import load_estimate, assemble_frames
 from plot_overlay import plot_overlay
 
+logging.basicConfig(level=logging.INFO, format="%(message)s")
 os.makedirs('results', exist_ok=True)
-print("Ensured 'results/' directory exists.")
+logging.info("Ensured 'results/' directory exists.")
 
 ensure_dependencies()
 

--- a/src/run_all_methods.py
+++ b/src/run_all_methods.py
@@ -25,9 +25,11 @@ import pathlib
 import subprocess
 import sys
 from typing import Iterable, Tuple
+import logging
 
+logging.basicConfig(level=logging.INFO, format="%(message)s")
 os.makedirs('results', exist_ok=True)
-print("Ensured 'results/' directory exists.")
+logging.info("Ensured 'results/' directory exists.")
 
 HERE = pathlib.Path(__file__).resolve().parent
 ROOT = HERE.parent

--- a/src/run_triad_only.py
+++ b/src/run_triad_only.py
@@ -19,7 +19,6 @@ from utils import ensure_dependencies
 from pyproj import Transformer
 
 os.makedirs('results', exist_ok=True)
-print("Ensured 'results/' directory exists.")
 
 HERE = Path(__file__).resolve().parent
 ROOT = HERE.parent
@@ -29,6 +28,7 @@ logging.basicConfig(
     format="%(asctime)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)
+logging.info("Ensured 'results/' directory exists.")
 
 TRUTH_PATH = HERE / "STATE_X001.txt"
 DATASETS = ["X001", "X002", "X003"]

--- a/src/summarise_runs.py
+++ b/src/summarise_runs.py
@@ -9,9 +9,11 @@ import csv
 import pathlib
 import re
 import os
+import logging
 
+logging.basicConfig(level=logging.INFO, format="%(message)s")
 os.makedirs('results', exist_ok=True)
-print("Ensured 'results/' directory exists.")
+logging.info("Ensured 'results/' directory exists.")
 RESULTS_DIR = pathlib.Path("results")
 
 LOG_DIR = pathlib.Path("logs")

--- a/src/validate_3sigma.py
+++ b/src/validate_3sigma.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 import os
+import logging
 
 import numpy as np
 from scipy.spatial.transform import Rotation as R, Slerp
@@ -21,8 +22,9 @@ import matplotlib.pyplot as plt
 # Reuse the robust loader from validate_with_truth
 from validate_with_truth import load_estimate
 
+logging.basicConfig(level=logging.INFO, format="%(message)s")
 os.makedirs('results', exist_ok=True)
-print("Ensured 'results/' directory exists.")
+logging.info("Ensured 'results/' directory exists.")
 
 
 def load_truth(path: str) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:

--- a/src/validate_filter.py
+++ b/src/validate_filter.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import logging
 from typing import Sequence, Tuple
 
 import numpy as np
@@ -18,8 +19,9 @@ import pandas as pd
 from matplotlib import pyplot as plt
 from scipy.spatial.transform import Rotation as R
 
+logging.basicConfig(level=logging.INFO, format="%(message)s")
 os.makedirs('results', exist_ok=True)
-print("Ensured 'results/' directory exists.")
+logging.info("Ensured 'results/' directory exists.")
 
 
 def _find_cols(df: pd.DataFrame, options: Sequence[Sequence[str]]) -> Sequence[str]:

--- a/src/validate_with_truth.py
+++ b/src/validate_with_truth.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import logging
 from pathlib import Path
 
 import numpy as np
@@ -12,8 +13,9 @@ from plot_overlay import plot_overlay
 import pandas as pd
 import re
 
+logging.basicConfig(level=logging.INFO, format="%(message)s")
 os.makedirs('results', exist_ok=True)
-print("Ensured 'results/' directory exists.")
+logging.info("Ensured 'results/' directory exists.")
 
 __all__ = [
     "load_estimate",


### PR DESCRIPTION
## Summary
- switch various scripts from `print` to `logging` when ensuring the `results/` directory exists
- initialize the logging configuration for these modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869adf149208325acb3e80ba79d8332