### PR TITLE
Fix ECEF->NED conversion transposes

### DIFF
--- a/MATLAB/Task_6.m
+++ b/MATLAB/Task_6.m
@@ -107,7 +107,7 @@ end
 pos_truth_ecef_i = interp1(t_truth, pos_truth_ecef, t_est, 'linear', 'extrap');
 vel_truth_ecef_i = interp1(t_truth, vel_truth_ecef, t_est, 'linear', 'extrap');
 acc_truth_ecef_i = interp1(t_truth, acc_truth_ecef, t_est, 'linear', 'extrap');
-pos_truth_ned_i  = (C*(pos_truth_ecef_i - ref_r0')).';
+pos_truth_ned_i  = (C * (pos_truth_ecef_i' - ref_r0)).';
 vel_truth_ned_i  = (C*vel_truth_ecef_i.').';
 acc_truth_ned_i  = (C*acc_truth_ecef_i.').';
 

--- a/MATLAB/task7_fused_truth_error_analysis.m
+++ b/MATLAB/task7_fused_truth_error_analysis.m
@@ -31,10 +31,10 @@ if isnan(lat) || isnan(lon) || any(isnan(r0))
     lon = deg2rad(lon_deg);
 end
 C = compute_C_ECEF_to_NED(lat, lon);
-pos_est = (C*(pos_est_ecef - r0.')).';
+pos_est = (C * (pos_est_ecef' - r0)).';
 vel_est = (C*vel_est_ecef.').';
 acc_est = (C*acc_est_ecef.').';
-pos_tru = (C*(pos_tru_ecef - r0.')).';
+pos_tru = (C * (pos_tru_ecef' - r0)).';
 vel_tru = (C*vel_tru_ecef.').';
 acc_tru = (C*acc_tru_ecef.').';
 


### PR DESCRIPTION
## Summary
- correct truth position conversion in `Task_6.m`
- fix estimator/truth position conversion in `task7_fused_truth_error_analysis.m`

## Testing
- `octave --eval "addpath('MATLAB'); run_triad_only"` *(fails: `'readtable' undefined`)*

------
https://chatgpt.com/codex/tasks/task_e_6883cd6330648325832fbb1b96392aa8