### PR TITLE
Align Task 6 filenames and titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,8 +266,8 @@ to make this distinction clear.
 
 ### Output
 
-* `<tag>_<frame>_overlay_truth.pdf` – fused output vs reference
-* `<tag>_task6_fused_truth_<frame>.pdf` – when `--fused-only` is used
+* `<tag>_task6_<frame>_overlay_truth.pdf` – fused output vs reference
+* `<tag>_task6_<frame>_overlay_fused_truth.pdf` – when `--fused-only` is used
 
 ## Task 7: Evaluation of Filter Results
 

--- a/docs/Python/Task6_Python.md
+++ b/docs/Python/Task6_Python.md
@@ -24,12 +24,12 @@ Task 5 output
 2. **Assemble Frames** – use :func:`assemble_frames` to align IMU, GNSS and truth
    data in NED, ECEF and body frames.
 3. **Generate Plots** – call :func:`plot_overlay` for each frame to save PDFs
-   named `<TAG>_<FRAME>_overlay_truth.pdf` in the results directory. With
+   named `<TAG>_task6_<FRAME>_overlay_truth.pdf` in the results directory. With
    ``--fused-only`` the filenames become
-   `<TAG>_task6_fused_truth_<frame>.pdf`.
+   `<TAG>_task6_<frame>_overlay_fused_truth.pdf`.
 4. **State Comparison** – additionally plot the raw `STATE_X*.txt` trajectory
    using its original time vector. These files are saved as
-   `<METHOD>_<FRAME>_overlay_state.pdf` and highlight any time offsets
+   `<TAG>_task6_<FRAME>_overlay_state.pdf` and highlight any time offsets
    between the estimate and truth.
 
 ## Result

--- a/src/plot_overlay.py
+++ b/src/plot_overlay.py
@@ -94,9 +94,13 @@ def plot_overlay(
             ax.legend(loc="best")
 
     if include_measurements:
-        title = f"{method} – {frame} Frame (Fused vs. Measured GNSS)"
+        title = f"Task 6 – {method} – {frame} Frame (Fused vs. Measured GNSS)"
     else:
-        title = f"{method} – {frame} Frame (Fused vs. Truth)" if t_truth is not None else f"{method} – {frame} Frame (Fused)"
+        title = (
+            f"Task 6 – {method} – {frame} Frame (Fused vs. Truth)"
+            if t_truth is not None
+            else f"Task 6 – {method} – {frame} Frame (Fused)"
+        )
     fig.suptitle(title)
     fig.tight_layout(rect=[0, 0, 1, 0.95])
     if filename is not None:

--- a/src/task6_plot_truth.py
+++ b/src/task6_plot_truth.py
@@ -192,9 +192,9 @@ def main() -> None:
                 a_t = a_t * sign
                 truth = (t_t, p_t, v_t, a_t)
         name = (
-            f"{tag}_task6_fused_truth_{frame_name.lower()}.pdf"
+            f"{tag}_task6_{frame_name}_overlay_fused_truth.pdf"
             if args.fused_only
-            else f"{tag}_{frame_name}_overlay_truth.pdf"
+            else f"{tag}_task6_{frame_name}_overlay_truth.pdf"
         )
         plot_overlay(
             frame_name,
@@ -239,7 +239,7 @@ def main() -> None:
             t_t = ensure_relative_time(t_t)
             if frame_name == "NED":
                 p_t = centre(p_t)
-        name_state = f"{tag}_{frame_name}_overlay_state.pdf"
+        name_state = f"{tag}_task6_{frame_name}_overlay_state.pdf"
         plot_overlay(
             frame_name,
             method,


### PR DESCRIPTION
## Summary
- rename Task 6 overlay PDFs with `task6` prefix
- prepend "Task 6 –" to overlay figure titles
- update Task 6 documentation

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687bd8c2aff8832584a0aa101d7e3f40