### PR TITLE
Fix MATLAB task file naming

### DIFF
--- a/MATLAB/Task_2.m
+++ b/MATLAB/Task_2.m
@@ -61,7 +61,15 @@ end
 % ------------------------------------------------------------------
 % Attempt to load gravity vector produced by Task 1 for this IMU/GNSS pair
 % ------------------------------------------------------------------
-task1_file = fullfile('results', ['Task1_init_' pair_tag '.mat']);
+task1_file = fullfile('results', ['Task1_init_' tag '.mat']);
+if ~isfile(task1_file)
+    % Fallback to method-agnostic filename for backwards compatibility
+    alt_file = fullfile('results', ['Task1_init_' pair_tag '.mat']);
+    if isfile(alt_file)
+        task1_file = alt_file;
+    end
+end
+
 if isfile(task1_file)
     task1_data = load(task1_file);
     if isfield(task1_data, 'g_NED')

--- a/MATLAB/Task_4.m
+++ b/MATLAB/Task_4.m
@@ -191,7 +191,15 @@ fprintf('Static gyro var  =[%.4g %.4g %.4g]\n', gyro_var);
 % Gravity vector and Earth rotation in NED frame
 % Attempt to reuse the gravity vector estimated in Task 1; if unavailable,
 % fall back to the nominal constant.
-task1_file = fullfile(results_dir, sprintf('Task1_init_%s.mat', pair_tag));
+task1_file = fullfile(results_dir, sprintf('Task1_init_%s.mat', tag));
+if ~isfile(task1_file)
+    % Fallback to method-agnostic filename for older runs
+    alt_file = fullfile(results_dir, sprintf('Task1_init_%s.mat', pair_tag));
+    if isfile(alt_file)
+        task1_file = alt_file;
+    end
+end
+
 if isfile(task1_file)
     t1 = load(task1_file);
     if isfield(t1, 'g_NED')

--- a/MATLAB/Task_6.m
+++ b/MATLAB/Task_6.m
@@ -30,9 +30,26 @@ if ~isfile(task5_file)
 end
 S = load(task5_file);
 
+% Determine method from filename or structure
+tok = regexp(task5_file, '_(\w+)_task5_results\.mat$', 'tokens');
+if ~isempty(tok)
+    method = tok{1}{1};
+elseif isfield(S,'method')
+    method = S.method;
+else
+    method = 'TRIAD';
+end
+
 % Load gravity vector from Task 1 initialisation
 pair_tag = [imu_name '_' gnss_name];
-task1_file = fullfile(results_dir, sprintf('Task1_init_%s.mat', pair_tag));
+task1_file = fullfile(results_dir, sprintf('Task1_init_%s.mat', [pair_tag '_' method]));
+if ~isfile(task1_file)
+    % Fallback to methodless file for backward compatibility
+    alt_file = fullfile(results_dir, sprintf('Task1_init_%s.mat', pair_tag));
+    if isfile(alt_file)
+        task1_file = alt_file;
+    end
+end
 if isfile(task1_file)
     init_data = load(task1_file);
     if isfield(init_data, 'g_NED')
@@ -43,16 +60,6 @@ if isfile(task1_file)
 else
     warning('Task 1 output not found: %s', task1_file);
     g_NED = [0;0;constants.GRAVITY];
-end
-
-% Derive method tag from filename or structure
-tok = regexp(task5_file, '_(\w+)_task5_results\.mat$', 'tokens');
-if ~isempty(tok)
-    method = tok{1}{1};
-elseif isfield(S,'method')
-    method = S.method;
-else
-    method = 'TRIAD';
 end
 
 if nargin < 4 || isempty(truth_file)


### PR DESCRIPTION
## Summary
- fix method-specific Task 1 file lookup in Task_2
- check method-specific Task 1 files in Task_4 and Task_6

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883d4a9e1548325932437ea6a313bb7