### PR TITLE
Add subtask numbers to Task 7 plot filenames

### DIFF
--- a/MATLAB/evaluate_filter_results.m
+++ b/MATLAB/evaluate_filter_results.m
@@ -74,7 +74,7 @@ for i = 1:3
 end
 sgtitle('Task 7 - GNSS - Predicted Residuals');
 set(f,'PaperPositionMode','auto');
-pdf = fullfile(output_dir, sprintf('%stask7_residuals_position_velocity.pdf', prefix));
+pdf = fullfile(output_dir, sprintf('%stask7_3_residuals_position_velocity.pdf', prefix));
 print(f, pdf, '-dpdf');
 close(f); fprintf('Saved %s\n', pdf);
 
@@ -87,7 +87,7 @@ for i = 1:3
 end
 xlabel('Time [s]'); sgtitle('Task 7 - Attitude Angles');
 set(f,'PaperPositionMode','auto');
-pdf_att = fullfile(output_dir, sprintf('%stask7_attitude_angles_euler.pdf', prefix));
+pdf_att = fullfile(output_dir, sprintf('%stask7_4_attitude_angles_euler.pdf', prefix));
 print(f, pdf_att, '-dpdf'); close(f); fprintf('Saved %s\n', pdf_att);
 
 norm_pos = vecnorm(res_pos,2,2);
@@ -101,7 +101,7 @@ plot(t, norm_vel, 'DisplayName','|vel error|');
 plot(t, norm_acc, 'DisplayName','|acc error|');
 xlabel('Time [s]'); ylabel('Error Norm'); legend; grid on;
 set(f,'PaperPositionMode','auto');
-pdf_norm = fullfile(output_dir, sprintf('%stask7_error_norms.pdf', prefix));
+pdf_norm = fullfile(output_dir, sprintf('%stask7_3_error_norms.pdf', prefix));
 print(f, pdf_norm, '-dpdf'); close(f); fprintf('Saved %s\n', pdf_norm);
 
 % Subtask 7.5: difference truth - fused over time
@@ -151,7 +151,7 @@ for i = 1:3
 end
 sgtitle('Truth - Fused Differences');
 set(f,'PaperPositionMode','auto');
-out_file_pdf = fullfile(out_dir, [run_id '_task7_diff_truth_fused_over_time.pdf']);
+out_file_pdf = fullfile(out_dir, [run_id '_task7_5_diff_truth_fused_over_time.pdf']);
 out_file_png = strrep(out_file_pdf, '.pdf', '.png');
 print(f, out_file_pdf, '-dpdf');
 print(f, out_file_png, '-dpng');

--- a/README.md
+++ b/README.md
@@ -248,10 +248,10 @@ Typical result PDFs:
 - `<tag>_<frame>_overlay_truth.pdf` – fused output vs reference (dataset tag is
   derived from the estimator filename)
 - ``results/task6/<tag>/<tag>_task6_overlay_state_<frame>.pdf`` – Task 6 overlay with GNSS, IMU and raw state
-- `task7_residuals_position_velocity.pdf` – Task 7 position/velocity residuals
-- `task7_attitude_angles_euler.pdf` – Task 7 Euler angle plots
+- `task7_3_residuals_position_velocity.pdf` – Task 7 position/velocity residuals
+- `task7_4_attitude_angles_euler.pdf` – Task 7 Euler angle plots
 - `task7_fused_vs_truth_error.pdf` – Task 7 fused minus truth velocity error
-- `<tag>_task7_diff_truth_fused_over_time.pdf` – Task 7 truth minus fused difference
+- `<tag>_task7_5_diff_truth_fused_over_time.pdf` – Task 7 truth minus fused difference
   plot
 
 ## Task 6: State Overlay
@@ -293,11 +293,11 @@ python src/run_all_methods.py --task 7
 
 * When running `run_all_methods.py`, plots are stored in
   `results/task7/<tag>/` as
