### PR TITLE
Fix MATLAB wrappers and remove Python dependency

### DIFF
--- a/MATLAB/run_all_datasets_matlab.m
+++ b/MATLAB/run_all_datasets_matlab.m
@@ -1,13 +1,18 @@
-function run_all_datasets_matlab()
+function run_all_datasets_matlab(method)
 %RUN_ALL_DATASETS_MATLAB  Pure MATLAB batch runner for all datasets
-%   Enumerates the IMU/GNSS pairs in the repository and executes
-%   Task_1 through Task_5 for the TRIAD method. The final Task 5
-%   results are saved as <IMU>_<GNSS>_TRIAD_kf_output.mat in the
-%   results directory. plot_results is called on each file to
-%   recreate the standard figures.
+%   RUN_ALL_DATASETS_MATLAB(METHOD) enumerates the IMU/GNSS pairs in the
+%   repository and executes Task_1 through Task_5 for the selected
+%   attitude initialisation METHOD (``'TRIAD'`` by default). The final Task 5
+%   results are saved as <IMU>_<GNSS>_<METHOD>_kf_output.mat in the results
+%   directory. ``plot_results`` is called on each file to recreate the standard
+%   figures.
 
 here = fileparts(mfilename('fullpath'));
 root = fileparts(here);
+
+if nargin < 1 || isempty(method)
+    method = 'TRIAD';
+end
 
 % Prefer a dedicated Data folder if present
 dataDir = fullfile(root, 'Data');
@@ -34,20 +39,20 @@ for k = 1:size(pairs,1)
     if ~isfile(imu);  imu  = get_data_file(pairs{k,1});  end
     if ~isfile(gnss); gnss = get_data_file(pairs{k,2}); end
 
-    fprintf('Processing %s with %s...\n', pairs{k,1}, pairs{k,2});
+    fprintf('Processing %s with %s using %s...\n', pairs{k,1}, pairs{k,2}, method);
 
-    Task_1(imu, gnss, 'TRIAD');
-    Task_2(imu, gnss, 'TRIAD');
-    Task_3(imu, gnss, 'TRIAD');
-    Task_4(imu, gnss, 'TRIAD');
-    Task_5(imu, gnss, 'TRIAD');
+    Task_1(imu, gnss, method);
+    Task_2(imu, gnss, method);
+    Task_3(imu, gnss, method);
+    Task_4(imu, gnss, method);
+    Task_5(imu, gnss, method);
 
     [~, imuStem, ~]  = fileparts(pairs{k,1});
     [~, gnssStem, ~] = fileparts(pairs{k,2});
-    task5File = fullfile(resultsDir, sprintf('%s_%s_TRIAD_task5_results.mat', ...
-        imuStem, gnssStem));
-    outFile  = fullfile(resultsDir, sprintf('%s_%s_TRIAD_kf_output.mat', ...
-        imuStem, gnssStem));
+    task5File = fullfile(resultsDir, sprintf('%s_%s_%s_task5_results.mat', ...
+        imuStem, gnssStem, method));
+    outFile  = fullfile(resultsDir, sprintf('%s_%s_%s_kf_output.mat', ...
+        imuStem, gnssStem, method));
     if isfile(task5File)
         S = load(task5File);
         save(outFile, '-struct', 'S');
@@ -61,7 +66,7 @@ for k = 1:size(pairs,1)
         end
         if isfile(cand)
             try
-                Task_6(imu, gnss, 'TRIAD');
+                Task_6(imu, gnss, method);
             catch ME
                 fprintf('Task_6 skipped: %s\n', ME.message);
             end

--- a/MATLAB/run_davenport_only.m
+++ b/MATLAB/run_davenport_only.m
@@ -1,3 +1,4 @@
-%% RUN_DAVENPORT_ONLY  Run all datasets using the Davenport method
-% Thin wrapper around run_method_only('Davenport').
-run_method_only('Davenport');
+%% RUN_DAVENPORT_ONLY  Run all datasets using the Davenport method (MATLAB pipeline)
+% This mirrors ``run_davenport_only.py`` but processes the data purely in
+% MATLAB by forwarding the Davenport method to ``run_all_datasets_matlab``.
+run_all_datasets_matlab('Davenport');

