### PR TITLE
Refactor Task 6 overlay output paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Typical result PDFs:
 - `<method>_attitude_angles.pdf` – attitude angles over time
 - `<tag>_<frame>_overlay_truth.pdf` – fused output vs reference (dataset tag is
   derived from the estimator filename)
-- `task6_<frame>_overlay_state.pdf` – Task 6 overlay with GNSS, IMU and raw state
+- `results/task6/<run_id>/<run_id>_task6_overlay_state_<frame>.pdf` – Task 6 overlay with GNSS, IMU and raw state
 - `task7_residuals_position_velocity.pdf` – Task 7 position/velocity residuals
 - `task7_attitude_angles_euler.pdf` – Task 7 Euler angle plots
 - `task7_fused_vs_truth_error.pdf` – Task 7 fused minus truth velocity error
@@ -266,12 +266,12 @@ python src/task6_plot_truth.py --est-file results/IMU_X001_GNSS_X001_TRIAD_kf_ou
 ```
 
 Passing `--show-measurements` adds the raw IMU and GNSS curves.  The resulting
-figures are written as ``<tag>_task6_<frame>_overlay_state.pdf`` in the
-``results/`` directory.
+figures are saved under ``results/task6/<tag>/`` as
+``<tag>_task6_overlay_state_<frame>.pdf``.
 
 ### Output
 
-* `<tag>_task6_<frame>_overlay_state.pdf` – fused output vs raw state file
+* `results/task6/<tag>/<tag>_task6_overlay_state_<frame>.pdf` – fused output vs raw state file
 
 ## Task 7: Evaluation of Filter Results
 

--- a/docs/Python/Task6_Python.md
+++ b/docs/Python/Task6_Python.md
@@ -23,8 +23,9 @@ Task 5 output
 2. **Assemble Frames** – use :func:`assemble_frames` to align IMU, GNSS and truth
    data in NED, ECEF and body frames.
 3. **Generate Plots** – call :func:`plot_overlay` for each frame to save PDFs
-   named `<TAG>_task6_<FRAME>_overlay_state.pdf` in the results directory.  The
-   ``--show-measurements`` flag adds the raw IMU and GNSS curves.
+   named `<TAG>_task6_overlay_state_<FRAME>.pdf` inside
+   ``results/task6/<TAG>/``.  The ``--show-measurements`` flag adds the raw IMU
+   and GNSS curves.
 
 ## Result
 

--- a/plot_summary.md
+++ b/plot_summary.md
@@ -15,7 +15,7 @@
 - **X001_TRIAD_attitude_angles.pdf**: Attitude angles over time
 - **<method>_<frame>_overlay_truth.pdf**: Fused results versus reference
 - **<method>_<frame>_overlay_state.pdf**: Fused results versus raw state file
-- **<tag>_task6_<frame>_overlay_state.pdf**: Task 6 overlay using raw state data
+- **results/task6/<tag>/<tag>_task6_overlay_state_<frame>.pdf**: Task 6 overlay using raw state data
 - **<tag>_task7_residuals_position_velocity.pdf**: Task 7 residuals
 - **<tag>_task7_attitude_angles_euler.pdf**: Task 7 attitude angles
 

--- a/src/task6_plot_truth.py
+++ b/src/task6_plot_truth.py
@@ -68,15 +68,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    out_dir = Path(args.output)
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    # Remove any existing Task 6 truth overlay PDFs to avoid confusion
-    for f in glob.glob(str(out_dir / "*task6_*_truth.pdf")):
-        try:
-            os.remove(f)
-        except OSError:
-            pass
+    out_base = Path(args.output)
 
     est_path = Path(args.est_file)
     m = re.match(r"(IMU_\w+)_(GNSS_\w+)_([A-Za-z]+)_kf_output", est_path.stem)
@@ -106,6 +98,16 @@ def main() -> None:
     gnss_file = gnss_file.resolve()
     method = m.group(3)
     tag = args.tag or f"{m.group(1)}_{m.group(2)}_{method}"
+
+    out_dir = out_base / "task6" / tag
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Remove any existing Task 6 truth overlay PDFs to avoid confusion
+    for f in glob.glob(str(out_dir / "*task6_*_truth.pdf")):
+        try:
+            os.remove(f)
+        except OSError:
+            pass
 
     est = load_estimate(str(est_path))
     frames = assemble_frames(est, imu_file, gnss_file, args.truth_file)
@@ -257,7 +259,7 @@ def main() -> None:
             t_t = ensure_relative_time(t_t)
             if frame_name == "NED":
                 p_t = centre(p_t)
-        name_state = f"{tag}_task6_{frame_name}_overlay_state.pdf"
+        name_state = f"{tag}_task6_overlay_state_{frame_name}.pdf"
         plot_overlay(
             frame_name,
             method,

--- a/tests/test_validate_with_truth.py
+++ b/tests/test_validate_with_truth.py
@@ -260,8 +260,15 @@ def test_overlay_truth_generation(tmp_path, monkeypatch):
         ],
     )
     task6_main()
-    state_files = {p.name for p in Path("results").glob("*_overlay_state.pdf")}
-    assert state_files, "Missing state overlay plots"
+    run_id = est_file.stem.replace("_kf_output", "")
+    run_dir = Path("results") / "task6" / run_id
+    expected_state = {
+        f"{run_id}_task6_overlay_state_NED.pdf",
+        f"{run_id}_task6_overlay_state_ECEF.pdf",
+        f"{run_id}_task6_overlay_state_Body.pdf",
+    }
+    produced_state = {p.name for p in run_dir.glob("*.pdf")}
+    assert expected_state.issubset(produced_state), f"Missing state overlays: {expected_state - produced_state}"
 
 
 def test_assemble_frames_small_truth():


### PR DESCRIPTION
## Summary
- save Task 6 overlay plots to `results/task6/<run_id>/`
- update documentation for new output location
- adjust tests for new figure names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882189a8b80832581176d774733e810