### PR TITLE
Handle long attitude quaternions

### DIFF
--- a/src/evaluate_filter_results.py
+++ b/src/evaluate_filter_results.py
@@ -178,6 +178,9 @@ def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) ->
     else:
         n = len(t)
 
+    # Ensure attitude quaternion array matches the residual length
+    quat = quat[:n]
+
     mean_pos = res_pos.mean(axis=0)
     std_pos = res_pos.std(axis=0)
     mean_vel = res_vel.mean(axis=0)

--- a/tests/test_evaluate_filter_results.py
+++ b/tests/test_evaluate_filter_results.py
@@ -14,3 +14,16 @@ def test_run_evaluation_npz_mismatched_lengths(tmp_path):
     run_evaluation_npz(str(f), str(tmp_path), tag="TEST")
     assert (tmp_path / "TEST_residuals_position_velocity.pdf").exists()
     assert (tmp_path / "TEST_attitude_angles_euler.pdf").exists()
+
+
+def test_run_evaluation_npz_long_quaternion(tmp_path):
+    """Quaternion array longer than residual arrays should be truncated."""
+    res_pos = np.zeros((5, 3))
+    res_vel = np.ones((5, 3))
+    t = np.linspace(0, 1, 5)
+    quat = np.tile([1.0, 0.0, 0.0, 0.0], (7, 1))
+    f = tmp_path / "data_long_q.npz"
+    np.savez(f, residual_pos=res_pos, residual_vel=res_vel, time_residuals=t, attitude_q=quat)
+    run_evaluation_npz(str(f), str(tmp_path), tag="TESTQ")
+    assert (tmp_path / "TESTQ_residuals_position_velocity.pdf").exists()
+    assert (tmp_path / "TESTQ_attitude_angles_euler.pdf").exists()


### PR DESCRIPTION
## Summary
- ensure attitude quaternion array is truncated to the same length as residuals
- test that long quaternion arrays are handled when evaluating results

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bd8c6ff988325bb9b4b3635364620