### PR TITLE
Fix MATLAB truth file loading

### DIFF
--- a/MATLAB/Task_6.m
+++ b/MATLAB/Task_6.m
@@ -43,7 +43,8 @@ if nargin < 4 || isempty(truth_file)
     end
 end
 
-truth = load(truth_file);
+% Load STATE_X truth file with comment support
+truth = read_state_file(truth_file);
 
 % Use reference coordinates from the estimate when available
 if isfield(S,'ref_lat'); ref_lat = S.ref_lat; else; ref_lat = deg2rad(-32.026554); end

--- a/MATLAB/align_and_validate_dtw_task6_task7.m
+++ b/MATLAB/align_and_validate_dtw_task6_task7.m
@@ -38,7 +38,8 @@ ref_r0 = double(npz{'ref_r0_m'});
 % -------------------------------------------------------------------------
 % Load truth trajectory
 % -------------------------------------------------------------------------
-truth_raw = load(truth_file);
+% Truth logs contain a comment header
+truth_raw = read_state_file(truth_file);
 truth_time = truth_raw(:,1);
 truth_pos_ecef = truth_raw(:,2:4);
 

--- a/MATLAB/read_state_file.m
+++ b/MATLAB/read_state_file.m
@@ -1,0 +1,25 @@
+function data = read_state_file(filename)
+%READ_STATE_FILE Load ground truth STATE_X file.
+%   DATA = READ_STATE_FILE(FILENAME) reads the numeric columns from the
+%   specified state file. Lines beginning with '#' are ignored so the
+%   function is robust to header comments. Returns a numeric matrix with
+%   one row per sample.
+%
+%   Mirrors the behaviour of ``np.loadtxt`` used in the Python
+%   implementation.
+
+if nargin < 1
+    error('read_state_file:MissingFile','Filename required');
+end
+
+if ~isfile(filename)
+    error('read_state_file:FileNotFound','File not found: %s', filename);
+end
+
+% Use readmatrix to honour comment lines starting with '#'
+try
+    data = readmatrix(filename, 'CommentStyle', '#');
+catch ME
+    error('read_state_file:ReadFailed','Failed to read %s: %s', filename, ME.message);
+end
+end

--- a/MATLAB/task6_overlay_plot.m
+++ b/MATLAB/task6_overlay_plot.m
@@ -62,7 +62,8 @@ if endsWith(ppath, '.npz')
     end
     t = double(data{'time_s'});
 else
-    raw = load(ppath);
+    % Text truth files may include a comment header
+    raw = read_state_file(ppath);
     t = raw(:,2);
     if strcmpi(frame,'ECEF')
         pos = raw(:,3:5);

--- a/MATLAB/task7_fused_truth_error_analysis.m
+++ b/MATLAB/task7_fused_truth_error_analysis.m
@@ -49,19 +49,27 @@ function [t, pos, vel, acc] = load_est(file)
             acc = gradient(gradient(pos)) ./ mean(diff(t))^2;
         end
     else
-        S = load(f);
-        if isfield(S,'time_s'); t = S.time_s(:); else; t = S.time(:); end
-        if isfield(S,'pos_ecef_m')
-            pos = S.pos_ecef_m;
-            vel = S.vel_ecef_ms;
+        if endsWith(f,'.txt')
+            raw = read_state_file(f);
+            t = raw(:,1);
+            pos = raw(:,2:4);
+            vel = raw(:,5:7);
+            acc = [zeros(1,3); diff(vel)./diff(t)];
         else
-            pos = S.pos_ecef;
-            vel = S.vel_ecef;
-        end
-        if isfield(S,'acc_ecef_ms2')
-            acc = S.acc_ecef_ms2;
-        else
-            acc = gradient(gradient(pos)) ./ mean(diff(t))^2;
+            S = load(f);
+            if isfield(S,'time_s'); t = S.time_s(:); else; t = S.time(:); end
+            if isfield(S,'pos_ecef_m')
+                pos = S.pos_ecef_m;
+                vel = S.vel_ecef_ms;
+            else
+                pos = S.pos_ecef;
+                vel = S.vel_ecef;
+            end
+            if isfield(S,'acc_ecef_ms2')
+                acc = S.acc_ecef_ms2;
+            else
+                acc = gradient(gradient(pos)) ./ mean(diff(t))^2;
+            end
         end
     end
 end

--- a/MATLAB/task7_plot_error_fused_vs_truth.m
+++ b/MATLAB/task7_plot_error_fused_vs_truth.m
@@ -19,7 +19,12 @@ end
 if ~exist(output_dir, 'dir'); mkdir(output_dir); end
 
 F = load(fused_file);
-T = load(truth_file);
+% Truth file may include a comment header
+if endsWith(truth_file, '.txt')
+    T = read_state_file(truth_file);
+else
+    T = load(truth_file);
+end
 
 time = F.time_s(:);
 if isfield(F, 'vel_ned_ms')
@@ -27,10 +32,14 @@ if isfield(F, 'vel_ned_ms')
 else
     vel_f = [F.vx(:), F.vy(:), F.vz(:)];
 end
-if isfield(T, 'vel_ned_ms')
-    vel_t = T.vel_ned_ms;
+if isnumeric(T)
+    vel_t = T(:,5:7);
 else
-    vel_t = [T.vx(:), T.vy(:), T.vz(:)];
+    if isfield(T, 'vel_ned_ms')
+        vel_t = T.vel_ned_ms;
+    else
+        vel_t = [T.vx(:), T.vy(:), T.vz(:)];
+    end
 end
 
 err = vel_f - vel_t;

--- a/src/read_state_file.py
+++ b/src/read_state_file.py
@@ -1,0 +1,15 @@
+"""Utility to load STATE_X ground truth files.
+
+This mirrors ``read_state_file.m`` by returning the numeric
+contents of the file while ignoring lines starting with ``#``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import numpy as np
+
+
+def read_state_file(filename: str | Path) -> np.ndarray:
+    """Return numeric array from a STATE_X file."""
+    path = Path(filename)
+    return np.loadtxt(path, comments="#")


### PR DESCRIPTION
## Summary
- add `read_state_file.m` utility and Python stub
- load STATE_X truth files with comment headers using new helper
- adjust Task 6/7 scripts to use the helper
- update overlay and validation routines accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881d6335854832594d87cf97ebf6c16