### PR TITLE
Add TRIAD basis stub

### DIFF
--- a/docs/Python/Task3_Python.md
+++ b/docs/Python/Task3_Python.md
@@ -24,6 +24,9 @@ Optional comparison plots
 The vectors are fed to `triad_svd()`, which forms the Wahba matrix and
 solves for the optimal rotation with a singular value decomposition.
 This is numerically more robust than the classic cross-product formula.
+The file `init_vectors.py` also defines a placeholder `triad_basis()`
+function, mirroring the MATLAB helper of the same name for future
+cross-language alignment.
 
 ### 3.3 Quaternion Output
 - Convert `R_tri` to a quaternion with `rot_to_quaternion()` and enforce a positive scalar component.

--- a/src/gnss_imu_fusion/__init__.py
+++ b/src/gnss_imu_fusion/__init__.py
@@ -3,6 +3,7 @@
 from .init_vectors import (
     average_rotation_matrices,
     svd_alignment,
+    triad_basis,
     triad_svd,
     davenport_q_method,
     butter_lowpass_filter,
@@ -21,6 +22,7 @@ from .plots import (
 __all__ = [
     "average_rotation_matrices",
     "svd_alignment",
+    "triad_basis",
     "triad_svd",
     "davenport_q_method",
     "butter_lowpass_filter",

--- a/src/gnss_imu_fusion/init_vectors.py
+++ b/src/gnss_imu_fusion/init_vectors.py
@@ -30,6 +30,29 @@ def svd_alignment(
     return U @ M @ Vt
 
 
+def triad_basis(vec1: np.ndarray, vec2: np.ndarray) -> np.ndarray:
+    """Return an orthonormal basis using the classic TRIAD construction.
+
+    Parameters
+    ----------
+    vec1 : np.ndarray
+        Primary reference vector.
+    vec2 : np.ndarray
+        Secondary reference vector.
+
+    Returns
+    -------
+    np.ndarray
+        3×3 matrix with ``vec1`` as the first column.
+
+    Notes
+    -----
+    This placeholder mirrors the MATLAB ``triad_basis`` helper and will be
+    expanded to match its functionality.
+    """
+    raise NotImplementedError("triad_basis is not yet implemented")
+
+
 def triad_svd(
     body_vec1: np.ndarray,
     body_vec2: np.ndarray,


### PR DESCRIPTION
## Summary
- add `triad_basis` stub for cross-language parity
- expose `triad_basis` in package `__init__`
- mention the stub in the Task 3 Python docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883dadfaec083258c456d5a56b76d0c