### PR TITLE
Fix Task 6 overlay output directory

### DIFF
--- a/plot_summary.md
+++ b/plot_summary.md
@@ -15,7 +15,7 @@
 - **X001_TRIAD_attitude_angles.pdf**: Attitude angles over time
 - **<method>_<frame>_overlay_truth.pdf**: Fused results versus reference
 - **<method>_<frame>_overlay_state.pdf**: Fused results versus raw state file
-- **<tag>_task6_<frame>_overlay_state.pdf**: Task 6 overlay using raw state data
+- **<tag>_task6_overlay_state_<frame>.pdf**: Task 6 overlay using raw state data
 - **<tag>_task7_residuals_position_velocity.pdf**: Task 7 residuals
 - **<tag>_task7_attitude_angles_euler.pdf**: Task 7 attitude angles
 

--- a/src/task6_plot_truth.py
+++ b/src/task6_plot_truth.py
@@ -258,7 +258,7 @@ def main() -> None:
             t_t = ensure_relative_time(t_t)
             if frame_name == "NED":
                 p_t = centre(p_t)
-        name_state = f"{tag}_task6_{frame_name}_overlay_state.pdf"
+        name_state = f"{tag}_task6_overlay_state_{frame_name}.pdf"
         plot_overlay(
             frame_name,
             method,

--- a/task6_overlay_plot.py
+++ b/task6_overlay_plot.py
@@ -8,8 +8,10 @@ Usage:
 
 This script synchronizes the time bases of the estimator output and ground
 truth, then generates a single figure with position, velocity and acceleration
-components overlaid. Only the fused estimate and truth are shown. The figure is
-saved to ``results/{DATASET}_{METHOD}_Task6_{FRAME}_Overlay.pdf`` and ``.png``.
+components overlaid. Only the fused estimate and truth are shown. Figures are
+written under ``results/task6/<run_id>/`` using the filename pattern
+``<run_id>_task6_overlay_state_<frame>.pdf`` where ``run_id`` combines the
+dataset and method, e.g. ``IMU_X003_GNSS_X002_TRIAD``.
 With ``--debug`` the script prints diagnostic information about the input
 datasets before plotting.
 """
@@ -151,9 +153,11 @@ def plot_overlay(
         ax.legend().set_visible(False)
 
     fig.tight_layout()
-    out_dir.mkdir(parents=True, exist_ok=True)
-    pdf_path = out_dir / f"{dataset}_{method}_Task6_{frame}_Overlay.pdf"
-    png_path = out_dir / f"{dataset}_{method}_Task6_{frame}_Overlay.png"
+    run_id = f"{dataset}_{method}"
+    task_dir = out_dir / "task6" / run_id
+    task_dir.mkdir(parents=True, exist_ok=True)
+    pdf_path = task_dir / f"{run_id}_task6_overlay_state_{frame}.pdf"
+    png_path = task_dir / f"{run_id}_task6_overlay_state_{frame}.png"
     fig.savefig(pdf_path)
     fig.savefig(png_path)
     plt.close(fig)

--- a/tests/test_validate_with_truth.py
+++ b/tests/test_validate_with_truth.py
@@ -261,7 +261,7 @@ def test_overlay_truth_generation(tmp_path, monkeypatch):
     )
     task6_main()
     state_dir = Path("results") / "task6" / "IMU_X001_small_GNSS_X001_small_TRIAD"
-    state_files = {p.name for p in state_dir.glob("*_overlay_state.pdf")}
+    state_files = {p.name for p in state_dir.glob("*_task6_overlay_state_*.pdf")}
     assert state_files, "Missing state overlay plots"
 
 


### PR DESCRIPTION
## Summary
- save Task 6 overlay figures under `results/task6/<run_id>/`
- use filename `<run_id>_task6_overlay_state_<frame>.pdf`
- update docs and tests for new naming

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68822105eea8832597ae403d3dde11b6