### PR TITLE
Add docs on method wrappers

### DIFF
--- a/MATLAB/README_pipeline.md
+++ b/MATLAB/README_pipeline.md
@@ -94,6 +94,16 @@ found even if you run the command from another folder.  When more than one
 pair is processed the function returns a cell array of result structs, each
 matching the corresponding `results/Result_<IMU>_<GNSS>_TRIAD.mat` file.
 
+Dedicated wrappers `run_triad_only.m`, `run_svd_only.m` and
+`run_davenport_only.m` behave like the Python helpers of the same name and
+simply forward the chosen method to `run_all_datasets_matlab`:
+
+```matlab
+run_triad_only      % TRIAD method
+run_svd_only        % SVD method
+run_davenport_only  % Davenport method
+```
+
 ### GNSS_IMU_Fusion_single
 
 Use `GNSS_IMU_Fusion_single` when you only need to process one IMU/GNSS pair.

--- a/README.md
+++ b/README.md
@@ -378,7 +378,9 @@ python src/run_triad_only.py
 run_triad_only
 ```
 The MATLAB version now calls `run_all_datasets_matlab` so it does not
-require Python. Both scripts generate the same output as running
+require Python. **Make sure your current working directory is the repository
+root** so the scripts can locate the bundled data files. Both scripts
+generate the same output as running
 `python src/run_all_datasets.py --method TRIAD` and validate the fused
 trajectory against the common `STATE_X001.txt` file. The extended
 summary is written to `results/summary_truth.csv` and includes
@@ -403,6 +405,11 @@ Dedicated wrappers `run_svd_only.py` and `run_davenport_only.py` mirror
 `run_triad_only.py` for the SVD and Davenport methods. MATLAB users can
 call `run_svd_only` or `run_davenport_only` for the same behaviour.  The file
 names now match between Python and MATLAB for consistency.
+
+Wrapper overview:
+
+* Python: `src/run_triad_only.py`, `src/run_svd_only.py`, `src/run_davenport_only.py`
+* MATLAB: `run_triad_only.m`, `run_svd_only.m`, `run_davenport_only.m`
 
 
 After all runs complete you can compare the datasets side by side:


### PR DESCRIPTION
## Summary
- mention running helper scripts from the repo root
- list Python and MATLAB wrappers for TRIAD, SVD and Davenport
- document dedicated MATLAB wrappers in the MATLAB README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881411c7f9483259d2e4c4299b245ef