### PR TITLE
Add static ratio warning

### DIFF
--- a/MATLAB/Task_2.m
+++ b/MATLAB/Task_2.m
@@ -221,14 +221,28 @@ end
 
 % --- Calculate static vectors from the interval ---
 N_static = end_idx - start_idx + 1;
+dataset_len = size(acc_filt, 1);
+static_duration = N_static * dt_imu;
+dataset_duration = dataset_len * dt_imu;
+
 static_acc_row = mean(acc_filt(start_idx:end_idx, :), 1);
 static_gyro_row = mean(gyro_filt(start_idx:end_idx, :), 1);
 acc_var = var(acc_filt(start_idx:end_idx, :), 0, 1);
 gyro_var = var(gyro_filt(start_idx:end_idx, :), 0, 1);
 
-fprintf('Static interval found: samples %d to %d (length %d samples)\n', start_idx, end_idx, N_static);
+fprintf('Static interval found: samples %d to %d (length %d samples, %.2f s)\n', ...
+        start_idx, end_idx, N_static, static_duration);
 fprintf('  Accel variance: [%.4g %.4g %.4g]\n', acc_var);
 fprintf('  Gyro  variance: [%.4g %.4g %.4g]\n', gyro_var);
+fprintf('  Static window covers %.1f%% of dataset duration.\n', ...
+        (N_static / dataset_len) * 100);
+fprintf('  Dataset duration: %.2f s\n', dataset_duration);
+if (N_static / dataset_len) > 0.90
+    warning(['Task_2:StaticPortionHigh', ...
+             ': detected static interval covers %.1f%% of the dataset. ', ...
+             'Verify motion data or adjust detection thresholds.'], ...
+            (N_static / dataset_len) * 100);
+end
 
 g_norm = norm(static_acc_row);
 fprintf('Estimated gravity magnitude from IMU: %.4f m/s^2 (expected ~%.2f)\n', ...

--- a/docs/MATLAB/Task2_MATLAB.md
+++ b/docs/MATLAB/Task2_MATLAB.md
@@ -29,6 +29,9 @@ Body-frame gravity g_body and Earth rate ω_ie_body
 - Optionally scale the accelerometer vector so its magnitude equals `9.81`.
 - Plot the detected interval with `plot_zupt_and_variance` and save the PDF.
 - When labelling the plot refer to the [standardized legend terms](../PlottingChecklist.md#standardized-legend-terms).
+- The duration of the static window is printed. If it exceeds 90% of the total
+  dataset a warning suggests verifying the motion data or relaxing the
+  detection thresholds.
 
 ### 2.3 Derive Body‑Frame Vectors
 - Negate the accelerometer mean to produce `g_body`.

--- a/docs/Python/Task2_Python.md
+++ b/docs/Python/Task2_Python.md
@@ -29,6 +29,9 @@ Body-frame gravity g_body and Earth rate ω_ie_body
 - Optionally scale the accelerometer vector so its magnitude is exactly `9.81 m/s²`.
 - Plot the detected interval with `plot_zupt_and_variance()` and save the PDF to `results/<tag>_ZUPT_variance.pdf`.
 - Refer to the [standardized legend terms](../PlottingChecklist.md#standardized-legend-terms) when labelling the curves.
+- The script prints the duration of the static window. If more than 90% of the
+  dataset is flagged as static a warning advises checking the motion data or
+  tweaking the detection thresholds.
 
 ### 2.3 Derive Body‑Frame Vectors
 - Negate the accelerometer mean to obtain `g_body`.

--- a/src/gnss_imu_fusion/init.py
+++ b/src/gnss_imu_fusion/init.py
@@ -113,6 +113,24 @@ def measure_body_vectors(
     else:
         static_start = max(0, static_start)
         static_end = min(static_end or len(acc), len(acc))
+
+    static_len = static_end - static_start
+    dataset_len = len(acc)
+    static_ratio = static_len / dataset_len
+    logging.info(
+        "Static interval: samples %d-%d (%.2f s) covering %.1f%% of dataset",
+        static_start,
+        static_end,
+        static_len * dt,
+        static_ratio * 100,
+    )
+    if static_ratio > 0.90:
+        logging.warning(
+            "Detected static interval covers %.1f%% of the dataset. "
+            "Verify motion data or adjust detection thresholds.",
+            static_ratio * 100,
+        )
+
     static_acc = np.mean(acc[static_start:static_end], axis=0)
     static_gyro = np.mean(gyro[static_start:static_end], axis=0)
     scale = GRAVITY / np.linalg.norm(static_acc)


### PR DESCRIPTION
## Summary
- compute how much of Task_2's dataset is flagged as static
- warn if static portion exceeds 90%
- document the new check in MATLAB and Python Task 2 docs

## Testing
- `pytest tests/test_ecef_to_geodetic.py::test_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_6883dade79b083258966234c243ea30a