### PR TITLE
Improve velocity diagnostics script

### DIFF
--- a/MATLAB/diagnose_velocity.m
+++ b/MATLAB/diagnose_velocity.m
@@ -5,6 +5,8 @@ function diagnose_velocity(est_file, truth_file, imu_file, gnss_file, frame, out
 %   is the MATLAB counterpart of the Python diagnose_velocity script.
 %   It is currently a placeholder and not implemented.
 %
+%   The Python implementation trims quaternion and time vectors to the
+%   shortest length when they differ.
 %   See diagnose_velocity.py for the full logic.
 %
 %See also: DIAGNOSE_VELOCITY.PY


### PR DESCRIPTION
## Summary
- handle quaternion/time vector mismatch in `diagnose_velocity.py`
- interpolate truth attitude to estimator time
- document trimming in MATLAB stub

## Testing
- `pytest -q`
- `pytest tests/test_plot_overlay.py::test_plot_overlay_with_truth -q`


------
https://chatgpt.com/codex/tasks/task_e_687e01631d8c8325b0b2e23470a9a65c