### PR TITLE
Fix Task 6 file path handling

### DIFF
--- a/src/run_all_methods.py
+++ b/src/run_all_methods.py
@@ -154,17 +154,28 @@ def main(argv=None):
     logger.debug(f"Datasets: {cases}")
     logger.debug(f"Methods: {methods}")
 
+    data_dir = ROOT / "Data"
+    if not data_dir.is_dir():
+        data_dir = ROOT
+
     results = []
     for (imu, gnss), m in itertools.product(cases, methods):
         tag = f"{pathlib.Path(imu).stem}_{pathlib.Path(gnss).stem}_{m}"
         log_path = pathlib.Path("results") / f"{tag}.log"
         print(f"\u25b6 {tag}")
+        imu_path = data_dir / imu
+        gnss_path = data_dir / gnss
+        if not imu_path.is_file():
+            imu_path = ROOT / imu
+        if not gnss_path.is_file():
+            gnss_path = ROOT / gnss
+
         if logger.isEnabledFor(logging.DEBUG):
             try:
                 gnss_preview = np.loadtxt(
-                    ROOT / gnss, delimiter=",", skiprows=1, max_rows=1
+                    gnss_path, delimiter=",", skiprows=1, max_rows=1
                 )
-                imu_preview = np.loadtxt(ROOT / imu, max_rows=1)
+                imu_preview = np.loadtxt(imu_path, max_rows=1)
                 logger.debug(
                     f"GNSS preview: shape {gnss_preview.shape}, first row: {gnss_preview}"
                 )
@@ -177,9 +188,9 @@ def main(argv=None):
             sys.executable,
             str(HERE / "GNSS_IMU_Fusion.py"),
             "--imu-file",
-            str(ROOT / imu),
+            str(imu_path),
             "--gnss-file",
-            str(ROOT / gnss),
+            str(gnss_path),
             "--method",
             m,
         ]
@@ -341,8 +352,12 @@ def main(argv=None):
                     str(HERE / "task6_plot_truth.py"),
                     "--est-file",
                     str(npz_path.with_suffix(".mat")),
+                    "--imu-file",
+                    str(imu_path),
+                    "--gnss-file",
+                    str(gnss_path),
                     "--truth-file",
-                    str(truth_file),
+                    str(truth_file.resolve()),
                     "--output",
                     "results",
                 ]

--- a/src/run_triad_only.py
+++ b/src/run_triad_only.py
@@ -92,6 +92,10 @@ def main(argv: Iterable[str] | None = None) -> None:
         cases = list(DEFAULT_DATASETS)
 
     method = "TRIAD"
+    data_dir = ROOT / "Data"
+    if not data_dir.is_dir():
+        data_dir = ROOT
+
     results: List[Dict[str, float | str]] = []
 
     for imu, gnss in cases:
@@ -99,10 +103,17 @@ def main(argv: Iterable[str] | None = None) -> None:
         log_path = pathlib.Path("results") / f"{tag}.log"
         print(f"\u25b6 {tag}")
 
+        imu_path = data_dir / imu
+        gnss_path = data_dir / gnss
+        if not imu_path.is_file():
+            imu_path = ROOT / imu
+        if not gnss_path.is_file():
+            gnss_path = ROOT / gnss
+
         if logger.isEnabledFor(logging.DEBUG):
             try:
-                gnss_preview = np.loadtxt(ROOT / gnss, delimiter=",", skiprows=1, max_rows=1)
-                imu_preview = np.loadtxt(ROOT / imu, max_rows=1)
+                gnss_preview = np.loadtxt(gnss_path, delimiter=",", skiprows=1, max_rows=1)
+                imu_preview = np.loadtxt(imu_path, max_rows=1)
                 logger.debug(
                     "GNSS preview: shape %s, first row: %s",
                     gnss_preview.shape,
@@ -120,9 +131,9 @@ def main(argv: Iterable[str] | None = None) -> None:
             sys.executable,
             str(HERE / "GNSS_IMU_Fusion.py"),
             "--imu-file",
-            str(ROOT / imu),
+            str(imu_path),
             "--gnss-file",
-            str(ROOT / gnss),
+            str(gnss_path),
             "--method",
             method,
         ]
@@ -283,8 +294,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                     str(HERE / "task6_plot_truth.py"),
                     "--est-file",
                     str(npz_path.with_suffix(".mat")),
+                    "--imu-file",
+                    str(imu_path),
+                    "--gnss-file",
+                    str(gnss_path),
                     "--truth-file",
-                    str(truth_file),
+                    str(truth_file.resolve()),
                     "--output",
                     "results",
                 ]


### PR DESCRIPTION
## Summary
- ensure run_all_methods.py, run_triad_only.py and run_all_datasets.py resolve IMU/GNSS files using a Data folder fallback
- pass absolute IMU and GNSS paths to task6_plot_truth.py
- extend task6_plot_truth.py with --imu-file/--gnss-file options and associated path logic

## Testing
- `ruff check src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881cd957ab4832585100aa4c2eae263