### PR TITLE
Improve truth velocity estimation

### DIFF
--- a/MATLAB/derive_velocity.m
+++ b/MATLAB/derive_velocity.m
@@ -1,0 +1,23 @@
+function vel = derive_velocity(time_s, pos, window_length, polyorder)
+%DERIVE_VELOCITY Estimate velocity using Savitzky-Golay smoothing.
+%
+% Usage:
+%   vel = derive_velocity(time_s, pos, window_length, polyorder)
+%
+% This is a MATLAB stub mirroring ``derive_velocity`` in
+% ``task6_plot_fused_trajectory.py``. It should smooth the input position
+% with a Savitzky-Golay filter and apply a central difference.
+%
+% TODO: implement full MATLAB version.
+
+if nargin < 3
+    window_length = 11;
+end
+if nargin < 4
+    polyorder = 2;
+end
+
+% Placeholder implementation
+vel = [zeros(1, size(pos,2)); diff(pos)./diff(time_s)];
+vel(1,:) = vel(2,:);
+end

--- a/src/task6_plot_fused_trajectory.py
+++ b/src/task6_plot_fused_trajectory.py
@@ -48,12 +48,30 @@ def ned_to_ecef(
     return pos_ecef, vel_ecef
 
 
-def derive_velocity(time_s: np.ndarray, pos: np.ndarray) -> np.ndarray:
-    """Numerically differentiate position to obtain velocity."""
+def derive_velocity(
+    time_s: np.ndarray,
+    pos: np.ndarray,
+    window_length: int = 11,
+    polyorder: int = 2,
+) -> np.ndarray:
+    """Estimate velocity from position.
+
+    The position is first smoothed with a Savitzky--Golay filter and then
+    differentiated using a central difference scheme.  ``window_length`` must be
+    odd.  ``polyorder`` controls the smoothing polynomial degree.
+    """
+
+    from scipy.signal import savgol_filter
+
+    if window_length % 2 == 0:
+        window_length += 1
+
+    pos_sm = savgol_filter(pos, window_length, polyorder, axis=0)
+    vel = np.zeros_like(pos_sm)
     dt = np.diff(time_s)
-    vel = np.zeros_like(pos)
-    vel[1:] = np.diff(pos, axis=0) / dt[:, None]
-    vel[0] = vel[1]
+    vel[1:-1] = (pos_sm[2:] - pos_sm[:-2]) / (dt[1:, None] + dt[:-1, None])
+    vel[0] = (pos_sm[1] - pos_sm[0]) / dt[0]
+    vel[-1] = (pos_sm[-1] - pos_sm[-2]) / dt[-1]
     return vel
 
 


### PR DESCRIPTION
## Summary
- use Savitzky–Golay smoothing and central differences when deriving truth velocity
- add MATLAB stub for `derive_velocity`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cdc6d2c5c8325b802d3ff87a644df