### PR TITLE
Add STATE overlay plots

### DIFF
--- a/docs/Python/Task6_Python.md
+++ b/docs/Python/Task6_Python.md
@@ -24,6 +24,10 @@ Task 5 output
    data in NED, ECEF and body frames.
 3. **Generate Plots** – call :func:`plot_overlay` for each frame to save PDFs
    named `<METHOD>_<FRAME>_overlay_truth.pdf` in the results directory.
+4. **State Comparison** – additionally plot the raw `STATE_X*.txt` trajectory
+   using its original time vector. These files are saved as
+   `<METHOD>_<FRAME>_overlay_state.pdf` and highlight any time offsets
+   between the estimate and truth.
 
 ## Result
 

--- a/docs/TRIAD_Task6_Wiki.md
+++ b/docs/TRIAD_Task6_Wiki.md
@@ -20,6 +20,9 @@ Task 5 fused trajectory
 1. Load the Task 5 output file (`*_kf_output.mat` or `.npz`).
 2. Interpolate IMU, GNSS and truth samples onto the same time vector.
 3. Save NED, ECEF and body-frame overlay plots using the standard layout.
+4. Create additional figures overlaying the raw `STATE_X*.txt` data without
+   alignment. These highlight how the estimator drifts relative to the logged
+   truth.
 
 ## Result
 

--- a/tests/test_validate_with_truth.py
+++ b/tests/test_validate_with_truth.py
@@ -221,6 +221,28 @@ def test_overlay_truth_generation(tmp_path, monkeypatch):
     produced = {p.name for p in Path("results").glob("*_overlay_truth.pdf")}
     assert expected.issubset(produced), f"Missing overlays: {expected - produced}"
 
+    # verify raw STATE overlay generation via task6_plot_truth.py
+    from src.task6_plot_truth import main as task6_main
+    # provide IMU/GNSS files expected by the script
+    Path("IMU_X001_small.dat").write_bytes((repo / "IMU_X001_small.dat").read_bytes())
+    Path("GNSS_X001_small.csv").write_bytes((repo / "GNSS_X001_small.csv").read_bytes())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "task6_plot_truth.py",
+            "--est-file",
+            str(est_file),
+            "--truth-file",
+            str(repo / "STATE_X001_small.txt"),
+            "--output",
+            str(Path("results")),
+        ],
+    )
+    task6_main()
+    state_files = {p.name for p in Path("results").glob("*_overlay_state.pdf")}
+    assert state_files, "Missing state overlay plots"
+
 
 def test_assemble_frames_small_truth():
     repo = Path(__file__).resolve().parent / "data"


### PR DESCRIPTION
## Summary
- extend Task6 script to plot raw STATE trajectory alongside fused results
- document new `_overlay_state.pdf` output
- test overlay generation in the Python pipeline

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c9ec85e5c83258976f8d85c5399be