### PR TITLE
Add normal gravity utilities and update trajectory integration

### DIFF
--- a/src/gnss_imu_fusion/integration.py
+++ b/src/gnss_imu_fusion/integration.py
@@ -2,18 +2,64 @@ from __future__ import annotations
 
 import numpy as np
 
+from ..utils import compute_C_ECEF_to_NED, gravity_ecef
 
-def integrate_trajectory(acc_body: np.ndarray, imu_time: np.ndarray, C_B_N: np.ndarray, g_NED: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Integrate body-frame accelerations to position and velocity in NED."""
+
+def integrate_trajectory(
+    acc_body: np.ndarray,
+    imu_time: np.ndarray,
+    C_B_N: np.ndarray,
+    g_NED: np.ndarray | None = None,
+    *,
+    lat: np.ndarray | None = None,
+    lon: np.ndarray | None = None,
+    g_ecef: np.ndarray | None = None,
+    h: np.ndarray | None = None,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Integrate body-frame accelerations to position and velocity in NED.
+
+    If ``lat`` and ``lon`` are provided (or ``g_ecef`` is given), a
+    position-dependent gravity vector is removed in the ECEF frame before
+    converting the acceleration back to NED for integration.  Otherwise a
+    constant ``g_NED`` is used for all epochs for backward compatibility.
+    """
+
     n = len(imu_time)
     pos = np.zeros((n, 3))
     vel = np.zeros((n, 3))
     acc = np.zeros((n, 3))
+
+    if lat is None or lon is None:
+        if g_NED is None:
+            raise ValueError("g_NED required when lat/lon not provided")
+        for i in range(1, n):
+            dt = imu_time[i] - imu_time[i - 1]
+            f_ned = C_B_N @ acc_body[i]
+            a_ned = f_ned + g_NED
+            acc[i] = a_ned
+            vel[i] = vel[i - 1] + a_ned * dt
+            pos[i] = pos[i - 1] + vel[i] * dt
+        return pos, vel, acc
+
+    lat = np.asarray(lat)
+    lon = np.asarray(lon)
+    if h is None:
+        h = np.zeros(n)
+    else:
+        h = np.asarray(h)
+
+    if g_ecef is None:
+        g_ecef = np.array([gravity_ecef(lat[i], lon[i], h[i]) for i in range(n)])
+
     for i in range(1, n):
         dt = imu_time[i] - imu_time[i - 1]
-        f_ned = C_B_N @ acc_body[i]
-        a_ned = f_ned + g_NED
+        C_e_n = compute_C_ECEF_to_NED(lat[i], lon[i])
+        C_b_e = C_e_n.T @ C_B_N
+        f_ecef = C_b_e @ acc_body[i]
+        a_ecef = f_ecef - g_ecef[i]
+        a_ned = C_e_n @ a_ecef
         acc[i] = a_ned
         vel[i] = vel[i - 1] + a_ned * dt
         pos[i] = pos[i - 1] + vel[i] * dt
+
     return pos, vel, acc

--- a/src/utils.py
+++ b/src/utils.py
@@ -211,3 +211,33 @@ def ecef_to_geodetic(x: float, y: float, z: float) -> Tuple[float, float, float]
     N = a / np.sqrt(1 - e_sq * np.sin(lat) ** 2)
     alt = p / np.cos(lat) - N
     return float(np.degrees(lat)), float(np.degrees(lon)), float(alt)
+
+
+def normal_gravity(lat: float, h: float = 0.0) -> float:
+    """Return gravity magnitude at latitude ``lat`` and height ``h``.
+
+    Parameters
+    ----------
+    lat : float
+        Geodetic latitude in radians.
+    h : float, optional
+        Height above the ellipsoid in metres.
+
+    Returns
+    -------
+    float
+        Gravity magnitude in m/s² using the WGS‑84 model.
+    """
+    sin_lat = np.sin(lat)
+    g = (
+        9.7803253359
+        * (1 + 0.00193185265241 * sin_lat**2)
+        / np.sqrt(1 - 0.00669437999013 * sin_lat**2)
+    )
+    return g - 3.086e-6 * h
+
+
+def gravity_ecef(lat: float, lon: float, h: float = 0.0) -> np.ndarray:
+    """Return gravity vector in ECEF coordinates."""
+    g_ned = np.array([0.0, 0.0, normal_gravity(lat, h)])
+    return compute_C_ECEF_to_NED(lat, lon).T @ g_ned


### PR DESCRIPTION
## Summary
- implement `normal_gravity` and `gravity_ecef` in utils
- extend `integrate_trajectory` to handle varying gravity by location
- compute latitude/longitude from GNSS data and pass to integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aa55f50a48325a5aee86a6a2060ff