### PR TITLE
Add Butterworth filter fallback for MATLAB

### DIFF
--- a/MATLAB/GNSS_IMU_Fusion_single.m
+++ b/MATLAB/GNSS_IMU_Fusion_single.m
@@ -221,7 +221,11 @@ if has_signal_toolbox
     acc_filt = filtfilt(b, a, acc);
     gyro_filt = filtfilt(b, a, gyro);
 else
-    if has_movmean
+    if exist('basic_butterworth_filter','file') == 2
+        warning('Butter/filtfilt unavailable. Using basic\_butterworth\_filter.');
+        acc_filt = basic_butterworth_filter(acc, cutoff, fs, order);
+        gyro_filt = basic_butterworth_filter(gyro, cutoff, fs, order);
+    elseif has_movmean
         warning('Butter/filtfilt unavailable. Using movmean for low-pass filtering.');
         win = max(1, round(fs * 0.05));
         acc_filt = movmean(acc, win, 1, 'Endpoints','shrink');

--- a/MATLAB/Task_2.m
+++ b/MATLAB/Task_2.m
@@ -154,7 +154,11 @@ if has_signal_toolbox
     acc_filt = filtfilt(b, a, acc);
     gyro_filt = filtfilt(b, a, gyro);
 else
-    if has_movmean
+    if exist('basic_butterworth_filter','file') == 2
+        warning('Butter/filtfilt unavailable. Using basic\_butterworth\_filter.');
+        acc_filt = basic_butterworth_filter(acc, cutoff, fs, order);
+        gyro_filt = basic_butterworth_filter(gyro, cutoff, fs, order);
+    elseif has_movmean
         warning('Butter/filtfilt unavailable. Using movmean for low-pass filtering.');
         win = max(1, round(fs * 0.05));
         acc_filt = movmean(acc, win, 1, 'Endpoints','shrink');

--- a/MATLAB/basic_butterworth_filter.m
+++ b/MATLAB/basic_butterworth_filter.m
@@ -1,0 +1,41 @@
+function data_filt = basic_butterworth_filter(data, cutoff, fs, order)
+%BASIC_BUTTERWORTH_FILTER Low-pass Butterworth filtering without toolboxes.
+%   data_filt = BASIC_BUTTERWORTH_FILTER(data, cutoff, fs, order) applies a
+%   zero-phase Butterworth filter to each column of DATA. Coefficients are
+%   computed directly using pole/zero formulas and a bilinear transform. This
+%   is intended as a lightweight fallback when the Signal Processing Toolbox
+%   functions BUTTER or FILTFILT are unavailable.
+%
+%   Parameters
+%   ----------
+%   data   - NxM array of data to filter (samples in rows)
+%   cutoff - Cut-off frequency in Hz (default 5.0)
+%   fs     - Sampling frequency in Hz (default 400)
+%   order  - Filter order (default 4)
+%
+%   Returns
+%   -------
+%   data_filt - Filtered data of the same size as DATA.
+%
+%   This mirrors the butter_lowpass_filter implementation in Python.
+
+    if nargin < 4 || isempty(order);   order = 4;   end
+    if nargin < 3 || isempty(fs);      fs = 400;   end
+    if nargin < 2 || isempty(cutoff);  cutoff = 5.0; end
+
+    % Pre-warp for bilinear transform
+    warped = 2*fs * tan(pi * cutoff / fs);
+    k = 0:(order-1);
+    angles = pi/2 + (2*k+1) * pi / (2*order);
+    poles_analog = warped * exp(1i*angles);
+    poles_digital = (2*fs + poles_analog) ./ (2*fs - poles_analog);
+    zeros_digital = -ones(1, order);
+    gain_analog = warped^order;
+    gain_digital = real(gain_analog ./ prod(2*fs - poles_analog));
+    b = real(poly(zeros_digital)) * gain_digital;
+    a = real(poly(poles_digital));
+
+    % Zero-phase filtering via forward and reverse filtering
+    y = filter(b, a, data);
+    data_filt = flipud(filter(b, a, flipud(y)));
+end

--- a/src/gnss_imu_fusion/__init__.py
+++ b/src/gnss_imu_fusion/__init__.py
@@ -7,6 +7,7 @@ from .init_vectors import (
     triad_svd,
     davenport_q_method,
     butter_lowpass_filter,
+    basic_butterworth_filter,
     angle_between,
     compute_wahba_errors,
 )
@@ -26,6 +27,7 @@ __all__ = [
     "triad_svd",
     "davenport_q_method",
     "butter_lowpass_filter",
+    "basic_butterworth_filter",
     "angle_between",
     "compute_wahba_errors",
     "compute_reference_vectors",

--- a/src/gnss_imu_fusion/init_vectors.py
+++ b/src/gnss_imu_fusion/init_vectors.py
@@ -79,6 +79,13 @@ def butter_lowpass_filter(
     return filtfilt(b, a, data, axis=0)
 
 
+def basic_butterworth_filter(
+    data: np.ndarray, cutoff: float = 5.0, fs: float = 400.0, order: int = 4
+) -> np.ndarray:
+    """Placeholder for MATLAB parity. Not implemented."""
+    raise NotImplementedError("basic_butterworth_filter is MATLAB-only")
+
+
 def angle_between(a: np.ndarray, b: np.ndarray) -> float:
     """Return the angle in degrees between two vectors."""
     a = np.asarray(a)


### PR DESCRIPTION
## Summary
- implement `basic_butterworth_filter` for MATLAB with direct pole/zero design
- use this helper in `Task_2.m` and `GNSS_IMU_Fusion_single.m` when butter/filtfilt are unavailable
- add Python stub and export to keep parity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883dd34a9088325a3f4642ca2ca77d8