### PR TITLE
Update derive_velocity implementations

### DIFF
--- a/MATLAB/derive_velocity.m
+++ b/MATLAB/derive_velocity.m
@@ -2,11 +2,12 @@ function vel = derive_velocity(time_s, pos, window_length, polyorder)
 %DERIVE_VELOCITY  Estimate velocity from a position trajectory.
 %
 %   vel = DERIVE_VELOCITY(time_s, pos, window_length, polyorder) smooths the
-%   input ``pos`` using a Savitzky--Golay filter and differentiates with a
-%   central difference scheme. ``time_s`` is a Nx1 vector of timestamps in
-%   seconds and ``pos`` is Nx3. ``window_length`` must be odd and defaults to 11
-%   while ``polyorder`` defaults to 2. The implementation mirrors
-%   ``velocity_utils.derive_velocity`` in the Python codebase.
+%   Nx3 position array ``pos`` (metres) using a Savitzky--Golay filter and
+%   differentiates it with a central difference scheme. ``time_s`` is an Nx1
+%   vector of timestamps in seconds. ``window_length`` specifies the filter
+%   window length (samples) and must be odd; ``polyorder`` sets the polynomial
+%   order. The returned ``vel`` is Nx3 in metres per second. This implementation
+%   mirrors ``velocity_utils.derive_velocity`` in the Python codebase.
 
 if nargin < 3 || isempty(window_length)
     window_length = 11;

--- a/src/velocity_utils.py
+++ b/src/velocity_utils.py
@@ -11,8 +11,26 @@ def derive_velocity(
     window_length: int = 11,
     polyorder: int = 2,
 ) -> np.ndarray:
-    """Estimate velocity from position.
+    """Estimate velocity from position samples.
 
+    Parameters
+    ----------
+    time_s : ndarray of shape (N,)
+        Sample timestamps in **seconds**.
+    pos : ndarray of shape (N, 3)
+        Position in **metres**.
+    window_length : int, optional
+        Savitzky--Golay filter window length (samples). Must be odd.
+    polyorder : int, optional
+        Polynomial order for the Savitzky--Golay filter.
+
+    Returns
+    -------
+    ndarray of shape (N, 3)
+        Estimated velocity in **m/s**.
+
+    Notes
+    -----
     The position is first smoothed with a Savitzky--Golay filter and then
     differentiated using a central difference scheme. ``window_length`` must be
     odd. ``polyorder`` controls the smoothing polynomial degree.

--- a/tests/test_derive_velocity.py
+++ b/tests/test_derive_velocity.py
@@ -1,0 +1,34 @@
+import subprocess
+import shutil
+import pytest
+import scipy.io
+
+np = pytest.importorskip("numpy")
+pytest.importorskip("scipy")
+
+from src.velocity_utils import derive_velocity
+
+
+def test_derive_velocity_matlab_parity(tmp_path):
+    matlab = shutil.which("matlab")
+    if not matlab:
+        pytest.skip("MATLAB not available")
+
+    t = np.linspace(0, 5, 51)
+    pos = np.vstack([np.sin(t), np.cos(t), t**2]).T
+
+    expected = derive_velocity(t, pos)
+
+    in_mat = tmp_path / "in.mat"
+    out_mat = tmp_path / "out.mat"
+    scipy.io.savemat(in_mat, {"time_s": t, "pos": pos})
+    cmd = (
+        f"load('{in_mat}');"
+        f"vel = derive_velocity(time_s, pos);"
+        f"save('{out_mat}', 'vel');"
+    )
+    subprocess.run([matlab, "-batch", cmd], check=True)
+    data = scipy.io.loadmat(out_mat)
+    matlab_vel = data["vel"]
+
+    assert np.allclose(matlab_vel, expected)


### PR DESCRIPTION
## Summary
- document shapes and units for `derive_velocity` in Python and MATLAB
- keep Python and MATLAB outputs consistent
- add a parity test for velocity derivation

## Testing
- `ruff check src/velocity_utils.py tests/test_derive_velocity.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880dfd86660832585c1044fb59c9fbc