### PR TITLE
Fix detection of Signal Processing Toolbox

### DIFF
--- a/MATLAB/Task_2.m
+++ b/MATLAB/Task_2.m
@@ -115,7 +115,10 @@ order = 4;
 nyquist_freq = 0.5 * fs;
 normal_cutoff = cutoff / nyquist_freq;
 
-if exist('filtfilt', 'file') == 2 && exist('butter', 'file') == 2 && license('test','Signal_Processing_Toolbox')
+% Check for Signal Processing Toolbox using known license feature names
+has_signal_toolbox = license('test','Signal_Toolbox') || ...
+                      license('test','Signal_Processing_Toolbox');
+if exist('filtfilt', 'file') == 2 && exist('butter', 'file') == 2 && has_signal_toolbox
     [b, a] = butter(order, normal_cutoff, 'low');
     acc_filt = filtfilt(b, a, acc);
     gyro_filt = filtfilt(b, a, gyro);
@@ -142,7 +145,7 @@ gyro_var_thresh  = 1e-6;    % match Python implementation
 min_length = 80;
 
 % Use movvar from Signal Processing Toolbox if available, otherwise use a loop
-if license('test', 'Signal_Processing_Toolbox') && exist('movvar', 'file')
+if has_signal_toolbox && exist('movvar', 'file')
     accel_var = movvar(acc_filt, window_size, 0, 'Endpoints', 'discard');
     gyro_var = movvar(gyro_filt, window_size, 0, 'Endpoints', 'discard');
 else


### PR DESCRIPTION
## Summary
- check for Signal Processing Toolbox using either `Signal_Toolbox` or `Signal_Processing_Toolbox`
- fall back to manual moving variance when `movvar` is unavailable

## Testing
- `ruff check src tests` *(fails: E741, F401)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68822a1a681083258b7d0c1bd68b60cf