### PR TITLE
Fix NED frame handling in truth overlay

### DIFF
--- a/src/task6_plot_truth.py
+++ b/src/task6_plot_truth.py
@@ -89,6 +89,10 @@ def main() -> None:
     else:
         ref_lat = float(np.asarray(ref_lat).squeeze())
         ref_lon = float(np.asarray(ref_lon).squeeze())
+        # Convert to radians when values appear to be in degrees
+        if abs(ref_lat) > np.pi or abs(ref_lon) > np.pi:
+            ref_lat = np.deg2rad(ref_lat)
+            ref_lon = np.deg2rad(ref_lon)
         ref_r0 = np.asarray(ref_r0).squeeze()
 
     C = compute_C_ECEF_to_NED(ref_lat, ref_lon)


### PR DESCRIPTION
## Summary
- ensure reference latitude and longitude from the estimator are in radians when plotting truth data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cc407b9448325be457ea80fdd7fbf