-  `<tag>_task7_residuals_position_velocity.pdf` and
-  `<tag>_task7_attitude_angles_euler.pdf`
+  `<tag>_task7_3_residuals_position_velocity.pdf` and
+  `<tag>_task7_4_attitude_angles_euler.pdf`
 * The helper script `src/task7_plot_error_fused_vs_truth.py` produces
   `task7_fused_vs_truth_error.pdf` showing the fused minus truth velocity error.
-* Subtask 7.5 generates `<tag>_task7_diff_truth_fused_over_time.pdf` with the
+* Subtask 7.5 generates `<tag>_task7_5_diff_truth_fused_over_time.pdf` with the
   component-wise difference between truth and fused trajectories.
 
 ### Notes
@@ -344,7 +344,7 @@ Provide a YAML configuration to process additional logs.
 Task 6 (truth overlay) and Task 7 (evaluation) are performed automatically for
 each run.  The additional figures are written to `results/` with the evaluation
 plots placed inside `results/task7/<tag>/`. Task 7 uses the dataset tag as a
-prefix, so you will find files like `<tag>_task7_residuals_position_velocity.pdf`
+prefix, so you will find files like `<tag>_task7_3_residuals_position_velocity.pdf`
 inside that folder.
 
 

--- a/plot_summary.md
+++ b/plot_summary.md
@@ -16,8 +16,8 @@
 - **<method>_<frame>_overlay_truth.pdf**: Fused results versus reference
 - **<method>_<frame>_overlay_state.pdf**: Fused results versus raw state file
 - **<tag>_task6_overlay_state_<frame>.pdf**: Task 6 overlay using raw state data
-- **<tag>_task7_residuals_position_velocity.pdf**: Task 7 residuals
-- **<tag>_task7_attitude_angles_euler.pdf**: Task 7 attitude angles
+ - **<tag>_task7_3_residuals_position_velocity.pdf**: Task 7 residuals
+ - **<tag>_task7_4_attitude_angles_euler.pdf**: Task 7 attitude angles
 
 ## Subtask 5.8 Comparison Plots
 

--- a/src/evaluate_filter_results.py
+++ b/src/evaluate_filter_results.py
@@ -122,7 +122,7 @@ def run_evaluation(
         axes[1, i].grid(True)
     fig.suptitle("Task 7 – GNSS - Predicted Residuals")
     fig.tight_layout(rect=[0, 0, 1, 0.95])
-    out_path = out_dir / f"{prefix}task7_residuals_position_velocity.pdf"
+    out_path = out_dir / f"{prefix}task7_3_residuals_position_velocity.pdf"
     fig.savefig(out_path)
     print(f"Saved {out_path}")
     plt.close(fig)
@@ -156,7 +156,7 @@ def run_evaluation(
     axs[2].set_xlabel("Time [s]")
     fig.suptitle("Task 7 – Attitude Angles")
     fig.tight_layout(rect=[0, 0, 1, 0.95])
-    fig.savefig(out_dir / f"{prefix}task7_attitude_angles_euler.pdf")
+    fig.savefig(out_dir / f"{prefix}task7_4_attitude_angles_euler.pdf")
     plt.close(fig)
 
 
@@ -242,7 +242,7 @@ def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) ->
         axes[1, i].grid(True)
     fig.suptitle("Task 7 – GNSS - Predicted Residuals")
     fig.tight_layout(rect=[0, 0, 1, 0.95])
-    out_path = out_dir / f"{prefix}task7_residuals_position_velocity.pdf"
+    out_path = out_dir / f"{prefix}task7_3_residuals_position_velocity.pdf"
     fig.savefig(out_path)
     print(f"Saved {out_path}")
     plt.close(fig)
@@ -259,7 +259,7 @@ def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) ->
     axs[2].set_xlabel("Time [s]")
     fig.suptitle("Task 7 – Attitude Angles")
     fig.tight_layout(rect=[0, 0, 1, 0.95])
-    att_path = out_dir / f"{prefix}task7_attitude_angles_euler.pdf"
+    att_path = out_dir / f"{prefix}task7_4_attitude_angles_euler.pdf"
     fig.savefig(att_path)
     print(f"Saved {att_path}")
     plt.close(fig)
