### PR TITLE
Add README note on fused-only overlay title

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,8 @@ python src/task6_plot_truth.py --est-file results/IMU_X001_GNSS_X001_TRIAD_kf_ou
 ```
 
 Pass `--fused-only` to hide the IMU and GNSS measurements so only the fused
-trajectory and truth are shown.
+trajectory and truth are shown. The overlay title changes to **Fused vs. Truth**
+to make this distinction clear.
 
 ### Output
 


### PR DESCRIPTION
## Summary
- clarify that the truth overlay title becomes **Fused vs. Truth** when using `--fused-only`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68788dd37a2083258593e18de9256fb5