### PR TITLE
Always use STATE_X001 for Tasks 6/7

### DIFF
--- a/MATLAB/Task_6.m
+++ b/MATLAB/Task_6.m
@@ -21,7 +21,9 @@ if ~isfile(kf_file)
     error('Task_6:FileNotFound', 'KF output not found: %s', kf_file);
 end
 
-state_name = [strrep(imu_name,'IMU','STATE') '.txt'];
+% Always reference STATE\_X001.txt regardless of the dataset name so that
+% this task can run on all logs even when per-dataset truth is missing.
+state_name = 'STATE_X001.txt';
 try
     state_file = get_data_file(state_name);
 catch

--- a/MATLAB/run_all_datasets_matlab.m
+++ b/MATLAB/run_all_datasets_matlab.m
@@ -58,11 +58,11 @@ for k = 1:size(pairs,1)
         if exist('plot_results.m','file')
             plot_results(outFile);
         end
-        stateName = [strrep(imuStem,'IMU','STATE') '.txt'];
-        cand = fullfile(dataDir, stateName);
-        if ~isfile(cand)
-            cand = fullfile(root, stateName);
-        end
+        % Always use the common STATE\_X001.txt trajectory as the reference
+        % for Tasks 6 and 7 regardless of the IMU/GNSS filename.  This
+        % ensures that evaluation is performed for every dataset even when
+        % dataset-specific truth files are unavailable.
+        cand = fullfile(root, 'STATE_X001.txt');
         if isfile(cand)
             try
                 Task_6(imu, gnss, method);

--- a/MATLAB/run_all_methods.m
+++ b/MATLAB/run_all_methods.m
@@ -32,14 +32,11 @@ colors  = {'r','g','b'};
 resultsDir = 'results';
 if ~exist(resultsDir,'dir'); mkdir(resultsDir); end
 
-% Check if ground truth file is available for optional Task 6 overlay
-stateName = [strrep(imu_name,'IMU','STATE') '.txt'];
-try
-    get_data_file(stateName); % throws if not found
-    haveTruth = true;
-catch
-    haveTruth = false;
-end
+% Always reference the common STATE\_X001.txt trajectory for Tasks 6 and 7
+% so that evaluation runs for any dataset regardless of its filename.
+stateName = 'STATE_X001.txt';
+cand = fullfile(fileparts(mfilename('fullpath')), '..', stateName);
+haveTruth = isfile(cand);
 
 % Load GNSS data and derive NED trajectory
 Tgnss = readtable(gnss_path);
@@ -112,8 +109,7 @@ for m = 1:numel(methods)
         try
             tag_m = sprintf('%s_%s_%s', imu_name, gnss_name, method);
             outDir = fullfile(resultsDir, 'task7', tag_m);
-            summary = task7_fused_truth_error_analysis(out_kf, ...
-                get_data_file(stateName), outDir);
+            summary = task7_fused_truth_error_analysis(out_kf, cand, outDir);
             save(fullfile(outDir,'task7_summary.mat'), 'summary');
         catch ME
             fprintf('Task_7 skipped for %s: %s\n', method, ME.message);

--- a/MATLAB/run_triad_only.m
+++ b/MATLAB/run_triad_only.m
@@ -62,11 +62,10 @@ for k = 1:size(pairs,1)
             plot_results(outFile);
         end
         % Optional Tasks 6 and 7 when ground truth is available
-        stateName = [strrep(imuStem,'IMU','STATE') '.txt'];
-        cand = fullfile(dataDir, stateName);
-        if ~isfile(cand)
-            cand = fullfile(root, stateName);
-        end
+        % Use the common STATE\_X001.txt reference trajectory for all
+        % datasets so that Tasks 6 and 7 are executed for every IMU/GNSS
+        % pair irrespective of the original dataset naming.
+        cand = fullfile(root, 'STATE_X001.txt');
         if isfile(cand)
             try
                 Task_6(imu, gnss, method);


### PR DESCRIPTION
## Summary
- use the common `STATE_X001.txt` file as the ground truth for MATLAB batch scripts
- update `Task_6.m` to load `STATE_X001.txt`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881caef41b08325b2fc7eb667956816