### PR TITLE
Update overlay plots for GNSS/IMU/Davenport

### DIFF
--- a/MATLAB/plot_overlay.m
+++ b/MATLAB/plot_overlay.m
@@ -1,6 +1,6 @@
 function plot_overlay(frame, method, t_imu, pos_imu, vel_imu, acc_imu, ...
     t_gnss, pos_gnss, vel_gnss, acc_gnss, t_fused, pos_fused, vel_fused, acc_fused, out_dir, varargin)
-%PLOT_OVERLAY  Save overlay plot comparing IMU, GNSS and fused tracks.
+%PLOT_OVERLAY  Save overlay plot comparing measured IMU, GNSS and fused tracks.
 %   PLOT_OVERLAY(FRAME, METHOD, T_IMU, POS_IMU, VEL_IMU, ACC_IMU, T_GNSS,
 %   POS_GNSS, VEL_GNSS, ACC_GNSS, T_FUSED, POS_FUSED, VEL_FUSED, ACC_FUSED,
 %   OUT_DIR) creates a 4x1 subplot figure showing the norms of position,
@@ -41,40 +41,40 @@ end
 h = figure('Visible','off');
 
 subplot(4,1,1); hold on;
-plot(t_imu, vecnorm(pos_imu,2,2), 'b--', 'DisplayName', 'IMU only');
-plot(t_gnss, vecnorm(pos_gnss,2,2), 'k.', 'DisplayName', 'GNSS');
+plot(t_gnss, vecnorm(pos_gnss,2,2), 'k-', 'DisplayName', 'Measured GNSS');
+plot(t_imu, vecnorm(pos_imu,2,2), 'c--', 'DisplayName', 'Measured IMU');
 if ~isempty(Ttruth) && ~isempty(ptruth)
-    plot(Ttruth, vecnorm(ptruth,2,2), 'g-', 'DisplayName', 'Truth');
+    plot(Ttruth, vecnorm(ptruth,2,2), 'm-', 'DisplayName', 'Truth');
 end
-plot(t_fused, vecnorm(pos_fused,2,2), 'r-', 'DisplayName', 'Fused');
+plot(t_fused, vecnorm(pos_fused,2,2), 'g:', 'DisplayName', ['Fused GNSS+IMU (' method ')']);
 ylabel('Position [m]');
 legend('show');
 
 subplot(4,1,2); hold on;
-plot(t_imu, vecnorm(vel_imu,2,2), 'b--');
-plot(t_gnss, vecnorm(vel_gnss,2,2), 'k.');
+plot(t_gnss, vecnorm(vel_gnss,2,2), 'k-', 'DisplayName', 'Measured GNSS');
+plot(t_imu, vecnorm(vel_imu,2,2), 'c--', 'DisplayName', 'Measured IMU');
 if ~isempty(Ttruth) && ~isempty(vtruth)
-    plot(Ttruth, vecnorm(vtruth,2,2), 'g-');
+    plot(Ttruth, vecnorm(vtruth,2,2), 'm-', 'DisplayName', 'Truth');
 end
-plot(t_fused, vecnorm(vel_fused,2,2), 'r-');
+plot(t_fused, vecnorm(vel_fused,2,2), 'g:', 'DisplayName', ['Fused GNSS+IMU (' method ')']);
 ylabel('Velocity [m/s]');
 
 subplot(4,1,3); hold on;
-plot(t_imu, vecnorm(acc_imu,2,2), 'b--');
-plot(t_gnss, vecnorm(acc_gnss,2,2), 'k.');
+plot(t_gnss, vecnorm(acc_gnss,2,2), 'k-', 'DisplayName', 'Measured GNSS');
+plot(t_imu, vecnorm(acc_imu,2,2), 'c--', 'DisplayName', 'Measured IMU');
 if ~isempty(Ttruth) && ~isempty(atruth)
-    plot(Ttruth, vecnorm(atruth,2,2), 'g-');
+    plot(Ttruth, vecnorm(atruth,2,2), 'm-', 'DisplayName', 'Truth');
 end
-plot(t_fused, vecnorm(acc_fused,2,2), 'r-');
+plot(t_fused, vecnorm(acc_fused,2,2), 'g:', 'DisplayName', ['Fused GNSS+IMU (' method ')']);
 ylabel('Acceleration [m/s^2]');
 
 subplot(4,1,4); hold on;
-plot(pos_imu(:,1), pos_imu(:,2), 'b--', 'DisplayName', 'IMU only');
-plot(pos_gnss(:,1), pos_gnss(:,2), 'k.', 'DisplayName', 'GNSS');
+plot(pos_gnss(:,1), pos_gnss(:,2), 'k-', 'DisplayName', 'Measured GNSS');
+plot(pos_imu(:,1), pos_imu(:,2), 'c--', 'DisplayName', 'Measured IMU');
 if ~isempty(ptruth)
-    plot(ptruth(:,1), ptruth(:,2), 'g-', 'DisplayName', 'Truth');
+    plot(ptruth(:,1), ptruth(:,2), 'm-', 'DisplayName', 'Truth');
 end
-plot(pos_fused(:,1), pos_fused(:,2), 'r-', 'DisplayName', 'Fused');
+plot(pos_fused(:,1), pos_fused(:,2), 'g:', 'DisplayName', ['Fused GNSS+IMU (' method ')']);
 xlabel([frame ' X']);
 ylabel([frame ' Y']);
 title('Trajectory');

--- a/src/plot_overlay.py
+++ b/src/plot_overlay.py
@@ -33,7 +33,8 @@ def plot_overlay(
     acc_truth: Optional[np.ndarray] = None,
     suffix: Optional[str] = None,
 ) -> None:
-    """Save a 3x3 overlay plot comparing IMU-only, GNSS and fused tracks.
+    """Save a 3x3 overlay plot comparing measured IMU, measured GNSS and
+    fused GNSS+IMU tracks.
 
     Parameters
     ----------
@@ -69,12 +70,11 @@ def plot_overlay(
     for row, (imu, gnss, fused, truth, ylab) in enumerate(datasets):
         for col, axis in enumerate(cols):
             ax = axes[row, col]
-            gnss_label = "Measured GNSS" if row < 2 else "Derived GNSS"
-            ax.plot(t_imu, imu[:, col], "b--", label=f"Derived IMU ({method})")
-            ax.plot(t_gnss, gnss[:, col], "k.", label=gnss_label)
+            ax.plot(t_gnss, gnss[:, col], "k", label="Measured GNSS")
+            ax.plot(t_imu, imu[:, col], "c--", label="Measured IMU")
             if t_truth is not None and truth is not None:
-                ax.plot(t_truth, truth[:, col], "g-", label="Truth")
-            ax.plot(t_fused, fused[:, col], "r-", label=f"Fused (GNSS+IMU, {method})")
+                ax.plot(t_truth, truth[:, col], "m-", label="Truth")
+            ax.plot(t_fused, fused[:, col], "g:", label=f"Fused GNSS+IMU ({method})")
             if row == 0:
                 ax.set_title(axis)
             if col == 0:


### PR DESCRIPTION
## Summary
- update Python `plot_overlay` to show Measured IMU, GNSS and fused Davenport data
- match MATLAB `plot_overlay` behaviour

## Testing
- `flake8 src/plot_overlay.py`
- `pytest tests/test_plot_overlay.py::test_plot_overlay_with_truth -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd2805a748325840bcb74b92c65fc