### PR TITLE
Update Task7 output path in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,8 @@ python src/run_all_methods.py --task 7
 
 ### Output:
 
-* Plots saved in `plots/task7/` using filenames
+* When running `run_all_methods.py`, plots are stored in
+  `results/task7/<tag>/` as
   `<tag>_residuals_position_velocity.pdf` and
   `<tag>_attitude_angles_euler.pdf`
 
@@ -329,9 +330,10 @@ python src/run_all_methods.py --config your_config.yml
 
 Running the script without `--config` processes the bundled example data sets.
 Task 6 (truth overlay) and Task 7 (evaluation) are performed automatically for
-each run and the additional figures are stored under `results/` and
-`results/task7/`.  Task 7 uses the dataset tag as a prefix so you will find
-files like `<tag>_residuals_position_velocity.pdf` inside that folder.
+each run.  The additional figures are written to `results/` with the evaluation
+plots placed inside `results/task7/<tag>/`. Task 7 uses the dataset tag as a
+prefix, so you will find files like `<tag>_residuals_position_velocity.pdf`
+inside that folder.
 
 
 #### run_all_datasets.py


### PR DESCRIPTION
## Summary
- document that Task 7 plots from `run_all_methods.py` are saved under `results/task7/<tag>/`
- ensure consistent path references in the README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687a847113388325851b828f7f8e8c75