### PR TITLE
Add dedicated SVD/Davenport run helpers

### DIFF
--- a/MATLAB/run_davenport_only.m
+++ b/MATLAB/run_davenport_only.m
@@ -1,0 +1,3 @@
+%% RUN_DAVENPORT_ONLY  Run all datasets using the Davenport method
+% Thin wrapper around run_method_only('Davenport').
+run_method_only('Davenport');

--- a/MATLAB/run_svd_only.m
+++ b/MATLAB/run_svd_only.m
@@ -1,0 +1,3 @@
+%% RUN_SVD_ONLY  Run all datasets using the SVD method
+% This is a small wrapper around run_method_only('SVD').
+run_method_only('SVD');

--- a/README.md
+++ b/README.md
@@ -393,6 +393,10 @@ python src/run_method_only.py --method SVD
 run_method_only('SVD')
 ```
 
+Dedicated wrappers `run_svd_only.py` and `run_davenport_only.py` mirror
+`run_triad_only.py` for the SVD and Davenport methods.  MATLAB users can
+call `run_svd_only` or `run_davenport_only` for the same behaviour.
+
 
 After all runs complete you can compare the datasets side by side:
 

--- a/src/run_davenport_only.py
+++ b/src/run_davenport_only.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""Run all datasets using only the Davenport initialisation method.
+
+This script simply calls ``run_method_only.py --method Davenport`` and
+passes through any extra command line arguments.
+"""
+from run_method_only import main
+import sys
+
+if __name__ == "__main__":
+    main(["--method", "Davenport", *sys.argv[1:]])

--- a/src/run_svd_only.py
+++ b/src/run_svd_only.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""Run all datasets using only the SVD initialisation method.
+
+This is a thin wrapper around ``run_method_only.py --method SVD``. Any
+additional command line arguments are forwarded to ``run_method_only``.
+"""
+from run_method_only import main
+import sys
+
+if __name__ == "__main__":
+    main(["--method", "SVD", *sys.argv[1:]])


### PR DESCRIPTION
## Summary
- add Python wrappers `run_svd_only.py` and `run_davenport_only.py`
- add MATLAB wrappers `run_svd_only.m` and `run_davenport_only.m`
- document the new helpers in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f4a3bf3448325b5f1f7e6a75334f5