### PR TITLE
Move results dir creation into main

### DIFF
--- a/src/FINAL.py
+++ b/src/FINAL.py
@@ -25,8 +25,6 @@ from tabulate import tabulate
 from tqdm import tqdm
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
-os.makedirs('results', exist_ok=True)
-logging.info("Ensured 'results/' directory exists.")
 
 HERE = pathlib.Path(__file__).resolve().parent
 ROOT = HERE.parent
@@ -79,6 +77,8 @@ def run_one(imu, gnss, method, verbose=False):
     return summary_lines
 
 def main():
+    os.makedirs('results', exist_ok=True)
+    logging.info("Ensured 'results/' directory exists.")
     parser = argparse.ArgumentParser()
     parser.add_argument("--verbose", action="store_true", help="Print detailed debug info")
     parser.add_argument("--datasets", default="ALL",

--- a/src/GNSS_IMU_Fusion.py
+++ b/src/GNSS_IMU_Fusion.py
@@ -25,8 +25,6 @@ from utils import (
 from constants import GRAVITY, EARTH_RATE
 from scripts.validate_filter import compute_residuals, plot_residuals
 from scipy.spatial.transform import Rotation as R
-
-os.makedirs('results', exist_ok=True)
 from .gnss_imu_fusion.init_vectors import (
     average_rotation_matrices,
     svd_alignment,
@@ -77,13 +75,14 @@ logging.basicConfig(
     format="%(message)s",
     handlers=[logging.StreamHandler(sys.stdout)]
 )
-logging.info("Ensured 'results/' directory exists.")
 
 # Minimum number of samples required from a static interval for bias estimation
 MIN_STATIC_SAMPLES = 500
 
 
 def main():
+    os.makedirs('results', exist_ok=True)
+    logging.info("Ensured 'results/' directory exists.")
     # Parse command-line arguments
     parser = argparse.ArgumentParser()
     parser.add_argument("--imu-file", required=True)

--- a/src/compare_python_matlab.py
+++ b/src/compare_python_matlab.py
@@ -10,8 +10,6 @@ import os
 import logging
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
-os.makedirs('results', exist_ok=True)
-logging.info("Ensured 'results/' directory exists.")
 
 
 def run_python_pipeline(imu_file: str, gnss_file: str, method: str) -> Path:
@@ -78,6 +76,8 @@ def load_matlab_metrics(mat_path: Path, imu_file: str, gnss_file: str) -> Tuple[
 
 
 def main() -> None:
+    os.makedirs('results', exist_ok=True)
+    logging.info("Ensured 'results/' directory exists.")
     ap = argparse.ArgumentParser(description="Compare Python and MATLAB results")
     ap.add_argument("--imu", default="IMU_X001.dat")
     ap.add_argument("--gnss", default="GNSS_X001.csv")

--- a/src/fusion_single.py
+++ b/src/fusion_single.py
@@ -11,8 +11,6 @@ from utils import compute_C_ECEF_to_NED
 from constants import GRAVITY, EARTH_RATE
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
-os.makedirs('results', exist_ok=True)
-logging.info("Ensured 'results/' directory exists.")
 
 
 def butter_lowpass_filter(data, cutoff=5.0, fs=400.0, order=4):
@@ -53,6 +51,8 @@ def quat_to_rot(q):
 
 
 def main():
+    os.makedirs('results', exist_ok=True)
+    logging.info("Ensured 'results/' directory exists.")
     parser = argparse.ArgumentParser()
     parser.add_argument('--imu-file', default='IMU_X001.dat')
     parser.add_argument('--gnss-file', default='GNSS_X001.csv')

--- a/src/generate_summary.py
+++ b/src/generate_summary.py
@@ -4,14 +4,14 @@ import pandas as pd
 from fpdf import FPDF
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
-os.makedirs('results', exist_ok=True)
-logging.info("Ensured 'results/' directory exists.")
 
 # Load run results produced by ``summarise_runs.py``
 DF_PATH = "results/summary.csv"
 
 
 def main():
+    os.makedirs('results', exist_ok=True)
+    logging.info("Ensured 'results/' directory exists.")
     df = pd.read_csv(DF_PATH)
 
     pdf = FPDF()

--- a/src/plot_compare_all.py
+++ b/src/plot_compare_all.py
@@ -13,8 +13,9 @@ import os
 import logging
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
-os.makedirs('results', exist_ok=True)
-logging.info("Ensured 'results/' directory exists.")
+if __name__ == "__main__":
+    os.makedirs('results', exist_ok=True)
+    logging.info("Ensured 'results/' directory exists.")
 RESULTS_DIR = pathlib.Path("results")
 COLOURS     = {"X001": "tab:blue", "X002": "tab:orange", "X003": "tab:green"}
 LABEL_MAP   = {"N": "North", "E": "East", "D": "Down"}

--- a/src/run_all_datasets.py
+++ b/src/run_all_datasets.py
@@ -27,8 +27,6 @@ from validate_with_truth import load_estimate, assemble_frames
 from plot_overlay import plot_overlay
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
-os.makedirs('results', exist_ok=True)
-logging.info("Ensured 'results/' directory exists.")
 
 ensure_dependencies()
 
@@ -87,6 +85,8 @@ def run_one(imu, gnss, method, verbose=False):
 
 
 def main():
+    os.makedirs('results', exist_ok=True)
+    logging.info("Ensured 'results/' directory exists.")
     parser = argparse.ArgumentParser()
     parser.add_argument("--verbose", action="store_true", help="Print detailed debug info")
     parser.add_argument("--datasets", default="ALL",

--- a/src/run_all_methods.py
+++ b/src/run_all_methods.py
@@ -38,8 +38,6 @@ from utils import compute_C_ECEF_to_NED
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="%(message)s")
-os.makedirs('results', exist_ok=True)
-logger.info("Ensured 'results/' directory exists.")
 
 HERE = pathlib.Path(__file__).resolve().parent
 ROOT = HERE.parent
@@ -97,6 +95,8 @@ def run_case(cmd, log_path):
 
 
 def main(argv=None):
+    os.makedirs('results', exist_ok=True)
+    logger.info("Ensured 'results/' directory exists.")
     parser = argparse.ArgumentParser(
         description="Run GNSS_IMU_Fusion with multiple datasets and methods",
     )

--- a/src/run_triad_only.py
+++ b/src/run_triad_only.py
@@ -18,8 +18,6 @@ from validate_with_truth import load_estimate, assemble_frames
 from utils import ensure_dependencies
 from pyproj import Transformer
 
-os.makedirs('results', exist_ok=True)
-
 HERE = Path(__file__).resolve().parent
 ROOT = HERE.parent
 
@@ -28,7 +26,9 @@ logging.basicConfig(
     format="%(asctime)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)
-logging.info("Ensured 'results/' directory exists.")
+if __name__ == "__main__":
+    os.makedirs('results', exist_ok=True)
+    logging.info("Ensured 'results/' directory exists.")
 
 TRUTH_PATH = HERE / "STATE_X001.txt"
 DATASETS = ["X001", "X002", "X003"]

--- a/src/summarise_runs.py
+++ b/src/summarise_runs.py
@@ -12,8 +12,9 @@ import os
 import logging
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
-os.makedirs('results', exist_ok=True)
-logging.info("Ensured 'results/' directory exists.")
+if __name__ == "__main__":
+    os.makedirs('results', exist_ok=True)
+    logging.info("Ensured 'results/' directory exists.")
 RESULTS_DIR = pathlib.Path("results")
 
 LOG_DIR = pathlib.Path("logs")


### PR DESCRIPTION
## Summary
- avoid creating `results/` on import
- relocate any `os.makedirs('results', exist_ok=True)` call into a `main()`/`__main__` block

## Testing
- `pip install -e .[tests]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876d645725c8325b47ddb5c62ebf1e0