### PR TITLE
Fix gravity integration sign

### DIFF
--- a/src/earth_model.py
+++ b/src/earth_model.py
@@ -1,0 +1,9 @@
+import numpy as np
+
+from .utils import normal_gravity
+
+
+def gravity_ned(lat_rad: float, h_m: float = 0.0) -> np.ndarray:
+    """Return gravity vector in **NED** (+Down) [m/s²]."""
+    g = normal_gravity(lat_rad, h_m)
+    return np.array([0.0, 0.0, +g])   # +g is down in NED

--- a/src/ins/mechanisation.py
+++ b/src/ins/mechanisation.py
@@ -1,0 +1,50 @@
+import numpy as np
+
+from ..earth_model import gravity_ned
+
+
+def mechanise_static(acc_body: np.ndarray, gyro_body: np.ndarray, dt: float,
+                      lat: float = 0.0, h: float = 0.0) -> np.ndarray:
+    """Simple strapdown integration for a stationary segment.
+
+    Parameters
+    ----------
+    acc_body : ndarray of shape (N, 3)
+        Raw accelerometer measurements in the body frame [m/s²].
+    gyro_body : ndarray of shape (N, 3)
+        Gyroscope measurements (unused here).
+    dt : float
+        Sampling interval in seconds.
+    lat : float, optional
+        Latitude in radians for gravity model.
+    h : float, optional
+        Height above ellipsoid in metres.
+
+    Returns
+    -------
+    ndarray of shape (N, 3)
+        Integrated velocity in the NED frame.
+    """
+    g_ned = gravity_ned(lat, h)
+    N = acc_body.shape[0]
+    v_n = np.zeros((N, 3))
+    C_bn = np.eye(3)
+    accel_bias = np.zeros(3)
+    coriolis_n = np.zeros(3)
+
+    for i in range(1, N):
+        # >>> GRAVITY_BEGIN
+        # Rotate delta-v to navigation frame
+        f_ib_n = C_bn @ (acc_body[i] - accel_bias)
+
+        # Apply gravity **once**
+        # *Subtract* because accelerometer measures specific force (i.e. +g when at rest)
+        f_ib_n -= g_ned               # <-- CORRECT SIGN
+
+        # Add Coriolis + centrifugal if present (unchanged)
+        f_ib_n += coriolis_n
+        # <<< GRAVITY_END
+
+        v_n[i] = v_n[i - 1] + f_ib_n * dt
+
+    return v_n

--- a/tests/test_gravity_sign.py
+++ b/tests/test_gravity_sign.py
@@ -1,0 +1,13 @@
+import numpy as np
+from src.ins.mechanisation import mechanise_static
+
+
+def test_static_velocity_drift():
+    dt = 0.01
+    N = 200
+    from src.earth_model import gravity_ned
+    g = gravity_ned(0.0, 0.0)[2]
+    acc_body = np.tile(np.array([0.0, 0.0, g]), (N, 1))
+    gyro_body = np.zeros((N, 3))
+    v_n = mechanise_static(acc_body, gyro_body, dt)
+    assert abs(v_n[-1, 2]) < 0.05


### PR DESCRIPTION
## Summary
- add minimal INS mechanisation module
- ensure gravity vector uses new `earth_model.gravity_ned`
- subtract gravity once when integrating
- test static integration to guard against double gravity

## Testing
- `pytest -q`
- `python src/validate_filter.py --estimates results/IMU_X002_GNSS_X002_Davenport_filter_state.csv --gnss GNSS_X002.csv --output results` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686acf7184ec83259bad4514fa0d2781