### PR TITLE
Fix numpy array truth check in validate_with_truth

### DIFF
--- a/src/validate_with_truth.py
+++ b/src/validate_with_truth.py
@@ -343,9 +343,9 @@ def load_estimate(path, times=None):
             "vel": vel,
             "quat": quat,
             "P": pick_key(["P", "P_hist"], data) if pos_found else None,
-            "ref_lat": data.get("ref_lat") or data.get("lat0"),
-            "ref_lon": data.get("ref_lon") or data.get("lon0"),
-            "ref_r0": data.get("ref_r0") or data.get("r0"),
+            "ref_lat": data.get("ref_lat") if data.get("ref_lat") is not None else data.get("lat0"),
+            "ref_lon": data.get("ref_lon") if data.get("ref_lon") is not None else data.get("lon0"),
+            "ref_r0": data.get("ref_r0") if data.get("ref_r0") is not None else data.get("r0"),
         }
     else:
         m = loadmat(path)
@@ -375,9 +375,9 @@ def load_estimate(path, times=None):
             "vel": vel,
             "quat": quat,
             "P": pick_key(["P", "P_hist"], m) if pos_found else None,
-            "ref_lat": m.get("ref_lat") or m.get("lat0"),
-            "ref_lon": m.get("ref_lon") or m.get("lon0"),
-            "ref_r0": m.get("ref_r0") or m.get("r0"),
+            "ref_lat": m.get("ref_lat") if m.get("ref_lat") is not None else m.get("lat0"),
+            "ref_lon": m.get("ref_lon") if m.get("ref_lon") is not None else m.get("lon0"),
+            "ref_r0": m.get("ref_r0") if m.get("ref_r0") is not None else m.get("r0"),
         }
 
     if est["time"] is None:


### PR DESCRIPTION
## Summary
- avoid using `or` on NumPy arrays when selecting reference values
- refactor `ref_lat`, `ref_lon`, and `ref_r0` selection logic

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686a6a6004308325b58fb9cc1311b885