### PR TITLE
Add Task 7 fused vs truth error scripts

### DIFF
--- a/MATLAB/task7_plot_error_fused_vs_truth.m
+++ b/MATLAB/task7_plot_error_fused_vs_truth.m
@@ -1,0 +1,52 @@
+function task7_plot_error_fused_vs_truth(fused_file, truth_file, output_dir)
+%TASK7_PLOT_ERROR_FUSED_VS_TRUTH  Plot velocity error between fused result and truth.
+%
+%   TASK7_PLOT_ERROR_FUSED_VS_TRUTH(FUSED_FILE, TRUTH_FILE, OUTPUT_DIR) loads
+%   the fused estimator output in FUSED_FILE and the reference trajectory in
+%   TRUTH_FILE. The difference ``FUSED - Truth`` is computed for each velocity
+%   component and plotted over time. The figure is saved as both PDF and PNG
+%   under OUTPUT_DIR.
+%
+%   Corresponds to src/task7_plot_error_fused_vs_truth.py
+%
+%   Usage:
+%       task7_plot_error_fused_vs_truth('fused_results.mat', ...
+%           'truth_results.mat', 'results');
+
+if nargin < 3 || isempty(output_dir)
+    output_dir = 'results';
+end
+if ~exist(output_dir, 'dir'); mkdir(output_dir); end
+
+F = load(fused_file);
+T = load(truth_file);
+
+time = F.time_s(:);
+if isfield(F, 'vel_ned_ms')
+    vel_f = F.vel_ned_ms;
+else
+    vel_f = [F.vx(:), F.vy(:), F.vz(:)];
+end
+if isfield(T, 'vel_ned_ms')
+    vel_t = T.vel_ned_ms;
+else
+    vel_t = [T.vx(:), T.vy(:), T.vz(:)];
+end
+
+err = vel_f - vel_t;
+
+f = figure('Visible','off');
+plot(time, err(:,1), 'r', time, err(:,2), 'g', time, err(:,3), 'b');
+legend({'Error X','Error Y','Error Z'}, 'Location','best');
+xlabel('Time [s]');
+ylabel('Velocity Error [m/s]');
+title('Task 7.1: FUSED - Truth Velocity Error');
+grid on; box on;
+set(f,'PaperPositionMode','auto');
+
+pdf = fullfile(output_dir, 'task7_fused_vs_truth_error.pdf');
+png = fullfile(output_dir, 'task7_fused_vs_truth_error.png');
+print(f, pdf, '-dpdf');
+print(f, png, '-dpng');
+close(f);
+end

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Typical result PDFs:
 - `task6_<frame>_overlay_state.pdf` – Task 6 overlay with GNSS, IMU and raw state
 - `task7_residuals_position_velocity.pdf` – Task 7 position/velocity residuals
 - `task7_attitude_angles_euler.pdf` – Task 7 Euler angle plots
+- `task7_fused_vs_truth_error.pdf` – Task 7 fused minus truth velocity error
 
 ## Task 6: State Overlay
 
@@ -292,6 +293,8 @@ python src/run_all_methods.py --task 7
   `results/task7/<tag>/` as
   `<tag>_task7_residuals_position_velocity.pdf` and
   `<tag>_task7_attitude_angles_euler.pdf`
+* The helper script `src/task7_plot_error_fused_vs_truth.py` produces
+  `task7_fused_vs_truth_error.pdf` showing the fused minus truth velocity error.
 
 ### Notes
 

--- a/src/task7_plot_error_fused_vs_truth.py
+++ b/src/task7_plot_error_fused_vs_truth.py
@@ -1,0 +1,88 @@
+"""Task 7.1: Investigate Error Between FUSED and Truth.
+
+Usage:
+    python src/task7_plot_error_fused_vs_truth.py --fused fused_results.npz \
+        --truth truth_results.npz --output-dir results
+
+This script computes the velocity error ``FUSED - Truth`` for each
+component and plots the error over time. The resulting figure is saved
+as both PDF and PNG under the output directory.
+
+Corresponds to MATLAB/task7_plot_error_fused_vs_truth.m
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def load_npz(path: Path) -> dict[str, np.ndarray]:
+    """Load a NumPy ``.npz`` archive as a dictionary."""
+    data = np.load(path)
+    return {k: data[k] for k in data.files}
+
+
+def plot_error(time: np.ndarray, err: np.ndarray, out_dir: Path) -> None:
+    """Plot velocity error components and save the figure."""
+    labels = ["X", "Y", "Z"]
+    plt.figure(figsize=(8, 4))
+    for i, lab in enumerate(labels):
+        plt.plot(time, err[:, i], label=f"Error {lab}")
+    plt.xlabel("Time [s]")
+    plt.ylabel("Velocity Error [m/s]")
+    plt.title("Task 7.1: FUSED - Truth Velocity Error")
+    plt.legend()
+    plt.grid(True)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    pdf = out_dir / "task7_fused_vs_truth_error.pdf"
+    png = out_dir / "task7_fused_vs_truth_error.png"
+    plt.savefig(pdf)
+    plt.savefig(png)
+    plt.close()
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fused", type=Path, required=True, help="fused .npz file")
+    parser.add_argument("--truth", type=Path, required=True, help="truth .npz file")
+    parser.add_argument("--output-dir", type=Path, default=Path("results"))
+    args = parser.parse_args(argv)
+
+    fused = load_npz(args.fused)
+    truth = load_npz(args.truth)
+
+    time = fused.get("time")
+    if time is None:
+        time = fused.get("time_s")
+    if time is None:
+        raise KeyError("Missing 'time' or 'time_s' in fused file")
+
+    vx = fused.get("vx")
+    vy = fused.get("vy")
+    vz = fused.get("vz")
+    if vx is None or vy is None or vz is None:
+        vel = fused.get("vel_ned_ms")
+        if vel is None:
+            raise KeyError("Missing velocity components in fused file")
+        vx, vy, vz = vel[:, 0], vel[:, 1], vel[:, 2]
+
+    tvx = truth.get("vx")
+    tvy = truth.get("vy")
+    tvz = truth.get("vz")
+    if tvx is None or tvy is None or tvz is None:
+        vel_t = truth.get("vel_ned_ms")
+        if vel_t is None:
+            raise KeyError("Missing velocity components in truth file")
+        tvx, tvy, tvz = vel_t[:, 0], vel_t[:, 1], vel_t[:, 2]
+
+    err = np.column_stack((vx - tvx, vy - tvy, vz - tvz))
+
+    plot_error(time, err, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python script `task7_plot_error_fused_vs_truth.py` to compute and plot fused minus truth velocity error
- add MATLAB equivalent `task7_plot_error_fused_vs_truth.m`
- document new output plot in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f4e0c18c832582323d0ddc453b67