### PR TITLE
Add fused-only plot option

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,9 @@ python src/task6_plot_truth.py --est-file results/IMU_X001_GNSS_X001_TRIAD_kf_ou
     --truth-file STATE_X001.txt --output results
 ```
 
+Pass `--fused-only` to hide the IMU and GNSS measurements so only the fused
+trajectory and truth are shown.
+
 ### Output
 
 * `<method>_<frame>_overlay_truth.pdf` – fused output vs reference

--- a/plot_summary.md
+++ b/plot_summary.md
@@ -13,6 +13,8 @@
 - **X001_TRIAD_task5_mixed_frames.pdf**: Kalman filter results in mixed frames
 - **X001_TRIAD_residuals.pdf**: Position and velocity residuals
 - **X001_TRIAD_attitude_angles.pdf**: Attitude angles over time
+- **<method>_<frame>_overlay_truth.pdf**: Fused results versus reference
+- **<method>_<frame>_overlay_state.pdf**: Fused results versus raw state file
 
 ## Subtask 5.8 Comparison Plots
 

--- a/src/plot_overlay.py
+++ b/src/plot_overlay.py
@@ -32,6 +32,7 @@ def plot_overlay(
     vel_truth: Optional[np.ndarray] = None,
     acc_truth: Optional[np.ndarray] = None,
     suffix: Optional[str] = None,
+    include_measurements: bool = True,
 ) -> None:
     """Save a 3x3 overlay plot comparing measured IMU, measured GNSS and
     fused GNSS+IMU tracks.
@@ -45,6 +46,9 @@ def plot_overlay(
         Filename suffix appended to ``"{method}_{frame}"`` when saving the
         figure. Defaults to ``"_overlay_truth.pdf"`` if any truth arrays are
         supplied and ``"_overlay.pdf"`` otherwise.
+    include_measurements : bool, optional
+        Plot measured IMU and GNSS series when ``True`` (default). When ``False``
+        only the fused estimate and optional truth data are shown.
     """
     if truth is not None:
         t_truth, pos_truth, vel_truth, acc_truth = truth
@@ -70,8 +74,9 @@ def plot_overlay(
     for row, (imu, gnss, fused, truth, ylab) in enumerate(datasets):
         for col, axis in enumerate(cols):
             ax = axes[row, col]
-            ax.plot(t_gnss, gnss[:, col], "k", label="Measured GNSS")
-            ax.plot(t_imu, imu[:, col], "c--", label="Measured IMU")
+            if include_measurements:
+                ax.plot(t_gnss, gnss[:, col], "k", label="Measured GNSS")
+                ax.plot(t_imu, imu[:, col], "c--", label="Measured IMU")
             if t_truth is not None and truth is not None:
                 ax.plot(t_truth, truth[:, col], "m-", label="Truth")
             ax.plot(t_fused, fused[:, col], "g:", label=f"Fused GNSS+IMU ({method})")
@@ -83,7 +88,11 @@ def plot_overlay(
                 ax.set_xlabel("Time [s]")
             ax.legend(loc="best")
 
-    fig.suptitle(f"{method} – {frame} Frame (Fused vs. Measured GNSS)")
+    if include_measurements:
+        title = f"{method} – {frame} Frame (Fused vs. Measured GNSS)"
+    else:
+        title = f"{method} – {frame} Frame (Fused vs. Truth)" if t_truth is not None else f"{method} – {frame} Frame (Fused)"
+    fig.suptitle(title)
     fig.tight_layout(rect=[0, 0, 1, 0.95])
     out_path = Path(out_dir) / f"{method}_{frame}{suffix}"
     fig.savefig(out_path)

--- a/src/run_all_methods.py
+++ b/src/run_all_methods.py
@@ -113,6 +113,11 @@ def main(argv=None):
         help="Skip plot generation for faster execution",
     )
     parser.add_argument(
+        "--fused-only",
+        action="store_true",
+        help="Forward --fused-only to Task 6 overlay plots",
+    )
+    parser.add_argument(
         "--task",
         type=int,
         help="Run a single helper task and exit",
@@ -261,6 +266,8 @@ def main(argv=None):
                     "--output",
                     "results",
                 ]
+                if args.fused_only:
+                    overlay_cmd.append("--fused-only")
                 with open(log_path, "a") as log:
                     log.write("\nTASK 6: Overlay fused output with truth\n")
                     proc = subprocess.Popen(

--- a/src/task6_plot_truth.py
+++ b/src/task6_plot_truth.py
@@ -38,6 +38,11 @@ def main() -> None:
         default="results",
         help="Directory for the generated PDFs",
     )
+    parser.add_argument(
+        "--fused-only",
+        action="store_true",
+        help="Hide IMU and GNSS measurements in the overlay plots",
+    )
     args = parser.parse_args()
 
     out_dir = Path(args.output)
@@ -192,6 +197,7 @@ def main() -> None:
             a_f,
             out_dir,
             truth,
+            include_measurements=not args.fused_only,
         )
 
         # Additional plot using raw STATE data without interpolation
@@ -211,18 +217,19 @@ def main() -> None:
                 t_g,
                 p_g,
                 v_g,
-                a_g,
-                t_f,
-                p_f,
-                v_f,
-                a_f,
-                out_dir,
-                t_truth=t_t,
-                pos_truth=p_t,
-                vel_truth=v_t,
-                acc_truth=a_t,
-                suffix="_overlay_state.pdf",
-            )
+            a_g,
+            t_f,
+            p_f,
+            v_f,
+            a_f,
+            out_dir,
+            t_truth=t_t,
+            pos_truth=p_t,
+            vel_truth=v_t,
+            acc_truth=a_t,
+            suffix="_overlay_state.pdf",
+            include_measurements=not args.fused_only,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_plot_overlay.py
+++ b/tests/test_plot_overlay.py
@@ -29,3 +29,33 @@ def test_plot_overlay_with_truth(tmp_path):
         acc_truth=acc,
     )
     assert (tmp_path / "TEST_ECEF_overlay_truth.pdf").exists()
+
+
+def test_plot_overlay_fused_only(tmp_path):
+    t = np.linspace(0, 1, 5)
+    pos = np.vstack([t, t, t]).T
+    vel = pos * 0
+    acc = pos * 0
+    plot_overlay(
+        "ECEF",
+        "TEST",
+        t,
+        pos,
+        vel,
+        acc,
+        t,
+        pos,
+        vel,
+        acc,
+        t,
+        pos,
+        vel,
+        acc,
+        tmp_path,
+        include_measurements=False,
+        t_truth=t,
+        pos_truth=pos,
+        vel_truth=vel,
+        acc_truth=acc,
+    )
+    assert (tmp_path / "TEST_ECEF_overlay_truth.pdf").exists()

--- a/tests/test_validate_with_truth.py
+++ b/tests/test_validate_with_truth.py
@@ -237,6 +237,7 @@ def test_overlay_truth_generation(tmp_path, monkeypatch):
             str(repo / "STATE_X001_small.txt"),
             "--output",
             str(Path("results")),
+            "--fused-only",
         ],
     )
     task6_main()


### PR DESCRIPTION
## Summary
- enhance `plot_overlay` with `include_measurements` parameter
- allow truth overlay plots to hide IMU/GNSS measurements via `--fused-only`
- forward new option from `run_all_methods.py`
- update tests for fused-only mode
- document fused-only overlay in README and plot summary

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68788a5b025c8325a7dfc6e3e437390c