### PR TITLE
Task-6: keep only state overlay plots; styling clean-up

### DIFF
--- a/tests/test_plot_overlay.py
+++ b/tests/test_plot_overlay.py
@@ -28,7 +28,7 @@ def test_plot_overlay_with_truth(tmp_path):
         vel_truth=vel,
         acc_truth=acc,
     )
-    assert (tmp_path / "TEST_ECEF_overlay_truth.pdf").exists()
+    assert (tmp_path / "TEST_ECEF_overlay_state.pdf").exists()
 
 
 def test_plot_overlay_fused_only(tmp_path):
@@ -58,7 +58,7 @@ def test_plot_overlay_fused_only(tmp_path):
         vel_truth=vel,
         acc_truth=acc,
     )
-    assert (tmp_path / "TEST_ECEF_overlay_truth.pdf").exists()
+    assert (tmp_path / "TEST_ECEF_overlay_state.pdf").exists()
 
 
 def test_plot_overlay_custom_filename(tmp_path):

--- a/tests/test_validate_with_truth.py
+++ b/tests/test_validate_with_truth.py
@@ -233,11 +233,11 @@ def test_overlay_truth_generation(tmp_path, monkeypatch):
     validate_main()
 
     expected = {
-        "TRIAD_NED_overlay_truth.pdf",
-        "TRIAD_ECEF_overlay_truth.pdf",
-        "TRIAD_Body_overlay_truth.pdf",
+        "TRIAD_NED_overlay_state.pdf",
+        "TRIAD_ECEF_overlay_state.pdf",
+        "TRIAD_Body_overlay_state.pdf",
     }
-    produced = {p.name for p in Path("results").glob("*_overlay_truth.pdf")}
+    produced = {p.name for p in Path("results").glob("*_overlay_state.pdf")}
     assert expected.issubset(produced), f"Missing overlays: {expected - produced}"
 
     # verify raw STATE overlay generation via task6_plot_truth.py


### PR DESCRIPTION
## Summary
- drop legacy truth overlay filename in `plot_overlay`
- tighten legends, harmonise colours and y-limits
- save overlay plots as PDF and PNG
- update tests for new `_overlay_state` output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ce55003748325a9e16b9415351ef2