### PR TITLE
Add MATLAB TRIAD initialisation pipeline

### DIFF
--- a/src/Task_1.m
+++ b/src/Task_1.m
@@ -1,0 +1,40 @@
+function Task_1(imu_path, gnss_path, method)
+%TASK_1 Initial attitude estimation using TRIAD
+%   TASK_1(IMU_PATH, GNSS_PATH, METHOD) reads the given dataset pair,
+%   converts GNSS velocity from ECEF to NED and computes the body->NED
+%   rotation matrix using the TRIAD algorithm. The result is saved under
+%   results/<IMU>_<GNSS>_TRIAD/initial_attitude.mat and a simple 3-D plot
+%   of the axes is written to initial_orientation.pdf.
+%
+% Example:
+%   Task_1('IMU_X001.dat','GNSS_X001.csv','TRIAD')
+
+    if nargin < 3
+        method = 'TRIAD';
+    end
+
+    data_imu  = utils.read_imu(imu_path);
+    data_gnss = utils.read_gnss(gnss_path);
+
+    % Use first valid GNSS sample
+    idx = find(data_gnss.X_ECEF_m ~= 0 | data_gnss.Y_ECEF_m ~= 0 | data_gnss.Z_ECEF_m ~= 0, 1);
+    lat = data_gnss.Latitude_deg(idx);
+    lon = data_gnss.Longitude_deg(idx);
+    vel_ecef = [data_gnss.VX_ECEF_mps(idx); data_gnss.VY_ECEF_mps(idx); data_gnss.VZ_ECEF_mps(idx)];
+
+    C = utils.ecef2ned_matrix(deg2rad(lat), deg2rad(lon));
+    vel_ned = C * vel_ecef;
+
+    acc_body = data_imu.accel(1,:).';
+    mag_body = data_imu.mag(1,:).';
+
+    [R_bn, q_bn] = utils.triad_algorithm(acc_body, mag_body, vel_ned);
+
+    [~, imu_stem, ~]  = fileparts(imu_path);
+    [~, gnss_stem, ~] = fileparts(gnss_path);
+    out_dir = fullfile('results', sprintf('%s_%s_%s_TRIAD', imu_stem, gnss_stem, method));
+    if ~exist(out_dir, 'dir'); mkdir(out_dir); end
+
+    utils.save_attitude_output(out_dir, R_bn, q_bn);
+    utils.plot_initial_orientation(out_dir, R_bn);
+end

