### PR TITLE
Add static interval duration warning

### DIFF
--- a/MATLAB/Task_2.m
+++ b/MATLAB/Task_2.m
@@ -238,6 +238,17 @@ fprintf('Static interval found: samples %d to %d (length %d samples)\n', start_i
 fprintf('  Accel variance: [%.4g %.4g %.4g]\n', acc_var);
 fprintf('  Gyro  variance: [%.4g %.4g %.4g]\n', gyro_var);
 
+% Compute duration of the static portion and compare with total dataset length
+static_duration = N_static * dt_imu;
+total_duration  = size(acc_filt, 1) * dt_imu;
+ratio_static = static_duration / total_duration;
+fprintf('Static interval duration: %.2f s of %.2f s total (%.1f%%)\n', ...
+        static_duration, total_duration, ratio_static*100);
+if ratio_static > 0.90
+    warning(['Static interval covers %.1f%% of the dataset. Verify motion data ' ...
+            'or adjust detection thresholds.'], ratio_static*100);
+end
+
 g_norm = norm(static_acc_row);
 fprintf('Estimated gravity magnitude from IMU: %.4f m/s^2 (expected ~%.2f)\n', ...
         g_norm, norm(g_NED));

--- a/docs/MATLAB/Task2_MATLAB.md
+++ b/docs/MATLAB/Task2_MATLAB.md
@@ -29,6 +29,10 @@ Body-frame gravity g_body and Earth rate ω_ie_body
 - Optionally scale the accelerometer vector so its magnitude equals `9.81`.
 - Plot the detected interval with `plot_zupt_and_variance` and save the PDF.
 - When labelling the plot refer to the [standardized legend terms](../PlottingChecklist.md#standardized-legend-terms).
+- After detection, the code prints the duration of the static window and
+  compares it to the total dataset length. If more than ~90 % of the data is
+  flagged as static, a warning suggests verifying the motion log or relaxing the
+  detection thresholds.
 
 ### 2.3 Derive Body‑Frame Vectors
 - Negate the accelerometer mean to produce `g_body`.


### PR DESCRIPTION
## Summary
- compute duration of the detected static window in `Task_2.m`
- warn if more than 90% of the dataset is marked static
- document this check in `docs/MATLAB/Task2_MATLAB.md`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6883dd1c32448325a1b301571e395cf9