### PR TITLE
Fix results directory in MATLAB batch scripts

### DIFF
--- a/MATLAB/run_all_datasets_matlab.m
+++ b/MATLAB/run_all_datasets_matlab.m
@@ -12,6 +12,11 @@ end
 
 here = fileparts(mfilename('fullpath'));
 root = fileparts(here);
+% Ensure "results" directory is under the repository root regardless of the
+% caller's current working directory.
+orig_dir = pwd;
+cd(root);
+cleanupObj = onCleanup(@() cd(orig_dir));
 
 % Prefer a dedicated Data folder if present
 dataDir = fullfile(root, 'Data');

--- a/MATLAB/run_triad_only.m
+++ b/MATLAB/run_triad_only.m
@@ -12,6 +12,11 @@ method = 'TRIAD';
 
 here = fileparts(mfilename('fullpath'));
 root = fileparts(here);
+% Switch to repository root so that all Tasks read/write results under
+% ``root/results`` regardless of the caller's working directory.
+orig_dir = pwd;
+cd(root);
+cleanupObj = onCleanup(@() cd(orig_dir));
 
 % Prefer a dedicated Data folder if present
 dataDir = fullfile(root, 'Data');


### PR DESCRIPTION
## Summary
- ensure `run_triad_only.m` and `run_all_datasets_matlab.m` switch to the repo root so all tasks place results in the correct `results/` directory

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688229a58834832584cba31ed8db629c