### PR TITLE
Add time shift option to validate_3sigma

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,9 @@ python src/validate_3sigma.py --est-file <kf.npz> --truth-file STATE_X001.txt \
     --output-dir results
 ```
 If the estimator output and truth file do not overlap, the script now
-prints a detailed error showing both time ranges.
+prints a detailed error showing both time ranges.  A constant offset can be
+applied to the truth timestamps via the optional `--time-shift` argument when
+alignment is required.
 
 ### Sample Processing Report
 

--- a/src/validate_3sigma.py
+++ b/src/validate_3sigma.py
@@ -7,7 +7,8 @@ interchangeably.  Ground truth is provided in ``STATE_X001.txt``
 with columns ``[time,x,y,z,vx,vy,vz,qw,qx,qy,qz]``.  Only the overlapping
 time window is used when computing the error and the ±3σ envelopes.  If
 there is no overlap, a ``RuntimeError`` is raised with the estimator and
-truth time ranges to aid debugging.
+truth time ranges to aid debugging.  Pass ``--time-shift`` to offset the
+truth timestamps when they need aligning with the estimate.
 """
 
 from __future__ import annotations
@@ -62,6 +63,12 @@ def main() -> None:
     ap.add_argument(
         "--output-dir", default="results/", help="Directory where plots are saved"
     )
+    ap.add_argument(
+        "--time-shift",
+        type=float,
+        default=0.0,
+        help="Seconds to add to truth timestamps before comparison",
+    )
     args = ap.parse_args()
 
     out_dir = Path(args.output_dir)
@@ -77,6 +84,8 @@ def main() -> None:
     P = np.asarray(est.get("P")) if est.get("P") is not None else None
 
     truth_t, truth_pos, truth_vel, truth_quat = load_truth(args.truth_file)
+
+    truth_t += args.time_shift
 
     truth_t_raw = truth_t.copy()
 

--- a/tests/test_validate_3sigma.py
+++ b/tests/test_validate_3sigma.py
@@ -34,3 +34,34 @@ def test_no_overlap_error(tmp_path, monkeypatch):
     msg = str(excinfo.value)
     assert "estimate spans 10.00-12.00s" in msg
     assert "truth spans 0.00-2.00s" in msg
+
+
+def test_time_shift_allows_overlap(tmp_path, monkeypatch):
+    data = {
+        "time": np.array([3.0, 4.0, 5.0]),
+        "pos": np.zeros((3, 3)),
+        "vel": np.zeros((3, 3)),
+        "quat": np.tile([1.0, 0.0, 0.0, 0.0], (3, 1)),
+    }
+    est_file = tmp_path / "est.npz"
+    np.savez(est_file, **data)
+    truth_file = Path("tests/data/simple_truth.txt")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "validate_3sigma.py",
+            "--est-file",
+            str(est_file),
+            "--truth-file",
+            str(truth_file),
+            "--output-dir",
+            str(tmp_path),
+            "--time-shift",
+            "3.0",
+        ],
+    )
+
+    main()
+    assert (tmp_path / "pos_err_X.pdf").exists()


### PR DESCRIPTION
## Summary
- extend validate_3sigma.py with `--time-shift` argument
- shift truth timestamps when requested
- document the new option in README and module docstring
- test that `--time-shift` allows interpolation without errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876d644a1108325b29c93be1f82bee0