### PR TITLE
Add Task6 metrics and Task7 residual analysis

### DIFF
--- a/MATLAB/Task_6.m
+++ b/MATLAB/Task_6.m
@@ -118,4 +118,17 @@ plot_overlay('Body', method, t_est, pos_body, vel_body, acc_body, ...
     't_truth', t_est, 'pos_truth', pos_truth_body, ...
     'vel_truth', vel_truth_body, 'acc_truth', acc_truth_body, ...
     'suffix', '_overlay_truth.pdf');
+
+% ------------------------------------------------------------------
+% Compute overlay metrics for summary tables
+% ------------------------------------------------------------------
+[mNED, ~]  = compute_overlay_metrics(t_est, pos_ned,  vel_ned,  pos_truth_ned_i,  vel_truth_ned_i);
+[mECEF, ~] = compute_overlay_metrics(t_est, pos_ecef, vel_ecef, pos_truth_ecef_i, vel_truth_ecef_i);
+[mBody, ~] = compute_overlay_metrics(t_est, pos_body, vel_body, pos_truth_body,  vel_truth_body);
+metrics = struct('NED', mNED, 'ECEF', mECEF, 'Body', mBody);
+metrics_file = fullfile(results_dir, sprintf('%s_%s_%s_task6_metrics.mat', ...
+    imu_name, gnss_name, method));
+save(metrics_file, 'metrics');
+fprintf('[Task6] %s %s RMSEpos(NED)=%.3f m final=%.3f m\n', ...
+    imu_name, method, mNED.rmse_pos, mNED.final_pos);
 end

--- a/MATLAB/compute_overlay_metrics.m
+++ b/MATLAB/compute_overlay_metrics.m
@@ -1,0 +1,30 @@
+function [metrics, residuals] = compute_overlay_metrics(t, pos_est, vel_est, pos_truth, vel_truth)
+%COMPUTE_OVERLAY_METRICS  Return RMSE and final error between fused and truth.
+%   [METRICS, RESIDUALS] = COMPUTE_OVERLAY_METRICS(T, POS_EST, VEL_EST,
+%   POS_TRUTH, VEL_TRUTH) computes residual position, velocity and
+%   acceleration given the fused estimate and ground truth arrays. ``t`` is
+%   the common time vector. The returned METRICS struct contains RMSE and
+%   final error magnitudes.  RESIDUALS.pos, RESIDUALS.vel and
+%   RESIDUALS.acc hold the per-sample differences.
+
+if nargin < 5
+    error('Not enough input arguments.');
+end
+
+res_pos = pos_est - pos_truth;
+res_vel = vel_est - vel_truth;
+acc_est = [zeros(1,3); diff(vel_est)./diff(t)];
+acc_truth = [zeros(1,3); diff(vel_truth)./diff(t)];
+res_acc = acc_est - acc_truth;
+
+metrics.rmse_pos = sqrt(mean(vecnorm(res_pos,2,2).^2));
+metrics.final_pos = norm(res_pos(end,:));
+metrics.rmse_vel = sqrt(mean(vecnorm(res_vel,2,2).^2));
+metrics.final_vel = norm(res_vel(end,:));
+metrics.rmse_acc = sqrt(mean(vecnorm(res_acc,2,2).^2));
+metrics.final_acc = norm(res_acc(end,:));
+
+residuals.pos = res_pos;
+residuals.vel = res_vel;
+residuals.acc = res_acc;
+end

--- a/MATLAB/run_all_datasets_matlab.m
+++ b/MATLAB/run_all_datasets_matlab.m
@@ -70,8 +70,10 @@ for k = 1:size(pairs,1)
                 fprintf('Task_6 skipped: %s\n', ME.message);
             end
             try
-                dataset = regexp(imuStem,'(X\d+)','match','once');
-                task7_ecef_residuals_plot(outFile, cand, dataset, resultsDir);
+                tag = sprintf('%s_%s_%s', imuStem, gnssStem, method);
+                outDir = fullfile(resultsDir, 'task7', tag);
+                summary = task7_fused_truth_error_analysis(outFile, cand, outDir);
+                save(fullfile(outDir,'task7_summary.mat'), 'summary');
             catch ME
                 fprintf('Task_7 skipped: %s\n', ME.message);
             end


### PR DESCRIPTION
## Summary
- compute overlay RMSE/final-error via `compute_overlay_metrics`
- update `Task_6` to save overlay metrics
- extend `task6_overlay_plot` to read MAT as well as NPZ
- add `task7_fused_truth_error_analysis` for fused–truth residual plots
- run Task 7 error analysis from `run_all_datasets_matlab`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68815223c15c8325b964ac5258a66481