### PR TITLE
Add auto time shift option

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,8 @@ python src/validate_3sigma.py --est-file <kf.npz> --truth-file STATE_X001.txt \
 If the estimator output and truth file do not overlap, the script now
 prints a detailed error showing both time ranges.  A constant offset can be
 applied to the truth timestamps via the optional `--time-shift` argument when
-alignment is required.
+alignment is required.  Passing `--auto-time-shift` will automatically apply
+the offset `est_start - truth_start` when no manual shift is provided.
 
 ### Sample Processing Report
 

--- a/src/validate_3sigma.py
+++ b/src/validate_3sigma.py
@@ -69,6 +69,11 @@ def main() -> None:
         default=0.0,
         help="Seconds to add to truth timestamps before comparison",
     )
+    ap.add_argument(
+        "--auto-time-shift",
+        action="store_true",
+        help="Automatically align truth timestamps to the estimate start",
+    )
     args = ap.parse_args()
 
     out_dir = Path(args.output_dir)
@@ -84,6 +89,13 @@ def main() -> None:
     P = np.asarray(est.get("P")) if est.get("P") is not None else None
 
     truth_t, truth_pos, truth_vel, truth_quat = load_truth(args.truth_file)
+
+    if args.auto_time_shift and args.time_shift == 0.0:
+        args.time_shift = float(t[0] - truth_t[0])
+        logging.info(
+            "Auto time shift enabled, applying %.3f s offset to truth timestamps",
+            args.time_shift,
+        )
 
     truth_t += args.time_shift
 

--- a/tests/test_validate_3sigma.py
+++ b/tests/test_validate_3sigma.py
@@ -66,3 +66,33 @@ def test_time_shift_allows_overlap(tmp_path, monkeypatch):
 
     main()
     assert (tmp_path / "pos_err_X.pdf").exists()
+
+
+def test_auto_time_shift(tmp_path, monkeypatch):
+    data = {
+        "time": np.array([3.0, 4.0, 5.0]),
+        "pos": np.zeros((3, 3)),
+        "vel": np.zeros((3, 3)),
+        "quat": np.tile([1.0, 0.0, 0.0, 0.0], (3, 1)),
+    }
+    est_file = tmp_path / "est.npz"
+    np.savez(est_file, **data)
+    truth_file = Path("tests/data/simple_truth.txt")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "validate_3sigma.py",
+            "--est-file",
+            str(est_file),
+            "--truth-file",
+            str(truth_file),
+            "--output-dir",
+            str(tmp_path),
+            "--auto-time-shift",
+        ],
+    )
+
+    main()
+    assert (tmp_path / "vel_err_Vx.pdf").exists()


### PR DESCRIPTION
## Summary
- add `--auto-time-shift` argument to `validate_3sigma.py`
- document automatic shifting in README
- test new option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876dcf6544483259ca8a3b331102349