### PR TITLE
Add DTW alignment helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,19 @@ applied to the truth timestamps via the optional `--time-shift` argument when
 alignment is required.  Passing `--auto-time-shift` will automatically apply
 the offset `est_start - truth_start` when no manual shift is provided.
 
+### Aligning Datasets with DTW
+
+The helper script `align_datasets_dtw.py` aligns an estimator output with the
+reference trajectory using Dynamic Time Warping. Edit the file paths at the top
+of the script if your results live elsewhere and then run:
+
+```bash
+pip install fastdtw
+python align_datasets_dtw.py
+```
+It prints the mean and standard deviation of the position error and writes the
+per‑sample errors to `aligned_position_errors.txt`.
+
 ### Sample Processing Report
 
 A sample run of `run_triad_only.py` is documented in [Report/](Report/index.md). Each page lists the equations and the PDF figures generated in the `results/` directory.

--- a/align_datasets_dtw.py
+++ b/align_datasets_dtw.py
@@ -1,0 +1,38 @@
+import numpy as np
+from fastdtw import fastdtw
+from scipy.spatial.distance import euclidean
+
+# Update these paths for your own data
+EST_FILE = "results/IMU_X002_GNSS_X002_TRIAD_kf_output.npz"
+TRUTH_FILE = "STATE_X001.txt"
+
+# Step 1: Load the data
+est_data = np.load(EST_FILE)
+truth_data = np.loadtxt(TRUTH_FILE, usecols=[1, 2, 3])
+
+# Step 2: Extract position arrays
+est_pos = est_data["position"]
+truth_pos = truth_data
+
+# Step 3: Normalise positions to [0, 1]
+est_norm = (est_pos - est_pos.min(axis=0)) / (est_pos.max(axis=0) - est_pos.min(axis=0))
+truth_norm = (truth_pos - truth_pos.min(axis=0)) / (truth_pos.max(axis=0) - truth_pos.min(axis=0))
+
+# Step 4: Align using DTW
+_, path = fastdtw(est_norm, truth_norm, dist=euclidean)
+est_idx, truth_idx = zip(*path)
+
+# Step 5: Reindex datasets along the DTW path
+aligned_est = est_pos[list(est_idx)]
+aligned_truth = truth_pos[list(truth_idx)]
+
+# Step 6: Compute position errors
+errors = np.linalg.norm(aligned_est - aligned_truth, axis=1)
+
+# Optional: assign a relative time scale
+relative_time = np.arange(len(aligned_est))
+
+print(f"Aligned time range: 0 to {relative_time[-1]} units")
+print(f"Position errors: mean={errors.mean():.4f}, std={errors.std():.4f}")
+
+np.savetxt("aligned_position_errors.txt", errors)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "filterpy",
   "cartopy",
   "geomaglib>=1.2.1",
+  "fastdtw",
 ]
 
 [project.optional-dependencies]
@@ -39,6 +40,7 @@ tests = [
     "cartopy",
     "tqdm",
     "tabulate",
+    "fastdtw",
     "pytest",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ filterpy
 cartopy
 geomaglib>=1.2.1
 pyproj
+fastdtw


### PR DESCRIPTION
## Summary
- add `align_datasets_dtw.py` for aligning datasets with Dynamic Time Warping
- document the new script in the README
- include `fastdtw` in requirements and `pyproject.toml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68773ea698488325baa466ea3a25c893