### PR TITLE
Update Task 6 overlay naming

### DIFF
--- a/MATLAB/task6_overlay_plot.m
+++ b/MATLAB/task6_overlay_plot.m
@@ -7,8 +7,10 @@ function pdf_path = task6_overlay_plot(est_file, truth_file, method, frame, data
 %   ``.npz`` or ``.txt`` files containing the fused estimator output and
 %   ground truth respectively. ``frame`` is either ``'ECEF'`` or ``'NED'``.
 %   The interpolated truth is overlaid on the estimate for position,
-%   velocity and acceleration and the figure saved under ``output_dir`` with
-%   a name ``<dataset>_<method>_Task6_<frame>_Overlay``.
+%   velocity and acceleration and the figure saved under
+%   ``results/task6/<run_id>/`` as ``<run_id>_task6_overlay_state_<frame>.pdf``.
+%   ``run_id`` combines the dataset and method, e.g.,
+%   ``IMU_X003_GNSS_X002_TRIAD``.
 
 if nargin < 4 || isempty(frame)
     frame = 'ECEF';
@@ -178,9 +180,11 @@ for ax = 1:3
     end
 end
 set(f,'PaperPositionMode','auto');
-if ~exist(out_dir,'dir'); mkdir(out_dir); end
-pdf_path = fullfile(out_dir, sprintf('%s_%s_Task6_%s_Overlay.pdf', dataset, method, upper(frame)));
-png_path = fullfile(out_dir, sprintf('%s_%s_Task6_%s_Overlay.png', dataset, method, upper(frame)));
+run_id = sprintf('%s_%s', dataset, method);
+task_dir = fullfile(out_dir, 'task6', run_id);
+if ~exist(task_dir,'dir'); mkdir(task_dir); end
+pdf_path = fullfile(task_dir, sprintf('%s_task6_overlay_state_%s.pdf', run_id, frame));
+png_path = fullfile(task_dir, sprintf('%s_task6_overlay_state_%s.png', run_id, frame));
 print(f, pdf_path, '-dpdf');
 print(f, png_path, '-dpng');
 close(f);


### PR DESCRIPTION
## Summary
- update MATLAB Task 6 overlay docstring
- save Task 6 overlay files under `results/task6/<run_id>/`
- use `<run_id>_task6_overlay_state_<frame>` naming scheme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68821a43c48c832589dc59a5bb65327d