### PR TITLE
Update Task7 diff plot naming

### DIFF
--- a/MATLAB/evaluate_filter_results.m
+++ b/MATLAB/evaluate_filter_results.m
@@ -151,9 +151,11 @@ for i = 1:3
 end
 sgtitle('Truth - Fused Differences');
 set(f,'PaperPositionMode','auto');
-out_file = fullfile(out_dir, [run_id '_diff_truth_fused_over_time.pdf']);
-print(f, out_file, '-dpdf');
-close(f); fprintf('Saved %s\n', out_file);
+out_file_pdf = fullfile(out_dir, [run_id '_task7_diff_truth_fused_over_time.pdf']);
+out_file_png = strrep(out_file_pdf, '.pdf', '.png');
+print(f, out_file_pdf, '-dpdf');
+print(f, out_file_png, '-dpng');
+close(f); fprintf('Saved %s\n', out_file_pdf);
 
 pos_thr = 1.0; vel_thr = 1.0;
 for i = 1:3

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Typical result PDFs:
 - `task7_residuals_position_velocity.pdf` – Task 7 position/velocity residuals
 - `task7_attitude_angles_euler.pdf` – Task 7 Euler angle plots
 - `task7_fused_vs_truth_error.pdf` – Task 7 fused minus truth velocity error
-- `<tag>_diff_truth_fused_over_time.pdf` – Task 7 truth minus fused difference
+- `<tag>_task7_diff_truth_fused_over_time.pdf` – Task 7 truth minus fused difference
   plot
 
 ## Task 6: State Overlay
@@ -297,7 +297,7 @@ python src/run_all_methods.py --task 7
   `<tag>_task7_attitude_angles_euler.pdf`
 * The helper script `src/task7_plot_error_fused_vs_truth.py` produces
   `task7_fused_vs_truth_error.pdf` showing the fused minus truth velocity error.
-* Subtask 7.5 generates `<tag>_diff_truth_fused_over_time.pdf` with the
+* Subtask 7.5 generates `<tag>_task7_diff_truth_fused_over_time.pdf` with the
   component-wise difference between truth and fused trajectories.
 
 ### Notes

--- a/src/evaluate_filter_results.py
+++ b/src/evaluate_filter_results.py
@@ -297,7 +297,7 @@ def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) ->
             out_dir,
         )
         print(
-            f"Saved {Path(out_dir) / (run_id + '_diff_truth_fused_over_time.pdf')}"
+            f"Saved {Path(out_dir) / (run_id + '_task7_diff_truth_fused_over_time.pdf')}"
         )
     else:
         print("Subtask 7.5 skipped: missing fused or truth data")
@@ -356,7 +356,7 @@ def subtask7_5_diff_plot(
 
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
-    pdf = out_dir / f"{run_id}_diff_truth_fused_over_time.pdf"
+    pdf = out_dir / f"{run_id}_task7_diff_truth_fused_over_time.pdf"
     png = pdf.with_suffix(".png")
     fig.savefig(pdf)
     fig.savefig(png)

--- a/tests/test_evaluate_filter_results.py
+++ b/tests/test_evaluate_filter_results.py
@@ -47,4 +47,4 @@ def test_run_evaluation_npz_diff_plot(tmp_path):
         vel_ned=fused_vel,
     )
     run_evaluation_npz(str(f), str(tmp_path), tag="TEST")
-    assert (tmp_path / "TEST_diff_truth_fused_over_time.pdf").exists()
+    assert (tmp_path / "TEST_task7_diff_truth_fused_over_time.pdf").exists()


### PR DESCRIPTION
## Summary
- rename diff plot output to `_task7_diff_truth_fused_over_time.*`
- update tests, MATLAB script, and README for new name

## Testing
- `pytest tests/test_evaluate_filter_results.py::test_run_evaluation_npz_diff_plot -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68822df497bc8325adbb6b564b9d931a