### PR TITLE
Improve error handling in validate_3sigma

### DIFF
--- a/src/validate_3sigma.py
+++ b/src/validate_3sigma.py
@@ -83,6 +83,11 @@ def main() -> None:
     truth_vel = truth_vel[mask]
     truth_quat = truth_quat[mask]
 
+    if truth_t.size == 0:
+        raise RuntimeError(
+            "No overlapping time range between estimator output and ground truth"
+        )
+
     pos_truth_i = np.vstack(
         [np.interp(t, truth_t, truth_pos[:, i]) for i in range(3)]
     ).T


### PR DESCRIPTION
## Summary
- check for overlap between estimation and truth data before interpolation
- raise a clear error when no overlap exists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876cc1c0f4c8325bd5bffb7d65f715b