### PR TITLE
Fix TRUTH_PATH in run_method_only

### DIFF
--- a/src/run_method_only.py
+++ b/src/run_method_only.py
@@ -34,7 +34,9 @@ ROOT = HERE.parent
 logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
-TRUTH_PATH = HERE / "STATE_X001.txt"
+# Use the project root for locating the common truth file so the script works
+# regardless of the current working directory.
+TRUTH_PATH = ROOT / "STATE_X001.txt"
 EXPECTED_LAT = -32.026554
 
 


### PR DESCRIPTION
## Summary
- correct the `STATE_X001.txt` location for `run_method_only.py`
- clarify comment about using project root

## Testing
- `./scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880fed8000c83258faae6700ee865a0