### PR TITLE
Align MATLAB Task_1 output with Python

### DIFF
--- a/MATLAB/validate_gravity_vector.m
+++ b/MATLAB/validate_gravity_vector.m
@@ -1,0 +1,24 @@
+function g_ned = validate_gravity_vector(lat_deg, h)
+%VALIDATE_GRAVITY_VECTOR Print gravity magnitude and return vector in NED.
+%   g_ned = VALIDATE_GRAVITY_VECTOR(LAT_DEG, H) computes the gravity
+%   magnitude using the WGS-84 normal gravity formula and prints the
+%   formatted message shown by the Python version of the pipeline.
+
+if nargin < 2
+    h = 0;
+end
+lat_rad = deg2rad(lat_deg);
+sin_lat = sin(lat_rad);
+
+% WGS-84 normal gravity with height correction
+g = 9.7803253359 * (1 + 0.00193185265241 * sin_lat^2) / ...
+    sqrt(1 - 0.00669437999013 * sin_lat^2);
+
+% height above ellipsoid correction
+g = g - 3.086e-6 * h;
+
+fprintf(['[Gravity Validation] Latitude: %.3f deg, altitude: %.1f m --> ' ...
+        'Gravity: %.6f m/s^2 (NED +Z is down)\n'], lat_deg, h, g);
+
+g_ned = [0; 0; g];
+end


### PR DESCRIPTION
## Summary
- improve Task_1 logging so it mirrors the Python script
- compute and print gravity using new `validate_gravity_vector`
- drop ECEF wording and simplify messages

## Testing
- `pytest -q tests/test_ecef_to_geodetic.py`
- `pytest -q tests/test_utils.py`
- `pytest -q tests/test_utils_additional.py`
- `pytest -q tests/test_average_rotation.py`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_686d47bf77988325b7612a7743ea5afe