--- a/src/matlab_utils.py
+++ b/src/matlab_utils.py
@@ -1,0 +1,36 @@
+"""Python stubs for the MATLAB TRIAD pipeline."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def read_imu(path: str):
+    """Stub for MATLAB :func:`read_imu`."""
+    raise NotImplementedError("read_imu is implemented in MATLAB")
+
+
+def read_gnss(path: str):
+    """Stub for MATLAB :func:`read_gnss`."""
+    raise NotImplementedError("read_gnss is implemented in MATLAB")
+
+
+def ecef2ned_matrix(lat_rad: float, lon_rad: float) -> np.ndarray:
+    """Stub for MATLAB :func:`ecef2ned_matrix`."""
+    raise NotImplementedError("ecef2ned_matrix is implemented in MATLAB")
+
+
+def triad_algorithm(acc_body: np.ndarray, mag_body: np.ndarray, vel_ned: np.ndarray):
+    """Stub for MATLAB :func:`triad_algorithm`."""
+    raise NotImplementedError("triad_algorithm is implemented in MATLAB")
+
+
+def save_attitude_output(out_dir: str, R_bn: np.ndarray, q_bn: np.ndarray):
+    """Stub for MATLAB :func:`save_attitude_output`."""
+    raise NotImplementedError("save_attitude_output is implemented in MATLAB")
+
+
+def plot_initial_orientation(out_dir: str, R_bn: np.ndarray):
+    """Stub for MATLAB :func:`plot_initial_orientation`."""
+    raise NotImplementedError("plot_initial_orientation is implemented in MATLAB")
+

--- a/src/run_all_datasets_matlab.m
+++ b/src/run_all_datasets_matlab.m
@@ -1,0 +1,28 @@
+function run_all_datasets_matlab(method)
+%RUN_ALL_DATASETS_MATLAB Batch process all IMU/GNSS pairs
+%   RUN_ALL_DATASETS_MATLAB(METHOD) runs Task_1 for each dataset pair
+%   using the specified initialisation METHOD (e.g. 'TRIAD').
+%
+% Example:
+%   run_all_datasets_matlab('TRIAD')
+
+    if nargin < 1 || isempty(method)
+        method = 'TRIAD';
+    end
+
+    here = fileparts(mfilename('fullpath'));
+    root = fileparts(here);
+    data_dir = root;
+    pairs = {
+        'IMU_X001.dat', 'GNSS_X001.csv';
+        'IMU_X002.dat', 'GNSS_X002.csv';
+        'IMU_X003.dat', 'GNSS_X002.csv';
+    };
+
+    for k = 1:size(pairs,1)
+        imu_file  = fullfile(data_dir, pairs{k,1});
+        gnss_file = fullfile(data_dir, pairs{k,2});
+        fprintf('Processing %s + %s using %s...\n', pairs{k,1}, pairs{k,2}, method);
+        Task_1(imu_file, gnss_file, method);
+    end
+end

--- a/src/run_triad_only.m
+++ b/src/run_triad_only.m
@@ -1,0 +1,9 @@
+function run_triad_only()
+%RUN_TRIAD_ONLY Entry point mirroring src/run_triad_only.py
+%   RUN_TRIAD_ONLY() executes run_all_datasets_matlab('TRIAD').
+%
+% Usage:
+%   run_triad_only
+
+    run_all_datasets_matlab('TRIAD');
+end

--- a/src/utils/ecef2ned_matrix.m
+++ b/src/utils/ecef2ned_matrix.m
@@ -1,0 +1,14 @@
+function C = ecef2ned_matrix(lat_rad, lon_rad)
+%ECEF2NED_MATRIX Rotation matrix from ECEF to NED frame.
+%   C = ECEF2NED_MATRIX(LAT_RAD, LON_RAD) returns a 3x3 matrix that
+%   rotates a vector from the Earth-Centred Earth-Fixed frame to the
+%   local North-East-Down frame.
+
+    s_lat = sin(lat_rad); c_lat = cos(lat_rad);
+    s_lon = sin(lon_rad); c_lon = cos(lon_rad);
+    C = [
+        -s_lat * c_lon, -s_lat * s_lon,  c_lat;
+        -s_lon,          c_lon,         0;
+        -c_lat * c_lon, -c_lat * s_lon, -s_lat
+    ];
+end

--- a/src/utils/plot_initial_orientation.m
+++ b/src/utils/plot_initial_orientation.m
@@ -1,0 +1,21 @@
+function plot_initial_orientation(out_dir, R_bn)
+%PLOT_INITIAL_ORIENTATION Generate a simple 3-D axis plot of orientation.
+%   PLOT_INITIAL_ORIENTATION(DIR, R_BN) saves a PDF figure showing the NED
+%   axes transformed by R_BN.
+
+    figure('Visible','off');
+    quiver3(0,0,0,1,0,0,'r','LineWidth',1.5); hold on;
+    quiver3(0,0,0,0,1,0,'g','LineWidth',1.5);
+    quiver3(0,0,0,0,0,1,'b','LineWidth',1.5);
+    T = R_bn';
+    quiver3(0,0,0,T(1,1),T(1,2),T(1,3),'--r');
+    quiver3(0,0,0,T(2,1),T(2,2),T(2,3),'--g');
+    quiver3(0,0,0,T(3,1),T(3,2),T(3,3),'--b');
+    grid on; axis equal;
+    xlabel('X'); ylabel('Y'); zlabel('Z');
+    legend({'N','E','D','b_x','b_y','b_z'},'Location','best');
+    title('Initial Orientation');
+    pdf_file = fullfile(out_dir, 'initial_orientation.pdf');
+    print('-dpdf', pdf_file);
+    close(gcf);
+end

--- a/src/utils/read_gnss.m
+++ b/src/utils/read_gnss.m
@@ -1,0 +1,6 @@
+function data = read_gnss(path)
+%READ_GNSS Load GNSS CSV measurements.
+%   DATA = READ_GNSS(PATH) returns a table with named columns.
+
+    data = readtable(path);
+end

--- a/src/utils/read_imu.m
+++ b/src/utils/read_imu.m
@@ -1,0 +1,16 @@
+function data = read_imu(path)
+%READ_IMU Load IMU measurements from a text file.
+%   DATA = READ_IMU(PATH) returns a struct with fields 'time', 'accel',
+%   'gyro' and 'mag'. The file is assumed to contain columns in this order
+%   with whitespace separation.
+
+    m = readmatrix(path);
+    data.time  = m(:,2);
+    data.accel = m(:,3:5);
+    data.gyro  = m(:,6:8);
+    if size(m,2) >= 11
+        data.mag = m(:,9:11);
+    else
+        data.mag = zeros(size(m,1),3);
+    end
+end

--- a/src/utils/save_attitude_output.m
+++ b/src/utils/save_attitude_output.m
@@ -1,0 +1,8 @@
+function save_attitude_output(out_dir, R_bn, q_bn)
+%SAVE_ATTITUDE_OUTPUT Save rotation matrix and quaternion.
+%   SAVE_ATTITUDE_OUTPUT(DIR, R_BN, Q_BN) writes initial_attitude.mat to
+%   DIR containing R_bn and q_bn.
+
+    out_file = fullfile(out_dir, 'initial_attitude.mat');
+    save(out_file, 'R_bn', 'q_bn');
+end

--- a/src/utils/triad_algorithm.m
+++ b/src/utils/triad_algorithm.m
@@ -1,0 +1,30 @@
+function [R_bn, q_bn] = triad_algorithm(acc_body, mag_body, vel_ned)
+%TRIAD_ALGORITHM Compute initial attitude using TRIAD.
+%   [R_BN, Q_BN] = TRIAD_ALGORITHM(ACC_BODY, MAG_BODY, VEL_NED) returns the
+%   body-to-NED rotation matrix and equivalent quaternion.
+%   ACC_BODY and MAG_BODY are 3x1 vectors measured in the body frame.
+%   VEL_NED is the velocity vector in the navigation frame.
+
+    b1 = acc_body / norm(acc_body);
+    b2 = cross(b1, mag_body);
+    b2 = b2 / norm(b2);
+    b3 = cross(b1, b2);
+    B = [b1, b2, b3];
+
+    n1 = vel_ned / norm(vel_ned);
+    n_ref = [1; 0; 0];
+    n2 = cross(n1, n_ref);
+    if norm(n2) < eps
+        n_ref = [0; 1; 0];
+        n2 = cross(n1, n_ref);
+    end
+    n2 = n2 / norm(n2);
+    n3 = cross(n1, n2);
+    N = [n1, n2, n3];
+
+    R_bn = B * N';
+    q_bn = rotm2quat(R_bn);
+    if q_bn(1) < 0
+        q_bn = -q_bn;
+    end
+end


### PR DESCRIPTION
## Summary
- implement a small MATLAB pipeline to run the TRIAD attitude estimation
- add supporting utility functions in `src/utils`
- provide Python stubs for MATLAB functions

## Testing
- `pytest -k matlab -q`
- `ruff check src/matlab_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6884f5aebfa08325839b30d81c1902fc