### PR TITLE
Improve velocity diagnostics frame handling

### DIFF
--- a/MATLAB/diagnose_velocity.m
+++ b/MATLAB/diagnose_velocity.m
@@ -1,7 +1,7 @@
-function diagnose_velocity(est_file, truth_file, imu_file, gnss_file, output_dir)
+function diagnose_velocity(est_file, truth_file, imu_file, gnss_file, frame, output_dir)
 %DIAGNOSE_VELOCITY  Stub for velocity diagnostics in MATLAB.
 %
-%   diagnose_velocity(EST_FILE, TRUTH_FILE, IMU_FILE, GNSS_FILE, OUTPUT_DIR)
+%   diagnose_velocity(EST_FILE, TRUTH_FILE, IMU_FILE, GNSS_FILE, FRAME, OUTPUT_DIR)
 %   is the MATLAB counterpart of the Python diagnose_velocity script.
 %   It is currently a placeholder and not implemented.
 %
@@ -9,7 +9,7 @@ function diagnose_velocity(est_file, truth_file, imu_file, gnss_file, output_dir
 %
 %See also: DIAGNOSE_VELOCITY.PY
 
-if nargin < 5
+if nargin < 6
     output_dir = 'results';
 end
 


### PR DESCRIPTION
## Summary
- add `--frame` option to `diagnose_velocity.py` and load all data in the chosen reference frame
- update MATLAB stub for `diagnose_velocity` to keep arguments in sync

## Testing
- `ruff check src/diagnose_velocity.py`
- `pytest -q tests/test_assemble_frames.py::test_assemble_frames_with_truth tests/test_plot_overlay.py::test_plot_overlay_with_truth -q`

------
https://chatgpt.com/codex/tasks/task_e_687deedba8ac8325a6d738ba647935e6