### PR TITLE
Improve MAT export in run_all_methods

### DIFF
--- a/src/run_all_methods.py
+++ b/src/run_all_methods.py
@@ -26,6 +26,11 @@ import subprocess
 import sys
 from typing import Iterable, Tuple
 import logging
+import numpy as np
+from scipy.spatial.transform import Rotation as R
+from scipy.io import savemat
+
+from utils import compute_C_ECEF_to_NED
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 os.makedirs('results', exist_ok=True)
@@ -57,6 +62,11 @@ def load_config(path: str):
     ] or list(DEFAULT_DATASETS)
     methods = data.get("methods", DEFAULT_METHODS)
     return datasets, methods
+
+
+def compute_C_NED_to_ECEF(lat: float, lon: float) -> np.ndarray:
+    """Return rotation matrix from NED to ECEF frame."""
+    return compute_C_ECEF_to_NED(lat, lon).T
 
 
 def run_case(cmd, log_path):
@@ -114,6 +124,52 @@ def main(argv=None):
         ret = run_case(cmd, log_path)
         if ret != 0:
             raise subprocess.CalledProcessError(ret, cmd)
+        # ------------------------------------------------------------------
+        # Convert NPZ output to a MATLAB file with explicit frame variables
+        # ------------------------------------------------------------------
+        npz_path = pathlib.Path("results") / f"{tag}_kf_output.npz"
+        if npz_path.exists():
+            data = np.load(npz_path, allow_pickle=True)
+            time_s = data.get("time")
+            pos_ned = data.get("pos_ned")
+            vel_ned = data.get("vel_ned")
+            if pos_ned is None:
+                pos_ned = data.get("fused_pos")
+            if vel_ned is None:
+                vel_ned = data.get("fused_vel")
+            ref_lat = float(np.squeeze(data.get("ref_lat")))
+            ref_lon = float(np.squeeze(data.get("ref_lon")))
+            ref_r0 = np.asarray(data.get("ref_r0"))
+
+            C_NED_ECEF = compute_C_NED_to_ECEF(ref_lat, ref_lon)
+            pos_ecef = (C_NED_ECEF @ pos_ned.T).T + ref_r0
+            vel_ecef = (C_NED_ECEF @ vel_ned.T).T
+
+            quat = data.get("attitude_q")
+            if quat is not None:
+                rot = R.from_quat(quat[:, [1, 2, 3, 0]])
+                C_B_N = rot.as_matrix()
+                pos_body = np.einsum("nij,nj->ni", C_B_N.transpose(0, 2, 1), pos_ned)
+                vel_body = np.einsum("nij,nj->ni", C_B_N.transpose(0, 2, 1), vel_ned)
+            else:
+                pos_body = np.zeros_like(pos_ned)
+                vel_body = np.zeros_like(vel_ned)
+
+            mat_out = {
+                "time_s": time_s,
+                "pos_ned_m": pos_ned,
+                "vel_ned_ms": vel_ned,
+                "pos_ecef_m": pos_ecef,
+                "vel_ecef_ms": vel_ecef,
+                "pos_body_m": pos_body,
+                "vel_body_ms": vel_body,
+                "ref_lat_rad": ref_lat,
+                "ref_lon_rad": ref_lon,
+                "ref_r0_m": ref_r0,
+                "att_quat": quat,
+                "method_name": m,
+            }
+            savemat(npz_path.with_suffix(".mat"), mat_out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- save position/velocity in multiple frames in run_all_methods
- provide helper to compute NED→ECEF matrix
- convert NPZ output to .mat file with consistent variable names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a74e197f8832584b96def72ed0a33