### PR TITLE
Hint to try --time-shift in validate_3sigma error

### DIFF
--- a/src/validate_3sigma.py
+++ b/src/validate_3sigma.py
@@ -99,7 +99,8 @@ def main() -> None:
     if truth_t.size == 0:
         raise RuntimeError(
             f"No overlap: estimate spans {t[0]:.2f}-{t[-1]:.2f}s "
-            f"but truth spans {truth_t_raw[0]:.2f}-{truth_t_raw[-1]:.2f}s"
+            f"but truth spans {truth_t_raw[0]:.2f}-{truth_t_raw[-1]:.2f}s. "
+            "If the ranges look correct but shifted, try --time-shift."
         )
 
     pos_truth_i = np.vstack(

--- a/tests/test_validate_3sigma.py
+++ b/tests/test_validate_3sigma.py
@@ -34,6 +34,7 @@ def test_no_overlap_error(tmp_path, monkeypatch):
     msg = str(excinfo.value)
     assert "estimate spans 10.00-12.00s" in msg
     assert "truth spans 0.00-2.00s" in msg
+    assert "time-shift" in msg
 
 
 def test_time_shift_allows_overlap(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- advise users to use `--time-shift` when ranges don't overlap but appear shifted
- verify error hint in unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876db00c5ec8325a5aa1872a03a28de