### PR TITLE
Update wrappers to use run_all_methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ run_triad_only
 ```
 The MATLAB version now calls `run_all_datasets_matlab` so it does not
 require Python. Both scripts generate the same output as running
-`python src/run_all_datasets.py --method TRIAD` and validate the fused
+`python src/run_all_methods.py --methods TRIAD` and validate the fused
 trajectory against the common `STATE_X001.txt` file. The extended
 summary is written to `results/summary_truth.csv` and includes
 acceleration RMSE, final and maximum errors.
@@ -389,8 +389,10 @@ acceleration RMSE, final and maximum errors.
 `run_method_only.py` extends the helper above with a selectable method and
 prints the same summary table as `run_triad_only.py`.  The MATLAB function
 `run_method_only` now mirrors this behaviour purely within MATLAB by calling
-`run_all_datasets_matlab` with the chosen method.  No Python interpreter is
-required for the MATLAB workflow:
+`run_all_datasets_matlab` with the chosen method.  The Python version
+forwards the method to `run_all_methods.py` so no direct calls to
+`run_all_datasets.py` are needed. No Python interpreter is required for the
+MATLAB workflow:
 
 ```bash
 python src/run_method_only.py --method SVD
@@ -400,8 +402,9 @@ run_method_only('SVD')
 ```
 
 Dedicated wrappers `run_svd_only.py` and `run_davenport_only.py` mirror
-`run_triad_only.py` for the SVD and Davenport methods.  MATLAB users can
-call `run_svd_only` or `run_davenport_only` for the same behaviour.
+`run_triad_only.py` for the SVD and Davenport methods.  Each forwards the
+chosen method to `run_all_methods.py`.  MATLAB users can call `run_svd_only`
+or `run_davenport_only` for the same behaviour.
 
 
 After all runs complete you can compare the datasets side by side:

--- a/src/run_all_methods.py
+++ b/src/run_all_methods.py
@@ -110,6 +110,15 @@ def main(argv=None):
         help="YAML file specifying datasets and methods",
     )
     parser.add_argument(
+        "--datasets",
+        default="ALL",
+        help="Comma separated dataset IDs (e.g. X001,X002) or ALL",
+    )
+    parser.add_argument(
+        "--methods",
+        help="Comma separated attitude initialisation methods or ALL",
+    )
+    parser.add_argument(
         "--no-plots",
         action="store_true",
         help="Skip plot generation for faster execution",
@@ -150,6 +159,19 @@ def main(argv=None):
         cases, methods = load_config(args.config)
     else:
         cases, methods = list(DEFAULT_DATASETS), list(DEFAULT_METHODS)
+
+    # Override dataset list via command line
+    if args.datasets and args.datasets.upper() != "ALL":
+        ids = {d.strip() for d in args.datasets.split(',')}
+        cases = [
+            (imu, gnss)
+            for imu, gnss in cases
+            if pathlib.Path(imu).stem.split('_')[1] in ids
+        ]
+
+    # Override method list via command line
+    if args.methods and args.methods.upper() != "ALL":
+        methods = [m.strip() for m in args.methods.split(',')]
 
     logger.debug(f"Datasets: {cases}")
     logger.debug(f"Methods: {methods}")

--- a/src/run_davenport_only.py
+++ b/src/run_davenport_only.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Run all datasets using only the Davenport initialisation method.
 
-This script simply calls ``run_method_only.py --method Davenport`` and
+This script simply calls ``run_all_methods.py --methods Davenport`` and
 passes through any extra command line arguments.
 """
-from run_method_only import main
+from run_all_methods import main
 import sys
 
 if __name__ == "__main__":
-    main(["--method", "Davenport", *sys.argv[1:]])
+    main(["--methods", "Davenport", *sys.argv[1:]])

--- a/src/run_svd_only.py
+++ b/src/run_svd_only.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Run all datasets using only the SVD initialisation method.
 
-This is a thin wrapper around ``run_method_only.py --method SVD``. Any
-additional command line arguments are forwarded to ``run_method_only``.
+This is a thin wrapper around ``run_all_methods.py --methods SVD``. Any
+additional command line arguments are forwarded to ``run_all_methods``.
 """
-from run_method_only import main
+from run_all_methods import main
 import sys
 
 if __name__ == "__main__":
-    main(["--method", "SVD", *sys.argv[1:]])
+    main(["--methods", "SVD", *sys.argv[1:]])

--- a/src/run_triad_only.py
+++ b/src/run_triad_only.py
@@ -2,7 +2,7 @@
 """Run all datasets using only the TRIAD initialisation method.
 
 This script forwards any additional command line arguments to
-``run_method_only.py`` with ``--method TRIAD`` so that the behaviour
+``run_all_methods.py`` with ``--methods TRIAD`` so that the behaviour
 matches ``run_all_methods.py`` when the TRIAD method is selected.
 
 Usage
@@ -10,8 +10,8 @@ Usage
     python src/run_triad_only.py [options]
 """
 
-from run_method_only import main
+from run_all_methods import main
 import sys
 
 if __name__ == "__main__":
-    main(["--method", "TRIAD", *sys.argv[1:]])
+    main(["--methods", "TRIAD", *sys.argv[1:]])


### PR DESCRIPTION
## Summary
- allow choosing datasets/methods directly in `run_all_methods.py`
- simplify the `run_*_only.py` helpers to call `run_all_methods`
- document the new behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881082b59d483258dff896f1d372fd0