### PR TITLE
Add Euler matrix utility and robust Task 7 loader

### DIFF
--- a/MATLAB/euler_to_rot.m
+++ b/MATLAB/euler_to_rot.m
@@ -1,0 +1,21 @@
+function R = euler_to_rot(eul)
+%EULER_TO_ROT Convert XYZ Euler angles to rotation matrix.
+%   R = EULER_TO_ROT(EUL) returns the rotation matrix corresponding to
+%   the Euler angles ``[roll; pitch; yaw]`` in radians using the XYZ
+%   convention.  This helper mirrors the Python implementation for
+%   cross-language parity.
+%
+%   Usage:
+%       R = euler_to_rot([roll; pitch; yaw]);
+%
+%   See also quat_to_rot.
+%
+%   "IMU" research codebase utility function.
+
+cr = cos(eul(1)); sr = sin(eul(1));
+cp = cos(eul(2)); sp = sin(eul(2));
+cy = cos(eul(3)); sy = sin(eul(3));
+R = [cy*cp, cy*sp*sr - sy*cr, cy*sp*cr + sy*sr;
+     sy*cp, sy*sp*sr + cy*cr, sy*sp*cr - cy*sr;
+     -sp,   cp*sr,            cp*cr];
+end

--- a/src/utils.py
+++ b/src/utils.py
@@ -196,6 +196,33 @@ def ecef_to_ned(pos_ecef: np.ndarray, ref_lat: float, ref_lon: float,
     return np.array([C @ (p - ref_ecef) for p in pos_ecef])
 
 
+def euler_to_rot(eul: np.ndarray) -> np.ndarray:
+    """Convert XYZ Euler angles to a rotation matrix.
+
+    Parameters
+    ----------
+    eul : array-like, shape (3,)
+        ``[roll, pitch, yaw]`` in **radians**.
+
+    Returns
+    -------
+    ndarray of shape (3, 3)
+        Rotation matrix from Body to NED using the XYZ convention.
+    """
+
+    eul = np.asarray(eul).reshape(3)
+    cr, sr = np.cos(eul[0]), np.sin(eul[0])
+    cp, sp = np.cos(eul[1]), np.sin(eul[1])
+    cy, sy = np.cos(eul[2]), np.sin(eul[2])
+    return np.array(
+        [
+            [cy * cp, cy * sp * sr - sy * cr, cy * sp * cr + sy * sr],
+            [sy * cp, sy * sp * sr + cy * cr, sy * sp * cr - cy * sr],
+            [-sp, cp * sr, cp * cr],
+        ]
+    )
+
+
 def ecef_to_geodetic(x: float, y: float, z: float) -> Tuple[float, float, float]:
     """Convert ECEF coordinates to geodetic latitude, longitude and altitude.
 


### PR DESCRIPTION
## Summary
- add missing `euler_to_rot.m` for MATLAB tasks
- compute ECEF data from NED if needed in `task7_fused_truth_error_analysis`
- add Python counterpart `euler_to_rot` utility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68838acf90348325a9d734aa86c5c5ed