### PR TITLE
Fix time_s loading

### DIFF
--- a/src/validate_with_truth.py
+++ b/src/validate_with_truth.py
@@ -456,7 +456,7 @@ def load_estimate(path, times=None):
 
     if path.endswith(".npz"):
         data = np.load(path, allow_pickle=True)
-        t = pick_key(["time_residuals", "time"], data)
+        t = pick_key(["time_residuals", "time", "time_s"], data)
         if t is not None:
             t = np.asarray(t).squeeze()
         pos = pick_key(["fused_pos", "pos_ned", "pos"], data)
@@ -500,7 +500,7 @@ def load_estimate(path, times=None):
         }
     else:
         m = loadmat(path)
-        t = pick_key(["time_residuals", "time"], m)
+        t = pick_key(["time_residuals", "time", "time_s"], m)
         if t is not None:
             t = np.asarray(t).squeeze()
         pos = pick_key(["fused_pos", "pos_ned", "pos"], m)

--- a/tests/test_validate_with_truth.py
+++ b/tests/test_validate_with_truth.py
@@ -99,6 +99,25 @@ def test_load_estimate_alt_names(tmp_path, pos_key, vel_key):
     assert np.allclose(est["P"], data["P_hist"])
 
 
+def test_load_estimate_time_s(tmp_path):
+    np = pytest.importorskip("numpy")
+    scipy = pytest.importorskip("scipy.io")
+
+    data = {
+        "fused_pos": np.zeros((5, 3)),
+        "fused_vel": np.zeros((5, 3)),
+        "attitude_q": np.tile([1, 0, 0, 0], (5, 1)),
+        "time_s": np.linspace(0.0, 1.0, 5),
+    }
+
+    f = tmp_path / "est.mat"
+    scipy.savemat(f, data)
+
+    est = load_estimate(str(f))
+
+    assert np.allclose(est["time"], data["time_s"])
+
+
 def test_load_estimate_interpolation(tmp_path):
     np = pytest.importorskip("numpy")
     scipy = pytest.importorskip("scipy.io")


### PR DESCRIPTION
## Summary
- handle `time_s` when loading estimator files
- test loading `time_s` field

## Testing
- `ruff check src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a893345d483258f0a21c7b2ab5afb