### PR TITLE
Fix Task6 overlay paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Typical result PDFs:
 - `<method>_attitude_angles.pdf` – attitude angles over time
 - `<tag>_<frame>_overlay_truth.pdf` – fused output vs reference (dataset tag is
   derived from the estimator filename)
-- `task6_<frame>_overlay_state.pdf` – Task 6 overlay with GNSS, IMU and raw state
+- ``results/task6/<tag>/<tag>_task6_overlay_state_<frame>.pdf`` – Task 6 overlay with GNSS, IMU and raw state
 - `task7_residuals_position_velocity.pdf` – Task 7 position/velocity residuals
 - `task7_attitude_angles_euler.pdf` – Task 7 Euler angle plots
 - `task7_fused_vs_truth_error.pdf` – Task 7 fused minus truth velocity error
@@ -266,12 +266,11 @@ python src/task6_plot_truth.py --est-file results/IMU_X001_GNSS_X001_TRIAD_kf_ou
 ```
 
 Passing `--show-measurements` adds the raw IMU and GNSS curves.  The resulting
-figures are written as ``<tag>_task6_<frame>_overlay_state.pdf`` in the
-``results/`` directory.
+figures are written as ``results/task6/<tag>/<tag>_task6_overlay_state_<frame>.pdf``.
 
 ### Output
 
-* `<tag>_task6_<frame>_overlay_state.pdf` – fused output vs raw state file
+* ``results/task6/<tag>/<tag>_task6_overlay_state_<frame>.pdf`` – fused output vs raw state file
 
 ## Task 7: Evaluation of Filter Results
 

--- a/docs/MATLAB/Task6_MATLAB.md
+++ b/docs/MATLAB/Task6_MATLAB.md
@@ -23,8 +23,8 @@ Task 5 output
 2. **Prepare Truth Data** – convert the ECEF truth trajectory to NED using the
    reference latitude, longitude and origin saved in the result file.
 3. **Interpolate** – align IMU, GNSS and truth samples on the filter time grid.
-4. **Plot** – call `plot_overlay` for the three frames which stores PDFs named
-   `<METHOD>_<FRAME>_overlay_state.pdf` in `results/`. The ``--show-measurements``
+4. **Plot** – call `plot_overlay` for the three frames which stores PDFs under
+   ``results/task6/<METHOD>/`` as `<METHOD>_task6_overlay_state_<FRAME>.pdf`. The ``--show-measurements``
    flag mirrors the Python implementation.
 
 ## Result

--- a/docs/Python/Task6_Python.md
+++ b/docs/Python/Task6_Python.md
@@ -23,7 +23,7 @@ Task 5 output
 2. **Assemble Frames** – use :func:`assemble_frames` to align IMU, GNSS and truth
    data in NED, ECEF and body frames.
 3. **Generate Plots** – call :func:`plot_overlay` for each frame to save PDFs
-   named `<TAG>_task6_<FRAME>_overlay_state.pdf` in the results directory.  The
+   under ``results/task6/<TAG>/`` as `<TAG>_task6_overlay_state_<FRAME>.pdf`. The
    ``--show-measurements`` flag adds the raw IMU and GNSS curves.
 
 ## Result

--- a/src/task6_plot_truth.py
+++ b/src/task6_plot_truth.py
@@ -68,16 +68,6 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    out_dir = Path(args.output)
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    # Remove any existing Task 6 truth overlay PDFs to avoid confusion
-    for f in glob.glob(str(out_dir / "*task6_*_truth.pdf")):
-        try:
-            os.remove(f)
-        except OSError:
-            pass
-
     est_path = Path(args.est_file)
     m = re.match(r"(IMU_\w+)_(GNSS_\w+)_([A-Za-z]+)_kf_output", est_path.stem)
     if not m:
@@ -106,6 +96,17 @@ def main() -> None:
     gnss_file = gnss_file.resolve()
     method = m.group(3)
     tag = args.tag or f"{m.group(1)}_{m.group(2)}_{method}"
+
+    # output directory for overlay figures
+    out_dir = Path(args.output) / "task6" / tag
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Remove any old Task 6 truth overlay PDFs in this directory
+    for f in glob.glob(str(out_dir / "*task6_*_truth.pdf")):
+        try:
+            os.remove(f)
+        except OSError:
+            pass
 
     est = load_estimate(str(est_path))
     frames = assemble_frames(est, imu_file, gnss_file, args.truth_file)

--- a/tests/test_validate_with_truth.py
+++ b/tests/test_validate_with_truth.py
@@ -260,7 +260,8 @@ def test_overlay_truth_generation(tmp_path, monkeypatch):
         ],
     )
     task6_main()
-    state_files = {p.name for p in Path("results").glob("*_overlay_state.pdf")}
+    state_dir = Path("results") / "task6" / "IMU_X001_small_GNSS_X001_small_TRIAD"
+    state_files = {p.name for p in state_dir.glob("*_overlay_state.pdf")}
     assert state_files, "Missing state overlay plots"
 
 


### PR DESCRIPTION
## Summary
- save Task6 overlay figures under `results/task6/<run_id>`
- document new location in README and task6 docs
- update tests for new output path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68821894d6f883258941316f8d2c908e