### PR TITLE
Add configurable velocity noise and ZUPT thresholds

### DIFF
--- a/MATLAB/GNSS_IMU_Fusion_single.m
+++ b/MATLAB/GNSS_IMU_Fusion_single.m
@@ -1,18 +1,33 @@
-function S = GNSS_IMU_Fusion_single(imu_file, gnss_file)
+function S = GNSS_IMU_Fusion_single(imu_file, gnss_file, vel_q_scale, vel_r, zupt_acc_var, zupt_gyro_var)
 %GNSS_IMU_FUSION_SINGLE  Run the five-task pipeline for one dataset.
-%   S = GNSS_IMU_FUSION_SINGLE(IMU_FILE, GNSS_FILE) resolves the dataset
+%   S = GNSS_IMU_FUSION_SINGLE(IMU_FILE, GNSS_FILE, VEL_Q_SCALE, VEL_R, ...
+%       ZUPT_ACC_VAR, ZUPT_GYRO_VAR) resolves the dataset
 %   paths using GET_DATA_FILE and sequentially executes Task_1 through
 %   Task_5 using the TRIAD method.  The Task 5 result structure is loaded
 %   from <IMU>_<GNSS>_TRIAD_task5_results.mat and returned.
 %
 %   Default files IMU_X001.dat and GNSS_X001.csv are used when the
-%   arguments are omitted.
+%   arguments are omitted. Additional parameters allow tuning of the
+%   velocity process/measurement noise and ZUPT detection thresholds.
+%   Currently these values are not used inside the function.
 
 if nargin < 1 || isempty(imu_file)
     imu_file = 'IMU_X001.dat';
 end
 if nargin < 2 || isempty(gnss_file)
     gnss_file = 'GNSS_X001.csv';
+end
+if nargin < 3 || isempty(vel_q_scale)
+    vel_q_scale = 10;
+end
+if nargin < 4 || isempty(vel_r)
+    vel_r = 0.25;
+end
+if nargin < 5 || isempty(zupt_acc_var)
+    zupt_acc_var = 0.01;
+end
+if nargin < 6 || isempty(zupt_gyro_var)
+    zupt_gyro_var = 1e-6;
 end
 
 imu_path  = get_data_file(imu_file);


### PR DESCRIPTION
## Summary
- expose velocity process/measurement noise and ZUPT thresholds as CLI options
- apply those options when constructing the Kalman Filter
- allow MATLAB stub to accept the same parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e3f8ff714832585842d7827e5d128