### PR TITLE
Use compression for MAT files

### DIFF
--- a/src/GNSS_IMU_Fusion.py
+++ b/src/GNSS_IMU_Fusion.py
@@ -1784,8 +1784,8 @@ def main():
     )
 
     # Also export results as MATLAB-compatible .mat for post-processing
-    from scipy.io import savemat
-    savemat(
+    from utils import save_mat
+    save_mat(
         f"results/{tag}_kf_output.mat",
         {
             "rmse_pos": np.array([rmse_pos]),

--- a/src/export_mat.py
+++ b/src/export_mat.py
@@ -3,8 +3,9 @@
 import os
 import sys
 import numpy as np
-from scipy.io import savemat
 import pathlib
+
+from utils import save_mat
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
 os.chdir(script_dir)
@@ -31,5 +32,5 @@ for tag in DATASETS:
         out['fused_pos'] = data['fused_pos']
     if 'fused_vel' in data:
         out['fused_vel'] = data['fused_vel']
-    savemat(mat_file, out)
+    save_mat(mat_file, out)
     print(f'Exported {mat_file}')

--- a/src/run_all_datasets.py
+++ b/src/run_all_datasets.py
@@ -17,7 +17,7 @@ import numpy as np
 import yaml
 import os
 import logging
-from scipy.io import savemat
+from utils import save_mat
 
 from utils import ensure_dependencies, ecef_to_geodetic
 from tabulate import tabulate
@@ -189,7 +189,7 @@ def main():
             for key in data.files:
                 if key not in ["time_residuals", "fused_pos", "fused_vel", "P_hist", "attitude_q"]:
                     mat_out[key] = data[key]
-            savemat(
+            save_mat(
                 results_dir / f"{pathlib.Path(imu).stem}_{pathlib.Path(gnss).stem}_{method}_kf_output.mat",
                 mat_out,
             )

--- a/src/run_all_methods.py
+++ b/src/run_all_methods.py
@@ -32,7 +32,7 @@ import pandas as pd
 from tabulate import tabulate
 import numpy as np
 from scipy.spatial.transform import Rotation as R
-from scipy.io import savemat
+from utils import save_mat
 
 from utils import compute_C_ECEF_to_NED
 
@@ -225,7 +225,7 @@ def main(argv=None):
                 "att_quat": quat,
                 "method_name": m,
             }
-            savemat(npz_path.with_suffix(".mat"), mat_out)
+            save_mat(npz_path.with_suffix(".mat"), mat_out)
 
     # --- nicely formatted summary table --------------------------------------
     if results:

--- a/src/utils.py
+++ b/src/utils.py
@@ -139,9 +139,20 @@ def adaptive_zupt_threshold(accel_data: np.ndarray, gyro_data: np.ndarray,
 
 
 def save_mat(filename: str, data: dict) -> None:
-    """Save *data* dictionary to a MATLAB ``.mat`` file."""
+    """Save *data* dictionary to a MATLAB ``.mat`` file.
+
+    Parameters
+    ----------
+    filename : str
+        Destination path for the ``.mat`` file.
+    data : dict
+        Mapping of variable names to arrays to be written.
+    """
+
     from scipy.io import savemat
-    savemat(filename, data)
+
+    # Store with compression to reduce disk usage
+    savemat(filename, data, do_compression=True)
 
 
 def compute_C_ECEF_to_NED(lat: float, lon: float) -> np.ndarray:


### PR DESCRIPTION
## Summary
- compress MATLAB exports by default
- use `save_mat` utility in scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c2ceb35148325878978b60f100fd0