### PR TITLE
Remove Python dependency from MATLAB batch scripts

### DIFF
--- a/MATLAB/run_all_datasets_matlab.m
+++ b/MATLAB/run_all_datasets_matlab.m
@@ -1,10 +1,14 @@
-function run_all_datasets_matlab()
+function run_all_datasets_matlab(method)
 %RUN_ALL_DATASETS_MATLAB  Pure MATLAB batch runner for all datasets
-%   Enumerates the IMU/GNSS pairs in the repository and executes
-%   Task_1 through Task_5 for the TRIAD method. The final Task 5
-%   results are saved as <IMU>_<GNSS>_TRIAD_kf_output.mat in the
-%   results directory. plot_results is called on each file to
-%   recreate the standard figures.
+%   RUN_ALL_DATASETS_MATLAB(METHOD) enumerates the IMU/GNSS pairs in the
+%   repository and executes Task_1 through Task_5 for the provided
+%   initialisation METHOD.  The final Task 5 results are saved as
+%   <IMU>_<GNSS>_<METHOD>_kf_output.mat in the results directory.
+%   plot_results is called on each file to recreate the standard figures.
+
+if nargin < 1 || isempty(method)
+    method = 'TRIAD';
+end
 
 here = fileparts(mfilename('fullpath'));
 root = fileparts(here);
@@ -36,18 +40,18 @@ for k = 1:size(pairs,1)
 
     fprintf('Processing %s with %s...\n', pairs{k,1}, pairs{k,2});
 
-    Task_1(imu, gnss, 'TRIAD');
-    Task_2(imu, gnss, 'TRIAD');
-    Task_3(imu, gnss, 'TRIAD');
-    Task_4(imu, gnss, 'TRIAD');
-    Task_5(imu, gnss, 'TRIAD');
+    Task_1(imu, gnss, method);
+    Task_2(imu, gnss, method);
+    Task_3(imu, gnss, method);
+    Task_4(imu, gnss, method);
+    Task_5(imu, gnss, method);
 
     [~, imuStem, ~]  = fileparts(pairs{k,1});
     [~, gnssStem, ~] = fileparts(pairs{k,2});
-    task5File = fullfile(resultsDir, sprintf('%s_%s_TRIAD_task5_results.mat', ...
-        imuStem, gnssStem));
-    outFile  = fullfile(resultsDir, sprintf('%s_%s_TRIAD_kf_output.mat', ...
-        imuStem, gnssStem));
+    task5File = fullfile(resultsDir, sprintf('%s_%s_%s_task5_results.mat', ...
+        imuStem, gnssStem, method));
+    outFile  = fullfile(resultsDir, sprintf('%s_%s_%s_kf_output.mat', ...
+        imuStem, gnssStem, method));
     if isfile(task5File)
         S = load(task5File);
         save(outFile, '-struct', 'S');
@@ -61,7 +65,7 @@ for k = 1:size(pairs,1)
         end
         if isfile(cand)
             try
-                Task_6(imu, gnss, 'TRIAD');
+                Task_6(imu, gnss, method);
             catch ME
                 fprintf('Task_6 skipped: %s\n', ME.message);
             end

--- a/MATLAB/run_method_only.m
+++ b/MATLAB/run_method_only.m
@@ -1,6 +1,7 @@
 %% RUN_METHOD_ONLY  Run all datasets with a chosen initialisation method
-% Mirrors run_method_only.py. The script sets up Python using pyenv and
-% invokes the Python helper with the desired method.
+% Pure MATLAB implementation mirroring ``run_method_only.py``. The helper
+% forwards the selected METHOD to ``run_all_datasets_matlab`` so no Python
+% interpreter is required.
 %
 % Usage:
 %   run_method_only                % defaults to 'TRIAD'
@@ -13,28 +14,5 @@ if nargin < 1 || isempty(method)
     method = 'TRIAD';
 end
 
-here = fileparts(mfilename('fullpath'));
-root = fileparts(here);
-
-py = pyenv;
-if py.Status == "NotLoaded"
-    try
-        py = pyenv("Version", "python3");
-    catch
-        try
-            py = pyenv("Version", "python");
-        catch
-            fprintf(['No usable Python interpreter found. Install Python 3 and ' ...
-                'configure pyenv to point to your installation.\n']);
-            return;
-        end
-    end
-end
-
-py_script = fullfile(root, 'src', 'run_method_only.py');
-cmd = sprintf('"%s" "%s" --method %s', py.Executable, py_script, method);
-status = system(cmd);
-if status ~= 0
-    error('run_method_only.py failed');
-end
+run_all_datasets_matlab(method);
 end

--- a/MATLAB/run_triad_only.m
+++ b/MATLAB/run_triad_only.m
@@ -9,5 +9,5 @@
 
 % Simply forward to the MATLAB batch runner. This enumerates all datasets,
 % runs Tasks 1--5 and triggers Task 6 when truth files exist.
-run_all_datasets_matlab();
+run_all_datasets_matlab('TRIAD');
 

--- a/README.md
+++ b/README.md
@@ -386,9 +386,11 @@ acceleration RMSE, final and maximum errors.
 
 #### run_method_only.py
 
-`run_method_only.py` extends the helper above with a selectable method.
-It reuses the dataset list from `run_all_datasets.py` and prints the same
-summary table. Call it directly or via the MATLAB wrapper:
+`run_method_only.py` extends the helper above with a selectable method and
+prints the same summary table as `run_triad_only.py`.  The MATLAB function
+`run_method_only` now mirrors this behaviour purely within MATLAB by calling
+`run_all_datasets_matlab` with the chosen method.  No Python interpreter is
+required for the MATLAB workflow:
 
 ```bash
 python src/run_method_only.py --method SVD

--- a/Report/getting_started.md
+++ b/Report/getting_started.md
@@ -53,7 +53,7 @@ The results and validation plots appear inside the newly created `results/` fold
    ```matlab
    run_triad_only
    % or
-   run_all_datasets_matlab
+   run_all_datasets_matlab('TRIAD')
    ```
    MATLAB saves the figures to the `results/` folder as well.
 

--- a/docs/AdvancedTopics.md
+++ b/docs/AdvancedTopics.md
@@ -75,9 +75,9 @@ Task_5(imu, gnss, 'TRIAD');   % uses Task4 results, writes Task5_results_IMU_X00
 
 ### MATLAB-only pipeline
 ```matlab
-run_all_datasets_matlab
+run_all_datasets_matlab('TRIAD')
 ```
-The script scans `Data/` (or the repository root if that folder is missing) for matching IMU and GNSS logs, executes `Task_1` through `Task_5` for each pair and saves the results as `IMU_<id>_GNSS_<id>_TRIAD_kf_output.mat` in `results/`. `plot_results` is invoked automatically to export the standard PDF figures.
+The function accepts the initialisation method as an optional argument. It scans `Data/` (or the repository root if that folder is missing) for matching IMU and GNSS logs, executes `Task_1` through `Task_5` for each pair and saves the results as `IMU_<id>_GNSS_<id>_<METHOD>_kf_output.mat` in `results/`. `plot_results` is invoked automatically to export the standard PDF figures.
 
 Prerequisites: MATLAB R2023a or newer with the Signal Processing and Navigation Toolboxes.
 


### PR DESCRIPTION
## Summary
- update `run_all_datasets_matlab` to accept a method argument
- make `run_method_only` a pure MATLAB wrapper
- call `run_all_datasets_matlab('TRIAD')` from `run_triad_only`
- document MATLAB-only usage in README and docs

## Testing
- `pip install -e .[tests]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688103dbf0e08325879fc36745b2c5a7