### PR TITLE
Handle mismatched residual lengths

### DIFF
--- a/src/evaluate_filter_results.py
+++ b/src/evaluate_filter_results.py
@@ -123,6 +123,17 @@ def run_evaluation_npz(npz_file: str, save_path: str) -> None:
     if res_pos is None or res_vel is None or t is None or quat is None:
         raise KeyError("Required residuals not found in NPZ file")
 
+    if len(t) != len(res_pos) or len(t) != len(res_vel):
+        n = min(len(t), len(res_pos), len(res_vel))
+        print(
+            f"Warning: residual arrays and time length mismatch, truncating to {n} samples"
+        )
+        t = t[:n]
+        res_pos = res_pos[:n]
+        res_vel = res_vel[:n]
+    else:
+        n = len(t)
+
     mean_pos = res_pos.mean(axis=0)
     std_pos = res_pos.std(axis=0)
     mean_vel = res_vel.mean(axis=0)

--- a/tests/test_evaluate_filter_results.py
+++ b/tests/test_evaluate_filter_results.py
@@ -1,0 +1,16 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+from src.evaluate_filter_results import run_evaluation_npz
+
+
+def test_run_evaluation_npz_mismatched_lengths(tmp_path):
+    res_pos = np.zeros((5, 3))
+    res_vel = np.ones((4, 3))
+    t = np.linspace(0, 1, 6)
+    quat = np.tile([1.0, 0.0, 0.0, 0.0], (4, 1))
+    f = tmp_path / "data.npz"
+    np.savez(f, residual_pos=res_pos, residual_vel=res_vel, time_residuals=t, attitude_q=quat)
+    run_evaluation_npz(str(f), str(tmp_path))
+    assert (tmp_path / "residuals_position_velocity.pdf").exists()
+    assert (tmp_path / "attitude_angles_euler.pdf").exists()


### PR DESCRIPTION
## Summary
- avoid mismatched length errors in `run_evaluation_npz`
- add regression test covering the mismatch case

## Testing
- `pip install -e .[tests]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878836e79b88325965b852eee2eecf3