### PR TITLE
Fix MATLAB output paths and Task 6 run_id

### DIFF
--- a/MATLAB/Task_6.m
+++ b/MATLAB/Task_6.m
@@ -24,8 +24,6 @@ start_time = tic;
 here = fileparts(mfilename('fullpath'));
 root = fileparts(here);
 results_dir = fullfile(root, 'results');
-out_dir = fullfile(results_dir, 'task6', run_id);
-if ~exist(out_dir, 'dir'); mkdir(out_dir); end
 
 if ~isfile(task5_file)
     error('Task_6:FileNotFound', 'Task 5 result not found: %s', task5_file);
@@ -44,6 +42,11 @@ elseif isfield(S,'method')
 else
     method = 'TRIAD';
 end
+
+% Build output directory using method and dataset identifiers
+run_id = sprintf('%s_%s_%s', imu_name, gnss_name, method);
+out_dir = fullfile(results_dir, 'task6', run_id);
+if ~exist(out_dir, 'dir'); mkdir(out_dir); end
 
 % Load gravity vector from Task 1 initialisation
 % Use explicit components to avoid any ambiguity in the filename

--- a/MATLAB/run_all_methods.m
+++ b/MATLAB/run_all_methods.m
@@ -29,7 +29,11 @@ end
 
 methods = {'TRIAD','Davenport','SVD'};
 colors  = {'r','g','b'};
-resultsDir = 'results';
+% Resolve repository root so results directory is consistent regardless of
+% the current working directory.
+here = fileparts(mfilename('fullpath'));
+root = fileparts(here);
+resultsDir = fullfile(root, 'results');
 if ~exist(resultsDir,'dir'); mkdir(resultsDir); end
 
 % Always reference the common STATE\_X001.txt trajectory for Tasks 6 and 7


### PR DESCRIPTION
## Summary
- resolve repository root for results directory in `run_all_methods.m`
- generate `run_id` and output directory inside `Task_6.m` after determining the method

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884f314d34883258eb532b62bac9ae4