### PR TITLE
Fix quaternion slicing in evaluation and add test

### DIFF
--- a/src/evaluate_filter_results.py
+++ b/src/evaluate_filter_results.py
@@ -177,6 +177,7 @@ def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) ->
         res_vel = res_vel[:n]
     else:
         n = len(t)
+    quat = quat[:n]
 
     mean_pos = res_pos.mean(axis=0)
     std_pos = res_pos.std(axis=0)

--- a/tests/test_evaluate_filter_results.py
+++ b/tests/test_evaluate_filter_results.py
@@ -14,3 +14,15 @@ def test_run_evaluation_npz_mismatched_lengths(tmp_path):
     run_evaluation_npz(str(f), str(tmp_path), tag="TEST")
     assert (tmp_path / "TEST_task7_residuals_position_velocity.pdf").exists()
     assert (tmp_path / "TEST_task7_attitude_angles_euler.pdf").exists()
+
+
+def test_run_evaluation_npz_quat_longer(tmp_path):
+    res_pos = np.zeros((5, 3))
+    res_vel = np.ones((5, 3))
+    t = np.linspace(0, 1, 5)
+    quat = np.tile([1.0, 0.0, 0.0, 0.0], (6, 1))
+    f = tmp_path / "data.npz"
+    np.savez(f, residual_pos=res_pos, residual_vel=res_vel, time_residuals=t, attitude_q=quat)
+    run_evaluation_npz(str(f), str(tmp_path), tag="TEST")
+    assert (tmp_path / "TEST_task7_residuals_position_velocity.pdf").exists()
+    assert (tmp_path / "TEST_task7_attitude_angles_euler.pdf").exists()


### PR DESCRIPTION
## Summary
- slice quaternion array when residual vectors are truncated
- test evaluate_filter_results with quaternion longer than residuals

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bdfd9ef2c832597c5cb35946aede3