### PR TITLE
Add MATLAB variant of run_all_methods

### DIFF
--- a/src/process_data.m
+++ b/src/process_data.m
@@ -1,0 +1,26 @@
+function result = process_data(data, method)
+%PROCESS_DATA Run GNSS/IMU fusion for a single dataset.
+%   RESULT = PROCESS_DATA(DATA, METHOD) calls GNSS_IMU_Fusion to execute
+%   the MATLAB pipeline. The resulting Task 5 MAT file is loaded and key
+%   arrays are returned in RESULT.
+
+if nargin < 2
+    method = 'TRIAD';
+end
+
+GNSS_IMU_Fusion(data.imu_file, data.gnss_file, method);
+
+pair_tag = [erase(data.imu_file,'.dat') '_' erase(data.gnss_file,'.csv')];
+mat_file = fullfile('results', sprintf('%s_%s_task5_results.mat', pair_tag, method));
+if exist(mat_file,'file')
+    S = load(mat_file);
+    result.time = (0:size(S.x_log,2)-1).';
+    result.fused_pos = S.x_log(1:3,:).';
+    result.fused_vel = S.vel_log.';
+    result.gnss_pos = S.gnss_pos_ned;
+    result.gnss_vel = S.gnss_vel_ned;
+else
+    warning('Result file not found: %s', mat_file);
+    result = struct();
+end
+end

--- a/src/read_data.m
+++ b/src/read_data.m
@@ -1,0 +1,19 @@
+function data = read_data(imu_file, gnss_file)
+%READ_DATA Load IMU and GNSS measurements.
+%   DATA = READ_DATA(IMU_FILE, GNSS_FILE) returns a struct with the raw
+%   IMU matrix and GNSS table. This mirrors the Python helper function used
+%   in run_all_methods.py.
+
+if nargin < 1
+    error('IMU file required');
+end
+if nargin < 2
+    error('GNSS file required');
+end
+
+data.imu_file = imu_file;
+data.gnss_file = gnss_file;
+
+data.imu  = readmatrix(imu_file);
+data.gnss = readtable(gnss_file);
+end

--- a/src/run_all_methods.m
+++ b/src/run_all_methods.m
@@ -1,0 +1,67 @@
+function run_all_methods(varargin)
+%RUN_ALL_METHODS  MATLAB equivalent of run_all_methods.py
+%   RUN_ALL_METHODS() processes all default IMU/GNSS pairs with the
+%   attitude initialisation methods TRIAD, SVD and Davenport. Results are
+%   saved under the 'results' directory and a summary table is written to
+%   results/summary.csv.
+%
+%   This is a simplified translation of the Python script
+%   ``src/run_all_methods.py`` and does not yet implement YAML config
+%   parsing or the optional overlay/evaluation steps.
+%
+%   Example:
+%       run_all_methods
+%
+%   Optional name/value pairs:
+%       'config'           - YAML configuration file (not implemented)
+%       'no_plots'         - true to skip plotting
+%       'show_measurements'- include measurements in overlay plots
+
+% Default datasets and methods
+DATASETS = {
+    'IMU_X001.dat', 'GNSS_X001.csv';
+    'IMU_X002.dat', 'GNSS_X002.csv';
+    'IMU_X003.dat', 'GNSS_X002.csv';
+};
+METHODS = {'TRIAD','SVD','Davenport'};
+
+p = inputParser;
+addParameter(p,'config','',@ischar);
+addParameter(p,'no_plots',false,@islogical);
+addParameter(p,'show_measurements',false,@islogical);
+parse(p,varargin{:});
+cfg_file = p.Results.config; %#ok<NASGU>
+
+if ~exist('results','dir')
+    mkdir('results');
+end
+
+summary = {};
+for i = 1:size(DATASETS,1)
+    imu_file  = DATASETS{i,1};
+    gnss_file = DATASETS{i,2};
+    for j = 1:numel(METHODS)
+        method = METHODS{j};
+        tag = sprintf('%s_%s_%s', erase(imu_file,'.dat'), erase(gnss_file,'.csv'), method);
+        fprintf('>> %s\n', tag);
+        data = read_data(imu_file, gnss_file);
+        result = process_data(data, method);
+        save_results(result, tag);
+        if isfield(result,'fused_pos') && isfield(result,'gnss_pos')
+            err = result.fused_pos - result.gnss_pos;
+            rmse_pos = sqrt(mean(sum(err.^2,2)));
+            final_pos = norm(err(end,:));
+        else
+            rmse_pos = NaN;
+            final_pos = NaN;
+        end
+        summary(end+1,:) = {imu_file, method, rmse_pos, final_pos}; %#ok<AGROW>
+    end
+end
+
+T = cell2table(summary, 'VariableNames', {'Dataset','Method','RMSEpos_m','EndErr_m'});
+writetable(T, fullfile('results','summary.csv'));
+
+fprintf('\n');
+disp(T);
+end

--- a/src/save_results.m
+++ b/src/save_results.m
@@ -1,0 +1,11 @@
+function save_results(result, tag)
+%SAVE_RESULTS Persist result structure to the results directory.
+%   SAVE_RESULTS(RESULT, TAG) writes RESULT to results/<TAG>_summary.mat.
+
+if isempty(result)
+    return;
+end
+outfile = fullfile('results', sprintf('%s_summary.mat', tag));
+if ~exist('results','dir'); mkdir('results'); end
+save(outfile, '-struct', 'result');
+end


### PR DESCRIPTION
## Summary
- implement a MATLAB edition of `run_all_methods` in `src/`
- add small helper functions `read_data`, `process_data` and `save_results`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f22e553483258712073f917cc8ca