--- a/MATLAB/run_method_only.m
+++ b/MATLAB/run_method_only.m
@@ -1,6 +1,7 @@
 %% RUN_METHOD_ONLY  Run all datasets with a chosen initialisation method
-% Mirrors run_method_only.py. The script sets up Python using pyenv and
-% invokes the Python helper with the desired method.
+% This now mirrors ``run_method_only.py`` using the pure MATLAB pipeline.
+% The selected METHOD is forwarded to ``run_all_datasets_matlab`` so no
+% external Python interpreter is required.
 %
 % Usage:
 %   run_method_only                % defaults to 'TRIAD'
@@ -13,28 +14,5 @@ if nargin < 1 || isempty(method)
     method = 'TRIAD';
 end
 
-here = fileparts(mfilename('fullpath'));
-root = fileparts(here);
-
-py = pyenv;
-if py.Status == "NotLoaded"
-    try
-        py = pyenv("Version", "python3");
-    catch
-        try
-            py = pyenv("Version", "python");
-        catch
-            fprintf(['No usable Python interpreter found. Install Python 3 and ' ...
-                'configure pyenv to point to your installation.\n']);
-            return;
-        end
-    end
-end
-
-py_script = fullfile(root, 'src', 'run_method_only.py');
-cmd = sprintf('"%s" "%s" --method %s', py.Executable, py_script, method);
-status = system(cmd);
-if status ~= 0
-    error('run_method_only.py failed');
-end
+run_all_datasets_matlab(method);
 end

--- a/MATLAB/run_svd_only.m
+++ b/MATLAB/run_svd_only.m
@@ -1,3 +1,4 @@
-%% RUN_SVD_ONLY  Run all datasets using the SVD method
-% This is a small wrapper around run_method_only('SVD').
-run_method_only('SVD');
+%% RUN_SVD_ONLY  Run all datasets using the SVD method (MATLAB pipeline)
+% Mirrors ``run_svd_only.py`` but relies entirely on MATLAB by calling
+% ``run_all_datasets_matlab`` with the SVD initialisation method.
+run_all_datasets_matlab('SVD');

--- a/MATLAB/run_triad_only.m
+++ b/MATLAB/run_triad_only.m
@@ -9,5 +9,5 @@
 
 % Simply forward to the MATLAB batch runner. This enumerates all datasets,
 % runs Tasks 1--5 and triggers Task 6 when truth files exist.
-run_all_datasets_matlab();
+run_all_datasets_matlab('TRIAD');
 

--- a/README.md
+++ b/README.md
@@ -398,8 +398,10 @@ run_method_only('SVD')
 ```
 
 Dedicated wrappers `run_svd_only.py` and `run_davenport_only.py` mirror
-`run_triad_only.py` for the SVD and Davenport methods.  MATLAB users can
-call `run_svd_only` or `run_davenport_only` for the same behaviour.
+`run_triad_only.py` for the SVD and Davenport methods.  The MATLAB
+counterparts now forward the chosen method to `run_all_datasets_matlab`
+so the entire pipeline runs without Python.  Invoke `run_svd_only` or
+`run_davenport_only` for the same behaviour.
 
 
 After all runs complete you can compare the datasets side by side:


### PR DESCRIPTION
## Summary
- run MATLAB batch processing without needing Python
- parameterise MATLAB `run_all_datasets_matlab` to accept the method
- update convenience scripts and documentation

## Testing
- `pytest -q tests/test_utils.py`
- `pytest -q tests/test_alignment.py`


------
https://chatgpt.com/codex/tasks/task_e_688104087fb08325beb8405c171eb38a