### PR TITLE
Add ECEF velocity residual diagnostics

### DIFF
--- a/MATLAB/diagnose_velocity.m
+++ b/MATLAB/diagnose_velocity.m
@@ -6,7 +6,8 @@ function diagnose_velocity(est_file, truth_file, imu_file, gnss_file, frame, out
 %   It is currently a placeholder and not implemented.
 %
 %   The Python implementation trims quaternion and time vectors to the
-%   shortest length when they differ.
+%   shortest length when they differ and prints mean/std/RMSE velocity
+%   residuals in the ECEF frame.
 %   See diagnose_velocity.py for the full logic.
 %
 %See also: DIAGNOSE_VELOCITY.PY

--- a/src/diagnose_velocity.py
+++ b/src/diagnose_velocity.py
@@ -96,7 +96,15 @@ def main() -> None:
     vel_error = vel_est - vel_truth_i
     vel_rmse = float(np.sqrt(np.mean(np.sum(vel_error**2, axis=1))))
     final_vel_err = float(np.linalg.norm(vel_error[-1]))
+    mean_vel_err = np.mean(vel_error, axis=0)
+    std_vel_err = np.std(vel_error, axis=0)
+    rmse_vec = np.sqrt(np.mean(vel_error**2, axis=0))
     print(f"Velocity RMSE: {vel_rmse:.3f} m/s, Final error: {final_vel_err:.3f} m/s")
+    print("Mean velocity residuals (ECEF):", mean_vel_err)
+    print("Std velocity residuals (ECEF):", std_vel_err)
+    print("RMSE velocity residuals (ECEF):", rmse_vec)
+    print("Final fused ECEF velocity:", vel_est[-1])
+    print("Final truth ECEF velocity:", vel_truth_i[-1])
 
     # Plots
     labels = ["X", "Y", "Z"]


### PR DESCRIPTION
## Summary
- compute mean/std/RMSE of velocity residuals in `diagnose_velocity.py`
- document the new analysis capability in the MATLAB stub

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e28a93c488325bad42a6aaa81f1f0