### PR TITLE
Improve diagnostics in validate_3sigma

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ For a quick look at ±3σ bounds stored in the covariance matrix run:
 python src/validate_3sigma.py --est-file <kf.npz> --truth-file STATE_X001.txt \
     --output-dir results
 ```
+If the estimator output and truth file do not overlap, the script now
+prints a detailed error showing both time ranges.
 
 ### Sample Processing Report
 

--- a/tests/test_validate_3sigma.py
+++ b/tests/test_validate_3sigma.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+import pytest
+
+from src.validate_3sigma import main
+
+np = pytest.importorskip("numpy")
+
+
+def test_no_overlap_error(tmp_path, monkeypatch):
+    data = {
+        "time": np.array([10.0, 11.0, 12.0]),
+        "pos": np.zeros((3, 3)),
+        "vel": np.zeros((3, 3)),
+        "quat": np.tile([1.0, 0.0, 0.0, 0.0], (3, 1)),
+    }
+    est_file = tmp_path / "est.npz"
+    np.savez(est_file, **data)
+    truth_file = Path("tests/data/simple_truth.txt")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "validate_3sigma.py",
+            "--est-file",
+            str(est_file),
+            "--truth-file",
+            str(truth_file),
+        ],
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        main()
+    msg = str(excinfo.value)
+    assert "estimate spans 10.00-12.00s" in msg
+    assert "truth spans 0.00-2.00s" in msg


### PR DESCRIPTION
## Summary
- clarify runtime error when no overlap with ground truth
- document detailed overlap message in README
- test that missing overlap shows both time ranges

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876d1b216888325bb5d5b45a4bae042