### PR TITLE
Quiet covariance lookup

### DIFF
--- a/MATLAB/task6_overlay_plot.m
+++ b/MATLAB/task6_overlay_plot.m
@@ -82,6 +82,9 @@ end
 % -------------------------------------------------------------------------
 function [t, pos, vel, acc] = load_estimate(path, frame)
 %LOAD_ESTIMATE Load fused estimator result from NPZ or MAT.
+%   Covariance matrices (P or P_hist) may be absent in the files. In
+%   line with the Python implementation, missing covariance is silently
+%   ignored here.
 
 ppath = string(path);
 if endsWith(ppath,'.npz')

--- a/src/validate_with_truth.py
+++ b/src/validate_with_truth.py
@@ -454,7 +454,7 @@ def load_estimate(path, times=None):
         match ``times``.
     """
 
-    def pick_key(keys, container, n_cols=None, default=None):
+    def pick_key(keys, container, n_cols=None, default=None, quiet=False):
         """Return the first matching value or any array with *n_cols* columns."""
         for k in keys:
             if k in container:
@@ -465,9 +465,15 @@ def load_estimate(path, times=None):
                     continue
                 arr = np.asarray(v)
                 if arr.ndim == 2 and arr.shape[1] == n_cols:
-                    print(f"Using '{k}' for '{keys[0] if keys else '?'}'")
+                    if not quiet:
+                        logging.debug("Using '%s' for '%s'", k, keys[0] if keys else "?")
                     return v
-        print(f"Could not find any of {keys}. Available keys: {list(container.keys())}")
+        if not quiet:
+            logging.debug(
+                "Could not find any of %s. Available keys: %s",
+                keys,
+                list(container.keys()),
+            )
         return default
 
     if path.endswith(".npz"):
@@ -497,7 +503,7 @@ def load_estimate(path, times=None):
             "pos": pos,
             "vel": vel,
             "quat": quat,
-            "P": pick_key(["P", "P_hist"], data) if pos_found else None,
+            "P": pick_key(["P", "P_hist"], data, quiet=True) if pos_found else None,
             "ref_lat": data.get("ref_lat")
             if data.get("ref_lat") is not None
             else data.get("ref_lat_rad")
@@ -541,7 +547,7 @@ def load_estimate(path, times=None):
             "pos": pos,
             "vel": vel,
             "quat": quat,
-            "P": pick_key(["P", "P_hist"], m) if pos_found else None,
+            "P": pick_key(["P", "P_hist"], m, quiet=True) if pos_found else None,
             "ref_lat": m.get("ref_lat")
             if m.get("ref_lat") is not None
             else m.get("ref_lat_rad")


### PR DESCRIPTION
## Summary
- add `quiet` flag to `pick_key` to optionally suppress logging
- silence covariance warnings in `load_estimate`
- document that MATLAB overlay ignores missing covariance

## Testing
- `pytest -q tests/test_validate_with_truth.py`

------
https://chatgpt.com/codex/tasks/task_e_6884e43d04c08325b0e257e416ce8fa8