### PR TITLE
Remove Task6 truth overlay generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,14 +246,13 @@ Typical result PDFs:
 - `<method>_attitude_angles.pdf` – attitude angles over time
 - `<tag>_<frame>_overlay_truth.pdf` – fused output vs reference (dataset tag is
   derived from the estimator filename)
-- `task6_<frame>_overlay_truth.pdf` – Task 6 overlay with GNSS and IMU
-- `task6_<frame>_overlay_fused_truth.pdf` – overlay of fused output only
+- `task6_<frame>_overlay_state.pdf` – Task 6 overlay with GNSS, IMU and raw state
 - `task7_residuals_position_velocity.pdf` – Task 7 position/velocity residuals
 - `task7_attitude_angles_euler.pdf` – Task 7 Euler angle plots
 
-## Task 6: Truth Overlay
+## Task 6: State Overlay
 
-This step recreates the Task 5 plots with the recorded reference trajectory added for comparison.
+This step recreates the Task 5 plots but overlays the fused trajectory with the raw `STATE_X` data.
 
 ### How to run
 
@@ -264,16 +263,13 @@ python src/task6_plot_truth.py --est-file results/IMU_X001_GNSS_X001_TRIAD_kf_ou
     --truth-file STATE_X001.txt --output results
 ```
 
-By default only the fused estimate and truth are plotted.  Pass
-`--show-measurements` to include the raw IMU and GNSS curves.  When truth data is
-provided the title always reads **Fused vs. Truth**.  Legends are consolidated
-below the figure and the truth acceleration curves are omitted when
-unavailable.
+Passing `--show-measurements` adds the raw IMU and GNSS curves.  The resulting
+figures are written as ``<tag>_task6_<frame>_overlay_state.pdf`` in the
+``results/`` directory.
 
 ### Output
 
-* `<tag>_task6_<frame>_overlay_truth.pdf` – fused output vs reference
-* `<tag>_task6_<frame>_overlay_measurements.pdf` – when `--show-measurements` is used
+* `<tag>_task6_<frame>_overlay_state.pdf` – fused output vs raw state file
 
 ## Task 7: Evaluation of Filter Results
 

--- a/docs/MATLAB/Task6_MATLAB.md
+++ b/docs/MATLAB/Task6_MATLAB.md
@@ -1,7 +1,7 @@
-# MATLAB Pipeline – Task 6 Truth Overlay
+# MATLAB Pipeline – Task 6 State Overlay
 
 `MATLAB/Task_6.m` visualises the Kalman filter output from Task 5 against the
-logged ground truth. It mirrors the Python implementation and uses the standard
+raw state trajectory. It mirrors the Python implementation and uses the standard
 legend names described in [PlottingChecklist](../PlottingChecklist.md).
 
 ## Overview
@@ -24,9 +24,8 @@ Task 5 output
    reference latitude, longitude and origin saved in the result file.
 3. **Interpolate** – align IMU, GNSS and truth samples on the filter time grid.
 4. **Plot** – call `plot_overlay` for the three frames which stores PDFs named
-   `<METHOD>_<FRAME>_overlay_truth.pdf` in `results/`. When truth data is
-   provided the title shows **Fused vs. Truth** and a single legend is placed
-   below the figure.
+   `<METHOD>_<FRAME>_overlay_state.pdf` in `results/`. The ``--show-measurements``
+   flag mirrors the Python implementation.
 
 ## Result
 

--- a/docs/Python/Task6_Python.md
+++ b/docs/Python/Task6_Python.md
@@ -1,8 +1,7 @@
-# Python Pipeline – Task 6 Truth Overlay
+# Python Pipeline – Task 6 State Overlay
 
-Task 6 visualises the Kalman filter output from Task 5 together with the known
-reference trajectory. The figures are identical to the Task 5 plots but include
-a black **Truth** line for direct comparison.
+Task 6 visualises the Kalman filter output from Task 5 together with the raw
+`STATE_X` trajectory. Only the ``*_overlay_state.pdf`` figures are produced.
 
 ## Overview
 
@@ -24,15 +23,8 @@ Task 5 output
 2. **Assemble Frames** – use :func:`assemble_frames` to align IMU, GNSS and truth
    data in NED, ECEF and body frames.
 3. **Generate Plots** – call :func:`plot_overlay` for each frame to save PDFs
-   named `<TAG>_task6_<FRAME>_overlay_truth.pdf` in the results directory.
-   The title indicates **Fused vs. Truth** whenever a reference trajectory is
-   supplied and a single legend is placed below the figure.  With
-   ``--show-measurements`` the IMU and GNSS measurements are included and the
-   filenames become `<TAG>_task6_<frame>_overlay_measurements.pdf`.
-4. **State Comparison** – additionally plot the raw `STATE_X*.txt` trajectory
-   using its original time vector. These files are saved as
-   `<TAG>_task6_<FRAME>_overlay_state.pdf` and highlight any time offsets
-   between the estimate and truth.
+   named `<TAG>_task6_<FRAME>_overlay_state.pdf` in the results directory.  The
+   ``--show-measurements`` flag adds the raw IMU and GNSS curves.
 
 ## Result
 

--- a/plot_summary.md
+++ b/plot_summary.md
@@ -15,8 +15,7 @@
 - **X001_TRIAD_attitude_angles.pdf**: Attitude angles over time
 - **<method>_<frame>_overlay_truth.pdf**: Fused results versus reference
 - **<method>_<frame>_overlay_state.pdf**: Fused results versus raw state file
-- **<tag>_task6_<frame>_overlay_truth.pdf**: Task 6 overlay with truth
-- **<tag>_task6_<frame>_overlay_fused_truth.pdf**: Fused-only overlay version
+- **<tag>_task6_<frame>_overlay_state.pdf**: Task 6 overlay using raw state data
 - **<tag>_task7_residuals_position_velocity.pdf**: Task 7 residuals
 - **<tag>_task7_attitude_angles_euler.pdf**: Task 7 attitude angles
 

--- a/src/diagnose_velocity.py
+++ b/src/diagnose_velocity.py
@@ -67,7 +67,7 @@ def main() -> None:
     print(f"Initial pos diff: {diff0}")
 
     # Interpolate truth to estimator time
-    pos_truth_i = np.vstack([np.interp(t_est, t_truth, pos_truth[:, i]) for i in range(3)]).T
+    _pos_truth_i = np.vstack([np.interp(t_est, t_truth, pos_truth[:, i]) for i in range(3)]).T  # noqa: F841
     vel_truth_i = np.vstack([np.interp(t_est, t_truth, vel_truth[:, i]) for i in range(3)]).T
 
     # Velocity diagnostics

--- a/src/task6_plot_truth.py
+++ b/src/task6_plot_truth.py
@@ -1,16 +1,19 @@
 #!/usr/bin/env python3
-"""Task 6 – Overlay fused results with the true trajectory.
+"""Task 6 – Overlay fused results with the raw state trajectory.
 
 This helper script loads the Kalman filter output from Task 5 together with
-the corresponding ground truth file and saves overlay figures in the same
-style as Task 5 but with the truth trajectory included. Plots and logs will
-be saved in ``results/``.
+the corresponding ground truth file and saves only ``*_overlay_state.pdf``
+figures showing the fused estimate versus the raw ``STATE_X`` data. Any
+legacy ``*_overlay_truth.pdf`` output is skipped. Plots and logs will be
+saved in ``results/``.
 """
 
 import argparse
 import re
 from pathlib import Path
 import time
+import glob
+import os
 
 from plot_overlay import plot_overlay
 from validate_with_truth import load_estimate, assemble_frames
@@ -55,6 +58,13 @@ def main() -> None:
 
     out_dir = Path(args.output)
     out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Remove any existing Task 6 truth overlay PDFs to avoid confusion
+    for f in glob.glob(str(out_dir / "*task6_*_truth.pdf")):
+        try:
+            os.remove(f)
+        except OSError:
+            pass
 
     est_path = Path(args.est_file)
     m = re.match(r"(IMU_\w+)_(GNSS_\w+)_([A-Za-z]+)_kf_output", est_path.stem)
@@ -191,31 +201,7 @@ def main() -> None:
                 v_t = v_t * sign
                 a_t = a_t * sign
                 truth = (t_t, p_t, v_t, a_t)
-        name = (
-            f"{tag}_task6_{frame_name}_overlay_truth.pdf"
-            if not args.show_measurements
-            else f"{tag}_task6_{frame_name}_overlay_measurements.pdf"
-        )
-        plot_overlay(
-            frame_name,
-            method,
-            t_i,
-            p_i,
-            v_i,
-            a_i,
-            t_g,
-            p_g,
-            v_g,
-            a_g,
-            t_f,
-            p_f,
-            v_f,
-            a_f,
-            out_dir,
-            truth,
-            filename=name,
-            include_measurements=args.show_measurements,
-        )
+        # Skip generation of legacy *overlay_truth.pdf figures
 
         if truth is not None:
             t_t, p_t, v_t, a_t = truth


### PR DESCRIPTION
## Summary
- remove production of `*_overlay_truth.pdf` in Task 6 script
- purge old Task 6 truth PDFs before plotting
- document that Task 6 now outputs only `*_overlay_state.pdf`
- update Python and MATLAB Task 6 docs accordingly
- fix ruff lint warning in `diagnose_velocity.py`

## Testing
- `ruff check src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cdb4d72f88325984d6d817ad04f7f