### PR TITLE
Add gravity input to Kalman predict

### DIFF
--- a/src/fusion_single.py
+++ b/src/fusion_single.py
@@ -176,7 +176,7 @@ def main():
         q_cur/=np.linalg.norm(q_cur)
         quats.append(q_cur.copy())
         R_bn=quat_to_rot(q_cur)
-        kf.predict(dt,R_bn,acc[i])
+        kf.predict(dt,R_bn,acc[i],g_ned)
         if gnss_idx<len(gnss_time)-1 and abs(imu[i,1]- (gnss_time[gnss_idx]-gnss_time[0]))<dt_imu/2:
             x_upd, resid, S = kf.update_gnss(pos_ned[gnss_idx],vel_ned[gnss_idx])
             upd_times.append(imu[i,1])

--- a/src/gnss_imu_fusion/kalman.py
+++ b/src/gnss_imu_fusion/kalman.py
@@ -56,7 +56,7 @@ class GNSSIMUKalman:
         R[3:6, 3:6] = np.eye(3) * (self.vel_meas_noise ** 2) / self.gnss_weight
         self.kf.R = R
 
-    def predict(self, dt, R_bn, acc_meas):
+    def predict(self, dt, R_bn, acc_meas, g_n):
         F = np.eye(12)
         F[0:3, 3:6] = np.eye(3) * dt
         F[3:6, 6:9] = -R_bn * dt
@@ -79,6 +79,7 @@ class GNSSIMUKalman:
         # manual integration of position/velocity
         acc_body = acc_meas - self.kf.x[6:9]
         acc_n = R_bn @ acc_body
+        acc_n += g_n
         self.kf.x[3:6] += acc_n * dt
         self.kf.x[0:3] += self.kf.x[3:6] * dt
 

--- a/tests/test_kalman_gravity.py
+++ b/tests/test_kalman_gravity.py
@@ -1,0 +1,20 @@
+import pytest
+
+from src.kalman import GNSSIMUKalman
+from src.constants import GRAVITY
+
+np = pytest.importorskip("numpy")
+
+
+def test_predict_handles_gravity():
+    kf = GNSSIMUKalman()
+    kf.init_state(np.zeros(3), np.zeros(3), np.zeros(3), np.zeros(3))
+    dt = 1.0
+    R_bn = np.eye(3)
+    acc_meas = np.array([0.0, 0.0, -GRAVITY])
+    g_n = np.array([0.0, 0.0, GRAVITY])
+
+    kf.predict(dt, R_bn, acc_meas, g_n)
+
+    assert np.allclose(kf.kf.x[3:6], 0.0, atol=1e-6)
+    assert np.allclose(kf.kf.x[0:3], 0.0, atol=1e-6)


### PR DESCRIPTION
## Summary
- extend `GNSSIMUKalman.predict` with a `g_n` argument and add gravity to the navigation acceleration
- pass the gravity vector in `fusion_single` when predicting
- test that a stationary measurement does not drift when gravity is supplied

## Testing
- `flake8 src/gnss_imu_fusion/kalman.py src/fusion_single.py tests/test_kalman_gravity.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aa560d4188325b6b490834d740e47