### PR TITLE
Prefix evaluation plots with dataset tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,9 @@ python src/run_all_methods.py --task 7
 
 ### Output:
 
-* Plots saved in `plots/task7/`
+* Plots saved in `plots/task7/` using filenames
+  `<tag>_residuals_position_velocity.pdf` and
+  `<tag>_attitude_angles_euler.pdf`
 
 ### Notes
 
@@ -321,7 +323,8 @@ python src/run_all_methods.py --config your_config.yml
 Running the script without `--config` processes the bundled example data sets.
 Task 6 (truth overlay) and Task 7 (evaluation) are performed automatically for
 each run and the additional figures are stored under `results/` and
-`results/task7/`.
+`results/task7/`.  Task 7 uses the dataset tag as a prefix so you will find
+files like `<tag>_residuals_position_velocity.pdf` inside that folder.
 
 
 #### run_all_datasets.py

--- a/src/run_all_methods.py
+++ b/src/run_all_methods.py
@@ -290,7 +290,7 @@ def main(argv=None):
                 buf = io.StringIO()
                 with redirect_stdout(buf):
                     try:
-                        run_evaluation_npz(str(npz_path), str(task7_dir))
+                        run_evaluation_npz(str(npz_path), str(task7_dir), tag)
                     except Exception as e:
                         print(f"Task 7 failed: {e}")
                 output = buf.getvalue()

--- a/tests/test_evaluate_filter_results.py
+++ b/tests/test_evaluate_filter_results.py
@@ -11,6 +11,6 @@ def test_run_evaluation_npz_mismatched_lengths(tmp_path):
     quat = np.tile([1.0, 0.0, 0.0, 0.0], (4, 1))
     f = tmp_path / "data.npz"
     np.savez(f, residual_pos=res_pos, residual_vel=res_vel, time_residuals=t, attitude_q=quat)
-    run_evaluation_npz(str(f), str(tmp_path))
-    assert (tmp_path / "residuals_position_velocity.pdf").exists()
-    assert (tmp_path / "attitude_angles_euler.pdf").exists()
+    run_evaluation_npz(str(f), str(tmp_path), tag="TEST")
+    assert (tmp_path / "TEST_residuals_position_velocity.pdf").exists()
+    assert (tmp_path / "TEST_attitude_angles_euler.pdf").exists()


### PR DESCRIPTION
## Summary
- allow evaluate_filter_results to add dataset tag prefix to output filenames
- propagate the tag from `run_all_methods.py`
- adjust unit test for new filenames
- document naming in Task 7 docs

## Testing
- `ruff check src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a019f4f508325871688ef24835de8