### PR TITLE
Fix Task6 overlay path

### DIFF
--- a/MATLAB/task6_overlay_plot.m
+++ b/MATLAB/task6_overlay_plot.m
@@ -7,8 +7,9 @@ function pdf_path = task6_overlay_plot(est_file, truth_file, method, frame, data
 %   ``.npz`` or ``.txt`` files containing the fused estimator output and
 %   ground truth respectively. ``frame`` is either ``'ECEF'`` or ``'NED'``.
 %   The interpolated truth is overlaid on the estimate for position,
-%   velocity and acceleration and the figure saved under ``output_dir`` with
-%   a name ``<dataset>_<method>_Task6_<frame>_Overlay``.
+%   velocity and acceleration and the figure saved under
+%   ``output_dir/task6/<dataset>_<method>/`` as
+%   ``<dataset>_<method>_task6_overlay_state_<frame>.pdf``.
 
 if nargin < 4 || isempty(frame)
     frame = 'ECEF';
@@ -178,9 +179,11 @@ for ax = 1:3
     end
 end
 set(f,'PaperPositionMode','auto');
-if ~exist(out_dir,'dir'); mkdir(out_dir); end
-pdf_path = fullfile(out_dir, sprintf('%s_%s_Task6_%s_Overlay.pdf', dataset, method, upper(frame)));
-png_path = fullfile(out_dir, sprintf('%s_%s_Task6_%s_Overlay.png', dataset, method, upper(frame)));
+run_id = sprintf('%s_%s', dataset, method);
+out_path = fullfile(out_dir, 'task6', run_id);
+if ~exist(out_path,'dir'); mkdir(out_path); end
+pdf_path = fullfile(out_path, sprintf('%s_task6_overlay_state_%s.pdf', run_id, upper(frame)));
+png_path = fullfile(out_path, sprintf('%s_task6_overlay_state_%s.png', run_id, upper(frame)));
 print(f, pdf_path, '-dpdf');
 print(f, png_path, '-dpng');
 close(f);

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Typical result PDFs:
 - `<method>_attitude_angles.pdf` – attitude angles over time
 - `<tag>_<frame>_overlay_truth.pdf` – fused output vs reference (dataset tag is
   derived from the estimator filename)
-- `task6_<frame>_overlay_state.pdf` – Task 6 overlay with GNSS, IMU and raw state
+- `<run_id>_task6_overlay_state_<frame>.pdf` – Task 6 overlay with GNSS, IMU and raw state
 - `task7_residuals_position_velocity.pdf` – Task 7 position/velocity residuals
 - `task7_attitude_angles_euler.pdf` – Task 7 Euler angle plots
 - `task7_fused_vs_truth_error.pdf` – Task 7 fused minus truth velocity error
@@ -266,12 +266,13 @@ python src/task6_plot_truth.py --est-file results/IMU_X001_GNSS_X001_TRIAD_kf_ou
 ```
 
 Passing `--show-measurements` adds the raw IMU and GNSS curves.  The resulting
-figures are written as ``<tag>_task6_<frame>_overlay_state.pdf`` in the
-``results/`` directory.
+figures are written as ``<run_id>_task6_overlay_state_<frame>.pdf`` in the
+``results/task6/<run_id>/`` directory, where ``run_id`` is
+``<IMU>_<GNSS>_<METHOD>``.
 
 ### Output
 
-* `<tag>_task6_<frame>_overlay_state.pdf` – fused output vs raw state file
+* `<run_id>_task6_overlay_state_<frame>.pdf` – fused output vs raw state file
 
 ## Task 7: Evaluation of Filter Results
 

--- a/docs/Python/Task6_Python.md
+++ b/docs/Python/Task6_Python.md
@@ -23,8 +23,9 @@ Task 5 output
 2. **Assemble Frames** – use :func:`assemble_frames` to align IMU, GNSS and truth
    data in NED, ECEF and body frames.
 3. **Generate Plots** – call :func:`plot_overlay` for each frame to save PDFs
-   named `<TAG>_task6_<FRAME>_overlay_state.pdf` in the results directory.  The
-   ``--show-measurements`` flag adds the raw IMU and GNSS curves.
+   named `<run_id>_task6_overlay_state_<FRAME>.pdf` under
+   `results/task6/<run_id>/`. The ``--show-measurements`` flag adds the raw IMU
+   and GNSS curves.
 
 ## Result
 

--- a/plot_summary.md
+++ b/plot_summary.md
@@ -15,7 +15,7 @@
 - **X001_TRIAD_attitude_angles.pdf**: Attitude angles over time
 - **<method>_<frame>_overlay_truth.pdf**: Fused results versus reference
 - **<method>_<frame>_overlay_state.pdf**: Fused results versus raw state file
-- **<tag>_task6_<frame>_overlay_state.pdf**: Task 6 overlay using raw state data
+- **<run_id>_task6_overlay_state_<frame>.pdf**: Task 6 overlay using raw state data
 - **<tag>_task7_residuals_position_velocity.pdf**: Task 7 residuals
 - **<tag>_task7_attitude_angles_euler.pdf**: Task 7 attitude angles
 

--- a/tests/test_validate_with_truth.py
+++ b/tests/test_validate_with_truth.py
@@ -260,7 +260,10 @@ def test_overlay_truth_generation(tmp_path, monkeypatch):
         ],
     )
     task6_main()
-    state_files = {p.name for p in Path("results").glob("*_overlay_state.pdf")}
+    state_files = {
+        p.name
+        for p in Path("results/task6").rglob("*_overlay_state_*.pdf")
+    }
     assert state_files, "Missing state overlay plots"
 
 


### PR DESCRIPTION
## Summary
- create task6 output folder per run in `task6_plot_truth.py`
- write overlay plots into `results/task6/<run_id>/`
- match MATLAB helper `task6_overlay_plot.m` output folder
- update README and docs for new naming convention
- adjust unit test expectations

## Testing
- `pytest tests/test_validate_with_truth.py::test_validate_with_truth -q`
- `pytest -q` *(partial run interrupted after success)*

------
https://chatgpt.com/codex/tasks/task_e_68821a7270dc83258091980bdfafff65