### PR TITLE
Add docstrings for navigation constants

### DIFF
--- a/MATLAB/constants.m
+++ b/MATLAB/constants.m
@@ -1,4 +1,5 @@
 classdef constants
+    % Mirrors constants defined in src/constants.py for cross-language parity
     properties (Constant)
         GRAVITY = 9.81;
         EARTH_RATE = 7.2921e-5;

--- a/MATLAB/constants.m
+++ b/MATLAB/constants.m
@@ -1,5 +1,7 @@
 classdef constants
     % Mirrors constants defined in src/constants.py for cross-language parity
+    % GRAVITY is a typical magnitude of gravitational acceleration (m/s^2).
+    % Algorithms may replace this with locally computed values when available.
     properties (Constant)
         GRAVITY = 9.81;
         EARTH_RATE = 7.2921e-5;

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,2 +1,16 @@
+"""Shared physical constants for the navigation algorithms.
+
+GRAVITY
+    Standard gravity expressed in metres per second squared (m/s^2).  This
+    value is used when normalising accelerometer measurements.
+
+EARTH_RATE
+    Earth's angular rotation rate expressed in radians per second (rad/s).
+    It is required for inertial navigation computations.
+
+These constants mirror those defined in ``MATLAB/constants.m`` to keep the
+Python and MATLAB implementations in sync.
+"""
+
 GRAVITY = 9.81
 EARTH_RATE = 7.2921e-5

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,15 +1,17 @@
 """Shared physical constants for the navigation algorithms.
 
 GRAVITY
-    Standard gravity expressed in metres per second squared (m/s^2).  This
-    value is used when normalising accelerometer measurements.
+    Typical magnitude of gravitational acceleration near Earth's surface
+    in metres per second squared (m/s^2).  Local gravity varies with
+    location, so algorithms may compute a more precise value; this default
+    is used when none is provided.
 
 EARTH_RATE
     Earth's angular rotation rate expressed in radians per second (rad/s).
     It is required for inertial navigation computations.
 
-These constants mirror those defined in ``MATLAB/constants.m`` to keep the
-Python and MATLAB implementations in sync.
+These constants mirror those defined in ``MATLAB/constants.m`` so that the
+Python and MATLAB implementations remain in sync.
 """
 
 GRAVITY = 9.81


### PR DESCRIPTION
## Summary
- document `GRAVITY` and `EARTH_RATE` in `src/constants.py`
- note MATLAB parity in `MATLAB/constants.m`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883bf0bf67c8325acbed92307ef88c3