### PR TITLE
Compute local gravity and add ECEF validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,15 @@ Once the `*_kf_output.mat` files are created, validate them with:
 python src/validate_all_outputs.py
 ```
 
+For a quick ECEF comparison that uses the gravity derived from the
+`STATE_X001.txt` trajectory, run:
+
+```bash
+python validate_ecef_modes.py --mode fusion
+```
+
+Use `--mode truth` to plot only the ground truth trajectory.
+
 The validator searches the `results/` folder for saved outputs, compares them
 to the common `STATE_X001.txt` ground truth and writes overlay figures and a CSV
 summary alongside the logs. All figures and summaries are therefore found in

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,2 +1,54 @@
-GRAVITY = 9.81
+"""Physical constants used throughout the repository."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from pyproj import Transformer
+
+DATA_ROOT = Path(__file__).resolve().parents[1]
+STATE_FILE = DATA_ROOT / "STATE_X001.txt"
+
+
+def _compute_local_gravity(state_file: Path) -> float:
+    """Return gravity magnitude at the mean position of ``state_file``."""
+
+    cols = [
+        "count",
+        "time",
+        "X_ECEF_m",
+        "Y_ECEF_m",
+        "Z_ECEF_m",
+        "VX_ECEF_mps",
+        "VY_ECEF_mps",
+        "VZ_ECEF_mps",
+        "q0",
+        "q1",
+        "q2",
+        "q3",
+    ]
+    df = pd.read_csv(state_file, sep="\s+", comment="#", names=cols)
+    x, y, z = df[["X_ECEF_m", "Y_ECEF_m", "Z_ECEF_m"]].mean()
+
+    transformer = Transformer.from_crs("epsg:4978", "epsg:4979", always_xy=True)
+    lon, lat, alt = transformer.transform(x, y, z)
+    lat_rad = np.deg2rad(lat)
+
+    gamma_e = 9.7803253359
+    k = 0.00193185265241
+    e2 = 0.00669437999013
+    sin2 = np.sin(lat_rad) ** 2
+    g = gamma_e * (1 + k * sin2) / np.sqrt(1 - e2 * sin2)
+    g -= 3.086e-6 * alt
+    return float(g)
+
+
+try:  # pragma: no cover - runtime check only
+    GRAVITY = _compute_local_gravity(STATE_FILE)
+except Exception:  # pragma: no cover - fallback
+    GRAVITY = 9.81
+
 EARTH_RATE = 7.2921e-5
+

--- a/validate_ecef_modes.py
+++ b/validate_ecef_modes.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Compare fusion output with ground truth using local gravity.
+
+This script computes the gravity magnitude from ``STATE_X001.txt`` and
+validates the ECEF position trajectories produced by each fusion method.
+Switch between 'fusion' (compare estimator vs truth) and 'truth'
+(plot only the truth trajectory) using ``--mode``.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from pyproj import Transformer
+import scipy.io as sio
+
+from src.utils import normal_gravity
+
+
+# ---------------------------------------------------------------------------
+# Gravity computation
+# ---------------------------------------------------------------------------
+
+def compute_local_gravity(state_file: Path) -> tuple[float, float, float, float]:
+    """Return gravity magnitude [m/s^2] and (lat, lon, alt)."""
+    cols = [
+        "count",
+        "time",
+        "X_ECEF_m",
+        "Y_ECEF_m",
+        "Z_ECEF_m",
+        "VX_ECEF_mps",
+        "VY_ECEF_mps",
+        "VZ_ECEF_mps",
+        "q0",
+        "q1",
+        "q2",
+        "q3",
+    ]
+    df = pd.read_csv(state_file, sep="\s+", comment="#", names=cols)
+    x, y, z = df[["X_ECEF_m", "Y_ECEF_m", "Z_ECEF_m"]].mean()
+    transformer = Transformer.from_crs("epsg:4978", "epsg:4979", always_xy=True)
+    lon, lat, alt = transformer.transform(x, y, z)
+    g = normal_gravity(np.deg2rad(lat), alt)
+    return float(g), float(lat), float(lon), float(alt)
+
+
+# ---------------------------------------------------------------------------
+# Main CLI
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> None:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--mode",
+        choices=["fusion", "truth"],
+        default="fusion",
+        help="validation mode",
+    )
+    p.add_argument(
+        "--state-file",
+        type=Path,
+        default=Path("STATE_X001.txt"),
+        help="ground truth trajectory file",
+    )
+    p.add_argument(
+        "--results-dir",
+        type=Path,
+        default=Path("results"),
+        help="directory containing *_kf_output.mat",
+    )
+    args = p.parse_args(argv)
+
+    g, lat, lon, alt = compute_local_gravity(args.state_file)
+    print(
+        f"Local gravity: {g:.6f} m/s^2 at lat={lat:.6f}°, lon={lon:.6f}°, alt={alt:.2f} m"
+    )
+
+    df_state = pd.read_csv(
+        args.state_file,
+        sep="\s+",
+        comment="#",
+        names=[
+            "count",
+            "time",
+            "X",
+            "Y",
+            "Z",
+            "VX",
+            "VY",
+            "VZ",
+            "q0",
+            "q1",
+            "q2",
+            "q3",
+        ],
+    )
+    truth_xyz = df_state[["X", "Y", "Z"]].to_numpy()
+
+    methods = ["TRIAD", "SVD", "Davenport"]
+    axes = ["X", "Y", "Z"]
+    args.results_dir.mkdir(exist_ok=True)
+
+    for method in methods:
+        est_file = args.results_dir / f"IMU_X002_GNSS_X002_{method}_kf_output.mat"
+        if args.mode == "fusion":
+            if not est_file.exists():
+                print(f"Estimator result '{est_file}' not found, skipping.")
+                continue
+            est = sio.loadmat(est_file)
+            est_xyz = est.get("pos_ecef_m")
+            if est_xyz is None:
+                print(f"{est_file} missing 'pos_ecef_m', skipping.")
+                continue
+
+            for i, ax in enumerate(axes):
+                plt.figure(figsize=(10, 5))
+                plt.plot(truth_xyz[:, i], label="Truth")
+                plt.plot(est_xyz[:, i].squeeze(), label=f"{method}")
+                plt.xlabel("Sample")
+                plt.ylabel(f"{ax} [m]")
+                plt.title(f"{method} {ax}-axis (g={g:.5f} m/s^2)")
+                plt.legend()
+                plt.grid(True)
+                plt.savefig(args.results_dir / f"{method}_ECEF_{ax}_fusion_vs_truth.png")
+                plt.close()
+
+            z_rmse = np.sqrt(np.mean((est_xyz[:, 2].squeeze() - truth_xyz[:, 2]) ** 2))
+            print(f"{method}: Z-axis RMSE {z_rmse:.2f} m")
+        else:  # truth mode
+            for i, ax in enumerate(axes):
+                plt.figure(figsize=(10, 5))
+                plt.plot(truth_xyz[:, i], label="Truth")
+                plt.xlabel("Sample")
+                plt.ylabel(f"{ax} [m]")
+                plt.title(f"STATE {ax}-axis")
+                plt.legend()
+                plt.grid(True)
+                plt.savefig(args.results_dir / f"STATE_ECEF_{ax}_Truth.png")
+                plt.close()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- compute local gravity from `STATE_X001.txt` in `constants.py`
- add a new CLI script `validate_ecef_modes.py` for switching validation modes
- document how to run the new validator in `README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ab5099c148325a6b817677384e551