### PR TITLE
Add debug diagnostics for task6 overlay script

### DIFF
--- a/MATLAB/task6_overlay_plot.m
+++ b/MATLAB/task6_overlay_plot.m
@@ -2,11 +2,13 @@ function task6_overlay_plot(~)
 %TASK6_OVERLAY_PLOT  Stub for Task 6 overlay plotting in MATLAB.
 %
 % Usage:
-%   task6_overlay_plot(est_file, truth_file, method, frame, dataset)
+%   task6_overlay_plot(est_file, truth_file, method, frame, dataset, debug)
 %
 % This stub mirrors ``task6_overlay_plot.py``. It should load the fused
 % estimator output and ground truth, synchronise their time bases, and plot
 % position, velocity and acceleration overlays in either ECEF or NED frames.
+% If ``debug`` is true the function should print dataset diagnostics similar to
+% the Python implementation.
 %
 % TODO: implement MATLAB version matching the Python functionality.
 %

--- a/task6_overlay_plot.py
+++ b/task6_overlay_plot.py
@@ -4,12 +4,14 @@
 Usage:
     python task6_overlay_plot.py --est-file <fused_estimate.npz> \
         --truth-file <STATE_X001.txt> --method TRIAD --frame ECEF \
-        --dataset IMU_X002_GNSS_X002
+        --dataset IMU_X002_GNSS_X002 [--debug]
 
 This script synchronizes the time bases of the estimator output and ground
 truth, then generates a single figure with position, velocity and acceleration
 components overlaid. Only the fused estimate and truth are shown. The figure is
 saved to ``results/{DATASET}_{METHOD}_Task6_{FRAME}_Overlay.pdf`` and ``.png``.
+With ``--debug`` the script prints diagnostic information about the input
+datasets before plotting.
 """
 
 from __future__ import annotations
@@ -25,6 +27,7 @@ from scipy.interpolate import interp1d
 # ---------------------------------------------------------------------------
 # helper functions
 # ---------------------------------------------------------------------------
+
 
 def load_truth(path: Path, frame: str) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Load ground truth file ``STATE_X*.txt``.
@@ -88,13 +91,43 @@ def interpolate_truth(t_est: np.ndarray, t_truth: np.ndarray, arr: np.ndarray) -
     return f(t_est)
 
 
+def print_debug_info(
+    t_est: np.ndarray, vel_est: np.ndarray, t_truth: np.ndarray, vel_truth: np.ndarray
+) -> None:
+    """Print dataset statistics to aid alignment debugging."""
+    print(f"Length of fused velocity: {vel_est.shape}")
+    print(f"Length of truth velocity: {vel_truth.shape}")
+    print(f"Fused time range: {t_est[0]:.3f} to {t_est[-1]:.3f}")
+    print(f"Truth time range: {t_truth[0]:.3f} to {t_truth[-1]:.3f}")
+    print("First 5 fused velocity X:", vel_est[:5, 0])
+    print("First 5 truth velocity X:", vel_truth[:5, 0])
+    print("Last 5 fused velocity X:", vel_est[-5:, 0])
+    print("Last 5 truth velocity X:", vel_truth[-5:, 0])
+    dv_truth = np.diff(vel_truth[:, 0])
+    dv_est = np.diff(vel_est[:, 0])
+    print("Max velocity jump in truth (X):", np.max(np.abs(dv_truth)))
+    print("Max velocity jump in fused (X):", np.max(np.abs(dv_est)))
+
+
 # ---------------------------------------------------------------------------
 # plotting
 # ---------------------------------------------------------------------------
 
-def plot_overlay(t_est: np.ndarray, pos_est: np.ndarray, vel_est: np.ndarray, acc_est: np.ndarray,
-                 t_truth: np.ndarray, pos_truth: np.ndarray, vel_truth: np.ndarray, acc_truth: np.ndarray,
-                 frame: str, method: str, dataset: str, out_dir: Path) -> Path:
+
+def plot_overlay(
+    t_est: np.ndarray,
+    pos_est: np.ndarray,
+    vel_est: np.ndarray,
+    acc_est: np.ndarray,
+    t_truth: np.ndarray,
+    pos_truth: np.ndarray,
+    vel_truth: np.ndarray,
+    acc_truth: np.ndarray,
+    frame: str,
+    method: str,
+    dataset: str,
+    out_dir: Path,
+) -> Path:
     """Create the overlay plot and save it to ``out_dir``."""
     labels = ["X", "Y", "Z"] if frame == "ECEF" else ["N", "E", "D"]
     colors = ["#377eb8", "#e41a1c", "#4daf4a"]  # colorblind friendly
@@ -132,14 +165,18 @@ def plot_overlay(t_est: np.ndarray, pos_est: np.ndarray, vel_est: np.ndarray, ac
 # main entry point
 # ---------------------------------------------------------------------------
 
+
 def main() -> None:
-    ap = argparse.ArgumentParser(description="Generate Task 6 overlay plot of fused estimate vs truth")
+    ap = argparse.ArgumentParser(
+        description="Generate Task 6 overlay plot of fused estimate vs truth"
+    )
     ap.add_argument("--est-file", required=True, help="fused estimator .npz file")
     ap.add_argument("--truth-file", required=True, help="ground truth STATE_X file")
     ap.add_argument("--method", required=True, help="estimation method name")
     ap.add_argument("--frame", choices=["ECEF", "NED"], default="ECEF", help="reference frame")
     ap.add_argument("--dataset", required=True, help="dataset identifier for filename")
     ap.add_argument("--output-dir", default="results", help="directory for saved figure")
+    ap.add_argument("--debug", action="store_true", help="print dataset diagnostics")
     args = ap.parse_args()
 
     est_path = Path(args.est_file)
@@ -148,6 +185,11 @@ def main() -> None:
 
     t_est, pos_est, vel_est, acc_est = load_estimate(est_path, args.frame)
     t_truth, pos_truth, vel_truth, acc_truth = load_truth(truth_path, args.frame)
+
+    if args.debug:
+        print_debug_info(t_est, vel_est, t_truth, vel_truth)
+        if len(t_est) != len(t_truth):
+            print(f"WARNING: time vector lengths differ (est {len(t_est)}, truth {len(t_truth)})")
 
     pos_truth_i = interpolate_truth(t_est, t_truth, pos_truth)
     vel_truth_i = interpolate_truth(t_est, t_truth, vel_truth)


### PR DESCRIPTION
## Summary
- extend `task6_overlay_plot.py` with optional `--debug` flag
- print dataset statistics when enabled to help diagnose time misalignments
- update MATLAB `task6_overlay_plot.m` stub for parity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dc6a9a80883259d8d82e0be20ef2f