### PR TITLE
Clarify test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,10 @@ To run the unit tests install the package in editable mode with the
 ```bash
 pip install -e .[tests]
 ```
-This pulls in `pytest` and the additional dependencies such as `cartopy`.
+This pulls in `pytest` together with the runtime libraries listed under
+`[project.optional-dependencies] tests` in `pyproject.toml` &mdash; most
+notably `numpy`, `scipy`, `matplotlib`, `pandas`, `filterpy`, and
+`cartopy`.
 
 #### Offline installation (optional)
 
@@ -361,7 +364,8 @@ mandatory** before executing any tests. The suite relies on *all* entries in
 some time to build. Using a dedicated virtual environment or container is
 strongly recommended.  The `test` target in the `Makefile` installs these
 extras for you. Alternatively, run the helper script `scripts/setup_tests.sh`
-before invoking `pytest`:
+before invoking `pytest` to install `numpy`, `scipy`, `matplotlib` and the
+other libraries defined in the `[tests]` extras:
 
 ```bash
 ./scripts/setup_tests.sh

--- a/scripts/setup_tests.sh
+++ b/scripts/setup_tests.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Install Python packages needed for running the tests
+# Install Python packages needed for running the tests. The `[tests]` extras
+# defined in `pyproject.toml` pull in the full runtime stack along with
+# additional test dependencies such as `numpy`, `scipy`, `matplotlib`,
+# `filterpy`, `cartopy` and `pytest`.
 pip install --upgrade pip setuptools wheel build
 pip install -e .[tests]


### PR DESCRIPTION
## Summary
- detail how to install required packages for tests in README
- clarify setup script to show what `[tests]` extras install

## Testing
- `./scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd59559d0832586b9ba7bb502be7e