### PR TITLE
Enable Task 7 evaluation in method-only runner

### DIFF
--- a/src/run_method_only.py
+++ b/src/run_method_only.py
@@ -3,8 +3,10 @@
 
 This script generalises ``run_triad_only.py``. It forwards the chosen
 method to ``run_all_datasets.py`` and validates the resulting trajectory
-against the bundled ground truth when available. The printed summary table
-matches the one produced by ``run_triad_only.py``.
+against the bundled ground truth when available. Task 6 overlay plots and
+Task 7 residual evaluation are executed automatically when the truth data
+is present. The printed summary table matches the one produced by
+``run_triad_only.py``.
 
 Usage
 -----
@@ -25,6 +27,7 @@ from tabulate import tabulate
 from scipy.spatial.transform import Rotation as R
 from plot_overlay import plot_overlay
 from validate_with_truth import load_estimate, assemble_frames
+from evaluate_filter_results import run_evaluation_npz
 from utils import ensure_dependencies
 from pyproj import Transformer
 
@@ -264,6 +267,15 @@ def main(argv=None):
                         P0 = np.diagonal(npz['P_hist'][0])[:3]
                 except Exception:
                     pass
+
+                # -------- Task 7: Residual evaluation --------
+                tag = f"{m2.group(1)}_{m2.group(2)}_{args.method}"
+                task7_dir = results / "task7" / tag
+                print("Running Task 7 evaluation ...")
+                try:
+                    run_evaluation_npz(str(npz_path), str(task7_dir), tag)
+                except Exception as e:
+                    print(f"Task 7 failed: {e}")
 
                 summary.append({
                     'dataset': m.group(1),

--- a/src/run_triad_only_cli.py
+++ b/src/run_triad_only_cli.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Command line interface to run all datasets using the TRIAD method.
+
+This is an alias for ``run_triad_only.py`` for users accustomed to the
+``*_cli.py`` naming pattern.  It simply forwards all command line
+arguments to ``run_method_only.py --method TRIAD`` which runs Tasks 1--5
+and, when truth logs are present, the Task 6 overlay and Task 7
+evaluation.
+
+Usage
+-----
+    python src/run_triad_only_cli.py [options]
+"""
+from run_method_only import main
+import sys
+
+if __name__ == "__main__":
+    main(["--method", "TRIAD", *sys.argv[1:]])


### PR DESCRIPTION
## Summary
- add residual evaluation in `run_method_only.py` so Task 7 plots are produced
- document automatic Task 6/7 behaviour
- provide `run_triad_only_cli.py` alias mirroring the MATLAB naming

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68814ad6f4f48325aeb18b0016f4d161