### PR TITLE
Fix indexing crash in run_all_methods

### DIFF
--- a/MATLAB/run_all_methods.m
+++ b/MATLAB/run_all_methods.m
@@ -162,10 +162,23 @@ close(fig);
 end
 
 function save_pva_grid(t, pos_ned, vel_ned, acc_ned, outfile)
+%SAVE_PVA_GRID Plot position, velocity and acceleration in a 3x3 grid.
+%   SAVE_PVA_GRID(T, POS, VEL, ACC, OUTFILE) plots the NED position, velocity
+%   and acceleration arrays against time vector T and saves the figure to
+%   OUTFILE.  Missing or malformed arrays are padded with NaNs so that the
+%   function never errors when data is unavailable.
+
     fig = figure('Visible','off','Units','pixels','Position',[0 0 1200 900]);
     tl = tiledlayout(3,3,'TileSpacing','compact','Padding','compact');
     labels = {'North [m]','East [m]','Down [m]'};
     rowTitle = {'Position','Velocity','Acceleration'};
+
+    n = numel(t);
+    filler = @(x) (isempty(x) || size(x,2) < 3 || size(x,1) ~= n);
+    if filler(pos_ned); pos_ned = nan(n,3); end
+    if filler(vel_ned); vel_ned = nan(n,3); end
+    if filler(acc_ned); acc_ned = nan(n,3); end
+
     data = {pos_ned, vel_ned, acc_ned};
     for row = 1:3
         for col = 1:3

--- a/src/scripts/plot_utils.py
+++ b/src/scripts/plot_utils.py
@@ -167,6 +167,16 @@ def plot_pva_grid(
     }
     cols = axis_labels.get(frame, ["X", "Y", "Z"])
 
+    def ensure_array(arr: np.ndarray) -> np.ndarray:
+        n = len(time)
+        if arr is None or arr.size == 0 or arr.ndim != 2 or arr.shape[1] < 3 or arr.shape[0] != n:
+            return np.full((n, 3), np.nan)
+        return arr
+
+    pos = ensure_array(pos)
+    vel = ensure_array(vel)
+    acc = ensure_array(acc)
+
     fig, axes = plt.subplots(3, 3, figsize=(12, 9), sharex=True)
     datasets = [
         (pos, "Position [m]"),


### PR DESCRIPTION
## Summary
- pad PVA grid data with NaNs so missing results don't crash MATLAB plotting
- mirror logic in Python `plot_utils.plot_pva_grid`

## Testing
- `ruff check src/scripts/plot_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884f2b839688325a4aeab89ceba1c86