### PR TITLE
Make run_triad_only MATLAB only

### DIFF
--- a/MATLAB/run_triad_only.m
+++ b/MATLAB/run_triad_only.m
@@ -1,70 +1,13 @@
-%% RUN_TRIAD_ONLY  Run all datasets using the TRIAD method and validate results
-% This MATLAB script mirrors run_triad_only.py. It calls the Python batch
-% processor with the TRIAD method and then validates the generated MAT files
-% against the reference STATE_X*.txt logs when available.
-%
-% The script attempts to locate a Python interpreter using ``pyenv``.  If
-% Python is not loaded it tries ``python3`` then ``python``.  When no
-% interpreter can be found a helpful message is printed.
+%% RUN_TRIAD_ONLY  Run all datasets using the TRIAD method (MATLAB pipeline)
+% This script mirrors ``run_triad_only.py`` but executes the batch
+% processing purely in MATLAB via ``run_all_datasets_matlab``.
+% All figures and MAT files are written to ``results/`` and Task 6 is
+% invoked automatically when matching ``STATE_X*.txt`` logs are present.
 %
 % Usage:
 %   run_triad_only
-%
-% All .mat files are written to the 'results' folder in the repository root.
-% When a matching STATE_<id>.txt exists the script invokes
-% validate_with_truth.py for the dataset.
 
-here = fileparts(mfilename('fullpath'));
-root = fileparts(here);
+% Simply forward to the MATLAB batch runner. This enumerates all datasets,
+% runs Tasks 1--5 and triggers Task 6 when truth files exist.
+run_all_datasets_matlab();
 
-% Initialise the Python environment. Try python3 then python if not loaded.
-py = pyenv;
-if py.Status == "NotLoaded"
-    try
-        py = pyenv("Version", "python3");
-    catch
-        try
-            py = pyenv("Version", "python");
-        catch
-            fprintf('No usable Python interpreter found. Install Python 3 and configure pyenv to point to your installation.\n');
-            return;
-        end
-    end
-end
-
-%% -- Run the Python batch processor ---------------------------------------
-py_script = fullfile(root, 'src', 'run_all_datasets.py');
-cmd = sprintf('"%s" "%s" --method TRIAD', py.Executable, py_script);
-status = system(cmd);
-if status ~= 0
-    error('run_all_datasets.py failed');
-end
-
-%% -- Validate each result when ground truth is available ------------------
-results_dir = fullfile(pwd, 'results');
-mat_files = dir(fullfile(results_dir, '*_TRIAD_kf_output.mat'));
-
-for k = 1:numel(mat_files)
-    name = mat_files(k).name;
-    tokens = regexp(name, '^IMU_(X\d+)_.*_TRIAD_kf_output\.mat$', 'tokens');
-    if isempty(tokens)
-        continue
-    end
-    ds = tokens{1}{1};
-    truth_file = fullfile(root, ['STATE_' ds '.txt']);
-    if ~isfile(truth_file)
-        continue
-    end
-    validate_py = fullfile(root, 'src', 'validate_with_truth.py');
-    first = readmatrix(truth_file, 'CommentStyle', '#');
-    r0 = first(1,3:5);
-    [lat_deg, lon_deg, ~] = ecef_to_geodetic(r0(1), r0(2), r0(3));
-    vcmd = sprintf(['"%s" "%s" --est-file "%s" --truth-file "%s" --output "%s" ' ...
-        '--ref-lat %.8f --ref-lon %.8f --ref-r0 %.3f %.3f %.3f'], ...
-        py.Executable, validate_py, fullfile(results_dir, name), truth_file, results_dir, ...
-        lat_deg, lon_deg, r0(1), r0(2), r0(3));
-    vstatus = system(vcmd);
-    if vstatus ~= 0
-        warning('Validation failed for %s', name);
-    end
-end

--- a/README.md
+++ b/README.md
@@ -374,11 +374,12 @@ python src/run_triad_only.py
 ```matlab
 run_triad_only
 ```
-This is equivalent to running `python src/run_all_datasets.py --method TRIAD`.
-The script also validates the fused trajectory against the common
-`STATE_X001.txt` file and writes an extended summary to
-`results/summary_truth.csv`. The table now includes acceleration RMSE,
-final and maximum errors.
+The MATLAB version now calls `run_all_datasets_matlab` so it does not
+require Python. Both scripts generate the same output as running
+`python src/run_all_datasets.py --method TRIAD` and validate the fused
+trajectory against the common `STATE_X001.txt` file. The extended
+summary is written to `results/summary_truth.csv` and includes
+acceleration RMSE, final and maximum errors.
 
 #### run_method_only.py
 


### PR DESCRIPTION
## Summary
- run_triad_only.m now invokes run_all_datasets_matlab instead of Python
- clarify README that the MATLAB wrapper no longer requires Python

## Testing
- `pip install -e .[tests]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e9b504c48325b4611261f288c8b9