### PR TITLE
Add dataset-specific truth overlay names

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,8 @@ Typical result PDFs:
 - `task5_all_body.pdf` – Kalman filter results in body frame
 - `<method>_residuals.pdf` – position and velocity residuals
 - `<method>_attitude_angles.pdf` – attitude angles over time
-- `<method>_<frame>_overlay_truth.pdf` – fused output vs reference using `STATE_X001.txt` (e.g. `SVD_ecef_overlay_truth.pdf`)
+- `<tag>_<frame>_overlay_truth.pdf` – fused output vs reference (dataset tag is
+  derived from the estimator filename)
 
 ## Task 6: Truth Overlay
 
@@ -261,7 +262,8 @@ to make this distinction clear.
 
 ### Output
 
-* `<method>_<frame>_overlay_truth.pdf` – fused output vs reference
+* `<tag>_<frame>_overlay_truth.pdf` – fused output vs reference
+* `<tag>_task6_fused_truth_<frame>.pdf` – when `--fused-only` is used
 
 ## Task 7: Evaluation of Filter Results
 

--- a/docs/Python/Task6_Python.md
+++ b/docs/Python/Task6_Python.md
@@ -24,7 +24,9 @@ Task 5 output
 2. **Assemble Frames** – use :func:`assemble_frames` to align IMU, GNSS and truth
    data in NED, ECEF and body frames.
 3. **Generate Plots** – call :func:`plot_overlay` for each frame to save PDFs
-   named `<METHOD>_<FRAME>_overlay_truth.pdf` in the results directory.
+   named `<TAG>_<FRAME>_overlay_truth.pdf` in the results directory. With
+   ``--fused-only`` the filenames become
+   `<TAG>_task6_fused_truth_<frame>.pdf`.
 4. **State Comparison** – additionally plot the raw `STATE_X*.txt` trajectory
    using its original time vector. These files are saved as
    `<METHOD>_<FRAME>_overlay_state.pdf` and highlight any time offsets

--- a/src/plot_overlay.py
+++ b/src/plot_overlay.py
@@ -32,6 +32,7 @@ def plot_overlay(
     vel_truth: Optional[np.ndarray] = None,
     acc_truth: Optional[np.ndarray] = None,
     suffix: Optional[str] = None,
+    filename: Optional[str] = None,
     include_measurements: bool = True,
 ) -> None:
     """Save a 3x3 overlay plot comparing measured IMU, measured GNSS and
@@ -46,6 +47,10 @@ def plot_overlay(
         Filename suffix appended to ``"{method}_{frame}"`` when saving the
         figure. Defaults to ``"_overlay_truth.pdf"`` if any truth arrays are
         supplied and ``"_overlay.pdf"`` otherwise.
+    filename : str or None, optional
+        Full filename (relative to ``out_dir``) for the saved figure. When
+        provided, overrides the ``method``/``frame`` naming scheme and the
+        ``suffix`` parameter.
     include_measurements : bool, optional
         Plot measured IMU and GNSS series when ``True`` (default). When ``False``
         only the fused estimate and optional truth data are shown.
@@ -94,6 +99,9 @@ def plot_overlay(
         title = f"{method} – {frame} Frame (Fused vs. Truth)" if t_truth is not None else f"{method} – {frame} Frame (Fused)"
     fig.suptitle(title)
     fig.tight_layout(rect=[0, 0, 1, 0.95])
-    out_path = Path(out_dir) / f"{method}_{frame}{suffix}"
+    if filename is not None:
+        out_path = Path(out_dir) / filename
+    else:
+        out_path = Path(out_dir) / f"{method}_{frame}{suffix}"
     fig.savefig(out_path)
     plt.close(fig)

--- a/src/task6_plot_truth.py
+++ b/src/task6_plot_truth.py
@@ -39,6 +39,10 @@ def main() -> None:
         help="Directory for the generated PDFs",
     )
     parser.add_argument(
+        "--tag",
+        help="Dataset tag used as filename prefix. Defaults to the prefix of --est-file",
+    )
+    parser.add_argument(
         "--fused-only",
         action="store_true",
         help="Hide IMU and GNSS measurements in the overlay plots",
@@ -55,6 +59,7 @@ def main() -> None:
     imu_file = Path(f"{m.group(1)}.dat")
     gnss_file = Path(f"{m.group(2)}.csv")
     method = m.group(3)
+    tag = args.tag or f"{m.group(1)}_{m.group(2)}_{method}"
 
     est = load_estimate(str(est_path))
     frames = assemble_frames(est, imu_file, gnss_file, args.truth_file)
@@ -180,6 +185,11 @@ def main() -> None:
                 v_t = v_t * sign
                 a_t = a_t * sign
                 truth = (t_t, p_t, v_t, a_t)
+        name = (
+            f"{tag}_task6_fused_truth_{frame_name.lower()}.pdf"
+            if args.fused_only
+            else f"{tag}_{frame_name}_overlay_truth.pdf"
+        )
         plot_overlay(
             frame_name,
             method,
@@ -197,6 +207,7 @@ def main() -> None:
             a_f,
             out_dir,
             truth,
+            filename=name,
             include_measurements=not args.fused_only,
         )
 
@@ -207,16 +218,17 @@ def main() -> None:
             t_t = ensure_relative_time(t_t)
             if frame_name == "NED":
                 p_t = centre(p_t)
+        name_state = f"{tag}_{frame_name}_overlay_state.pdf"
         plot_overlay(
             frame_name,
             method,
             t_i,
             p_i,
-                v_i,
-                a_i,
-                t_g,
-                p_g,
-                v_g,
+            v_i,
+            a_i,
+            t_g,
+            p_g,
+            v_g,
             a_g,
             t_f,
             p_f,
@@ -227,7 +239,7 @@ def main() -> None:
             pos_truth=p_t,
             vel_truth=v_t,
             acc_truth=a_t,
-            suffix="_overlay_state.pdf",
+            filename=name_state,
             include_measurements=not args.fused_only,
         )
 

--- a/tests/test_plot_overlay.py
+++ b/tests/test_plot_overlay.py
@@ -59,3 +59,33 @@ def test_plot_overlay_fused_only(tmp_path):
         acc_truth=acc,
     )
     assert (tmp_path / "TEST_ECEF_overlay_truth.pdf").exists()
+
+
+def test_plot_overlay_custom_filename(tmp_path):
+    t = np.linspace(0, 1, 5)
+    pos = np.vstack([t, t, t]).T
+    vel = pos * 0
+    acc = pos * 0
+    plot_overlay(
+        "ECEF",
+        "TEST",
+        t,
+        pos,
+        vel,
+        acc,
+        t,
+        pos,
+        vel,
+        acc,
+        t,
+        pos,
+        vel,
+        acc,
+        tmp_path,
+        filename="custom.pdf",
+        t_truth=t,
+        pos_truth=pos,
+        vel_truth=vel,
+        acc_truth=acc,
+    )
+    assert (tmp_path / "custom.pdf").exists()


### PR DESCRIPTION
## Summary
- support custom output filename in `plot_overlay`
- add `--tag` flag to `task6_plot_truth.py`
- name truth overlay PDFs with dataset tag and add fused-only variant
- document new naming in README and Task 6 docs
- test custom filename path

## Testing
- `ruff check src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a1a4f7078832589d7d1130eb26ac2