@@ -279,7 +279,7 @@ def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) ->
     ax.legend()
     ax.grid(True)
     fig.tight_layout()
-    norm_path = out_dir / f"{prefix}task7_error_norms.pdf"
+    norm_path = out_dir / f"{prefix}task7_3_error_norms.pdf"
     fig.savefig(norm_path)
     print(f"Saved {norm_path}")
     plt.close(fig)
@@ -297,7 +297,7 @@ def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) ->
             out_dir,
         )
         print(
-            f"Saved {Path(out_dir) / (run_id + '_task7_diff_truth_fused_over_time.pdf')}"
+            f"Saved {Path(out_dir) / (run_id + '_task7_5_diff_truth_fused_over_time.pdf')}"
         )
     else:
         print("Subtask 7.5 skipped: missing fused or truth data")
@@ -356,7 +356,7 @@ def subtask7_5_diff_plot(
 
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
-    pdf = out_dir / f"{run_id}_task7_diff_truth_fused_over_time.pdf"
+    pdf = out_dir / f"{run_id}_task7_5_diff_truth_fused_over_time.pdf"
     png = pdf.with_suffix(".png")
     fig.savefig(pdf)
     fig.savefig(png)

--- a/tests/test_evaluate_filter_results.py
+++ b/tests/test_evaluate_filter_results.py
@@ -12,8 +12,8 @@ def test_run_evaluation_npz_mismatched_lengths(tmp_path):
     f = tmp_path / "data.npz"
     np.savez(f, residual_pos=res_pos, residual_vel=res_vel, time_residuals=t, attitude_q=quat)
     run_evaluation_npz(str(f), str(tmp_path), tag="TEST")
-    assert (tmp_path / "TEST_task7_residuals_position_velocity.pdf").exists()
-    assert (tmp_path / "TEST_task7_attitude_angles_euler.pdf").exists()
+    assert (tmp_path / "TEST_task7_3_residuals_position_velocity.pdf").exists()
+    assert (tmp_path / "TEST_task7_4_attitude_angles_euler.pdf").exists()
 
 
 def test_run_evaluation_npz_quat_longer(tmp_path):
@@ -24,8 +24,8 @@ def test_run_evaluation_npz_quat_longer(tmp_path):
     f = tmp_path / "data.npz"
     np.savez(f, residual_pos=res_pos, residual_vel=res_vel, time_residuals=t, attitude_q=quat)
     run_evaluation_npz(str(f), str(tmp_path), tag="TEST")
-    assert (tmp_path / "TEST_task7_residuals_position_velocity.pdf").exists()
-    assert (tmp_path / "TEST_task7_attitude_angles_euler.pdf").exists()
+    assert (tmp_path / "TEST_task7_3_residuals_position_velocity.pdf").exists()
+    assert (tmp_path / "TEST_task7_4_attitude_angles_euler.pdf").exists()
 
 
 def test_run_evaluation_npz_diff_plot(tmp_path):
@@ -47,4 +47,4 @@ def test_run_evaluation_npz_diff_plot(tmp_path):
         vel_ned=fused_vel,
     )
     run_evaluation_npz(str(f), str(tmp_path), tag="TEST")
-    assert (tmp_path / "TEST_task7_diff_truth_fused_over_time.pdf").exists()
+    assert (tmp_path / "TEST_task7_5_diff_truth_fused_over_time.pdf").exists()


### PR DESCRIPTION
## Summary
- append subtask numbers to Task 7 output filenames
- update MATLAB implementation to mirror new naming
- adjust README and plot summary to document new names
- update unit tests for the renamed files

## Testing
- `ruff check .` *(fails: SyntaxError and lint errors in unrelated files)*
- `pytest tests/test_evaluate_filter_results.py::test_run_evaluation_npz_mismatched_lengths -q`
- `pytest tests/test_evaluate_filter_results.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68837621797083259417ac00d1daac73