### PR TITLE
Implement MATLAB derive_velocity and parity test

### DIFF
--- a/MATLAB/derive_velocity.m
+++ b/MATLAB/derive_velocity.m
@@ -1,14 +1,21 @@
 function vel = derive_velocity(time_s, pos, window_length, polyorder)
-%DERIVE_VELOCITY Estimate velocity using Savitzky-Golay smoothing.
+%DERIVE_VELOCITY Estimate velocity from position measurements.
 %
 % Usage:
 %   vel = derive_velocity(time_s, pos, window_length, polyorder)
 %
-% This is a MATLAB stub mirroring ``derive_velocity`` in
-% ``velocity_utils.py``. It should smooth the input position
-% with a Savitzky-Golay filter and apply a central difference.
+% Inputs
+%   time_s       - Nx1 vector of time stamps [s]
+%   pos          - Nx3 matrix of positions [m]
+%   window_length - (optional) odd window length for smoothing
+%   polyorder     - (optional) polynomial order for smoothing
 %
-% TODO: implement full MATLAB version.
+% Output
+%   vel          - Nx3 matrix of velocity [m/s]
+%
+% The implementation mirrors ``src/velocity_utils.py::derive_velocity``.
+% The position is smoothed with a Savitzky-Golay filter and then
+% differentiated using a central difference scheme.
 
 if nargin < 3
     window_length = 11;
@@ -17,7 +24,58 @@ if nargin < 4
     polyorder = 2;
 end
 
-% Placeholder implementation
-vel = [zeros(1, size(pos,2)); diff(pos)./diff(time_s)];
-vel(1,:) = vel(2,:);
+if mod(window_length, 2) == 0
+    window_length = window_length + 1;
+end
+
+time_s = time_s(:);
+N = numel(time_s);
+if size(pos, 1) ~= N
+    error('time_s and pos must have the same number of rows');
+end
+
+half = floor(window_length / 2);
+pos_sm = zeros(size(pos));
+
+coeff = savgol_coeffs(window_length, polyorder);
+for col = 1:size(pos, 2)
+    pos_sm(:, col) = conv(pos(:, col), coeff, 'same');
+    % fit polynomial to edges like scipy.signal.savgol_filter(mode="interp")
+    p_left = polyfit(0:window_length-1, pos(1:window_length, col).', polyorder);
+    for k = 1:half
+        pos_sm(k, col) = polyval(p_left, k - 1);
+    end
+    p_right = polyfit(0:window_length-1, pos(end-window_length+1:end, col).', polyorder);
+    for k = 1:half
+        pos_sm(end-half+k, col) = polyval(p_right, window_length - half + k - 1);
+    end
+end
+
+vel = zeros(size(pos_sm));
+dt = diff(time_s);
+vel(2:end-1, :) = (pos_sm(3:end, :) - pos_sm(1:end-2, :)) ./ (dt(2:end) + dt(1:end-1));
+vel(1, :) = (pos_sm(2, :) - pos_sm(1, :)) / dt(1);
+vel(end, :) = (pos_sm(end, :) - pos_sm(end-1, :)) / dt(end);
+end
+
+function coeff = savgol_coeffs(window_length, polyorder)
+    if polyorder >= window_length
+        error('polyorder must be less than window_length');
+    end
+    half = floor(window_length / 2);
+    if mod(window_length, 2) == 0
+        pos = half - 0.5;
+    else
+        pos = half;
+    end
+    x = (-pos:window_length - pos - 1);
+    x = fliplr(x);
+    A = zeros(polyorder + 1, window_length);
+    for k = 0:polyorder
+        A(k + 1, :) = x .^ k;
+    end
+    y = zeros(polyorder + 1, 1);
+    y(1) = 1;
+    coeff = pinv(A) * y;
+    coeff = coeff(:).';
 end

--- a/src/velocity_utils.py
+++ b/src/velocity_utils.py
@@ -13,9 +13,25 @@ def derive_velocity(
 ) -> np.ndarray:
     """Estimate velocity from position.
 
-    The position is first smoothed with a Savitzky--Golay filter and then
+    Parameters
+    ----------
+    time_s : ndarray of shape (N,)
+        Time samples in seconds.
+    pos : ndarray of shape (N, 3)
+        Position samples in meters (ECEF or NED).
+    window_length : int, optional
+        Odd window length for Savitzky--Golay smoothing.
+    polyorder : int, optional
+        Polynomial order for the smoothing filter.
+
+    Returns
+    -------
+    ndarray of shape (N, 3)
+        Estimated velocity in m/s.
+
+    The position is smoothed with a Savitzky--Golay filter and then
     differentiated using a central difference scheme. ``window_length`` must be
-    odd. ``polyorder`` controls the smoothing polynomial degree.
+    odd.
     """
     if window_length % 2 == 0:
         window_length += 1

--- a/tests/test_derive_velocity_matlab.py
+++ b/tests/test_derive_velocity_matlab.py
@@ -1,0 +1,34 @@
+import subprocess
+import shutil
+
+import pytest
+
+
+def test_matlab_derive_velocity_parity(tmp_path):
+    octave = shutil.which("octave")
+    if not octave:
+        pytest.skip("Octave not available")
+
+    np = pytest.importorskip("numpy")
+    spio = pytest.importorskip("scipy.io")
+
+    from src.velocity_utils import derive_velocity as py_derive_velocity
+
+    t = np.linspace(0.0, 10.0, 101)
+    pos = np.stack((np.sin(t), np.cos(t), t), axis=1)
+    input_mat = tmp_path / "input.mat"
+    output_mat = tmp_path / "out.mat"
+    spio.savemat(input_mat, {"time_s": t[:, None], "pos": pos})
+
+    cmd = (
+        f"addpath('MATLAB'); data=load('{input_mat}'); "
+        f"vel=derive_velocity(data.time_s, data.pos); "
+        f"save('-mat7-binary', '{output_mat}', 'vel');"
+    )
+    subprocess.run([octave, "--quiet", "--eval", cmd], check=True)
+
+    vel_matlab = spio.loadmat(output_mat)["vel"]
+    vel_py = py_derive_velocity(t, pos)
+
+    assert np.allclose(vel_matlab, vel_py, atol=1e-6)
+


### PR DESCRIPTION
## Summary
- implement MATLAB/derive_velocity.m using Savitzky-Golay smoothing and central difference
- document shapes and units in derive_velocity implementations
- add Python test comparing MATLAB and Python results

## Testing
- `ruff check src/velocity_utils.py tests/test_derive_velocity_matlab.py`
- `pytest -k derive_velocity_matlab -q`

------
https://chatgpt.com/codex/tasks/task_e_6880dacc522c8325929b64a0fd6b6c3f