### PR TITLE
Add MATLAB TRIAD batch pipeline

### DIFF
--- a/src/Task_1.m
+++ b/src/Task_1.m
@@ -1,0 +1,58 @@
+function result = Task_1(imu_file, gnss_file, method)
+%TASK_1  TRIAD-based initial attitude estimation.
+%   RESULT = TASK_1(IMU_FILE, GNSS_FILE, METHOD) loads the IMU and GNSS logs,
+%   derives the reference and body vectors and solves for the body-to-NED
+%   rotation using the TRIAD algorithm.  The output rotation matrix ``R_bn``
+%   and quaternion ``q_bn`` are saved under ``results/<IMU>_<GNSS>_METHOD/``.
+%
+%   This function mirrors the logic of ``src/run_triad_only.py`` but is
+%   implemented in MATLAB for cross-language parity.
+%
+% See also: run_all_datasets_matlab, triad_algorithm
+
+    if nargin < 3 || isempty(method)
+        method = 'TRIAD';
+    end
+
+    [~, imu_name, ~]  = fileparts(imu_file);
+    [~, gnss_name, ~] = fileparts(gnss_file);
+    tag = sprintf('%s_%s_%s', imu_name, gnss_name, method);
+    out_dir = fullfile('results', tag);
+    if ~exist(out_dir, 'dir'); mkdir(out_dir); end
+
+    % Load data
+    imu  = read_imu(imu_file);
+    gnss = read_gnss(gnss_file);
+
+    % First valid GNSS sample for reference location
+    idx = find((gnss.X_ECEF_m ~= 0) | (gnss.Y_ECEF_m ~= 0) | ...
+               (gnss.Z_ECEF_m ~= 0), 1, 'first');
+    if isempty(idx)
+        error('No valid GNSS position in %s', gnss_file);
+    end
+    [lat_deg, lon_deg, ~] = ecef2geodetic(gnss.X_ECEF_m(idx), ...
+                                         gnss.Y_ECEF_m(idx), ...
+                                         gnss.Z_ECEF_m(idx));
+    lat = deg2rad(lat_deg);
+    lon = deg2rad(lon_deg);
+    C_e2n = ecef2ned_matrix(lat, lon);
+
+    vel_ecef = [gnss.VX_ECEF_mps(idx), gnss.VY_ECEF_mps(idx), gnss.VZ_ECEF_mps(idx)]';
+    vel_ned = C_e2n * vel_ecef;
+
+    % Simple static interval: first 200 samples
+    win = 1:min(200, numel(imu.time_s));
+    g_body = -mean(imu.accel_mps2(win, :), 1)';
+    omega_body = mean(imu.gyro_radps(win, :), 1)';
+
+    g_ned = [0; 0; 9.80665];
+    omega_ned = 7.292115e-5 * [cos(lat); 0; -sin(lat)];
+
+    [R_bn, q_bn] = triad_algorithm(g_body, omega_body, g_ned, omega_ned);
+
+    save_attitude_output(out_dir, R_bn, q_bn);
+    plot_initial_orientation(R_bn, out_dir);
+
+    result.R_bn = R_bn;
+    result.q_bn = q_bn;
+end

--- a/src/run_all_datasets_matlab.m
+++ b/src/run_all_datasets_matlab.m
@@ -1,0 +1,43 @@
+function run_all_datasets_matlab(method)
+%RUN_ALL_DATASETS_MATLAB  Loop over all IMU/GNSS pairs.
+%   RUN_ALL_DATASETS_MATLAB(METHOD) calls Task_1 for each available dataset
+%   pair using the specified initialisation METHOD.  When METHOD is omitted
+%   it defaults to 'TRIAD'.
+%
+% The helper mirrors ``src/run_triad_only.py`` but is implemented entirely in
+% MATLAB for cross-language parity.
+%
+% Example:
+%   run_all_datasets_matlab('TRIAD');
+%
+% See also: Task_1, run_triad_only
+
+    if nargin < 1 || isempty(method)
+        method = 'TRIAD';
+    end
+
+    here = fileparts(mfilename('fullpath'));
+    root = fileparts(here);
+    data_dir = fullfile(root, 'Data');
+    if ~exist(data_dir, 'dir')
+        data_dir = root;
+    end
+
+    pairs = {
+        'IMU_X001.dat', 'GNSS_X001.csv';
+        'IMU_X002.dat', 'GNSS_X002.csv';
+        'IMU_X003.dat', 'GNSS_X002.csv';
+    };
+
+    for k = 1:size(pairs, 1)
+        imu_file  = fullfile(data_dir, pairs{k,1});
+        gnss_file = fullfile(data_dir, pairs{k,2});
+        if ~isfile(imu_file)
+            imu_file = fullfile(root, pairs{k,1});
+        end
+        if ~isfile(gnss_file)
+            gnss_file = fullfile(root, pairs{k,2});
+        end
+        Task_1(imu_file, gnss_file, method);
+    end
+end

--- a/src/run_triad_only.m
+++ b/src/run_triad_only.m
@@ -1,0 +1,14 @@
+function run_triad_only
+%RUN_TRIAD_ONLY  Process all datasets using the TRIAD method only
+%   This mirrors the behaviour of ``src/run_triad_only.py`` but runs the
+%   simplified MATLAB Task 1 pipeline.  All IMU/GNSS pairs bundled with the
+%   repository are processed and the initial attitude for each pair is saved
+%   under ``results/<IMU>_<GNSS>_TRIAD/``.
+%
+% Usage:
+%   run_triad_only
+%
+% See also: run_all_datasets_matlab, Task_1
+
+    run_all_datasets_matlab('TRIAD');
+end

--- a/src/utils/ecef2ned_matrix.m
+++ b/src/utils/ecef2ned_matrix.m
@@ -1,0 +1,15 @@
+function C = ecef2ned_matrix(lat_rad, lon_rad)
+%ECEF2NED_MATRIX  Rotation matrix from ECEF to NED.
+%   C = ECEF2NED_MATRIX(LAT_RAD, LON_RAD) returns the 3x3 rotation matrix
+%   that transforms vectors in the ECEF frame to the local North-East-Down
+%   frame at the specified latitude and longitude (radians).
+
+    s_lat = sin(lat_rad);
+    c_lat = cos(lat_rad);
+    s_lon = sin(lon_rad);
+    c_lon = cos(lon_rad);
+
+    C = [-s_lat * c_lon, -s_lat * s_lon,  c_lat; ...
+         -s_lon,          c_lon,         0; ...
+         -c_lat * c_lon, -c_lat * s_lon, -s_lat];
+end

--- a/src/utils/plot_initial_orientation.m
+++ b/src/utils/plot_initial_orientation.m
@@ -1,0 +1,21 @@
+function plot_initial_orientation(R_bn, out_dir)
+%PLOT_INITIAL_ORIENTATION  Visualise the body axes in NED.
+%   PLOT_INITIAL_ORIENTATION(R_BN, OUT_DIR) draws a simple 3‑D plot of the
+%   body axes defined by the rotation matrix and saves it as
+%   ``initial_orientation.pdf`` in OUT_DIR.
+
+    fig = figure('Visible','off'); %#ok<LFIG>
+    quiver3(0,0,0,1,0,0,'r','LineWidth',1.5); hold on;
+    quiver3(0,0,0,0,1,0,'g','LineWidth',1.5);
+    quiver3(0,0,0,0,0,1,'b','LineWidth',1.5);
+    A = R_bn';
+    quiver3(0,0,0,A(1,1),A(1,2),A(1,3),'--r');
+    quiver3(0,0,0,A(2,1),A(2,2),A(2,3),'--g');
+    quiver3(0,0,0,A(3,1),A(3,2),A(3,3),'--b');
+    xlabel('North'); ylabel('East'); zlabel('Down');
+    legend({'N','E','D','Body X','Body Y','Body Z'},'Location','best');
+    grid on; axis equal; view(35,20);
+    file = fullfile(out_dir,'initial_orientation.pdf');
+    print(fig, file, '-dpdf');
+    close(fig);
+end

--- a/src/utils/read_gnss.m
+++ b/src/utils/read_gnss.m
@@ -1,0 +1,8 @@
+function gnss = read_gnss(filename)
+%READ_GNSS  Load GNSS CSV log into a table.
+%   GNSS = READ_GNSS(FILENAME) returns a table containing the columns
+%   ``X_ECEF_m``, ``Y_ECEF_m``, ``Z_ECEF_m`` and their velocities in m/s.
+
+    opts = detectImportOptions(filename);
+    gnss = readtable(filename, opts);
+end

--- a/src/utils/read_imu.m
+++ b/src/utils/read_imu.m
@@ -1,0 +1,24 @@
+function imu = read_imu(filename)
+%READ_IMU  Load IMU measurements from a .dat file.
+%   IMU = READ_IMU(FILENAME) returns a struct with time, gyroscope and
+%   accelerometer data.  The file format is expected to match the sample
+%   logs bundled with the repository:
+%       [index, time, dtheta_x, dtheta_y, dtheta_z, dv_x, dv_y, dv_z, ...]
+%
+%   Gyroscope and accelerometer increments are converted to rates using the
+%   sampling period derived from the time column or a default of 400 Hz.
+
+    data = readmatrix(filename);
+    if size(data,2) < 8
+        error('Unexpected IMU format in %s', filename);
+    end
+    time = data(:,2);
+    if numel(time) > 1
+        dt = mean(diff(time(1:min(end,100))));
+    else
+        dt = 1/400; % fall back
+    end
+    imu.time_s = time;
+    imu.gyro_radps = data(:,3:5) / dt;
+    imu.accel_mps2 = data(:,6:8) / dt;
+end

--- a/src/utils/save_attitude_output.m
+++ b/src/utils/save_attitude_output.m
@@ -1,0 +1,13 @@
+function save_attitude_output(out_dir, R_bn, q_bn)
+%SAVE_ATTITUDE_OUTPUT  Store rotation matrix and quaternion.
+%   SAVE_ATTITUDE_OUTPUT(OUT_DIR, R_BN, Q_BN) writes ``initial_attitude.mat``
+%   to OUT_DIR containing ``R_bn`` and ``q_bn``.
+
+    if ~exist(out_dir, 'dir')
+        mkdir(out_dir);
+    end
+    file = fullfile(out_dir, 'initial_attitude.mat');
+    R_bn = double(R_bn); %#ok<NASGU>
+    q_bn = double(q_bn); %#ok<NASGU>
+    save(file, 'R_bn', 'q_bn');
+end

--- a/src/utils/triad_algorithm.m
+++ b/src/utils/triad_algorithm.m
@@ -1,0 +1,54 @@
+function [R_bn, q_bn] = triad_algorithm(v1_b, v2_b, v1_n, v2_n)
+%TRIAD_ALGORITHM  Compute body-to-NED rotation using TRIAD.
+%   [R, Q] = TRIAD_ALGORITHM(V1_B, V2_B, V1_N, V2_N) returns the rotation
+%   matrix ``R`` and quaternion ``Q`` (``[w x y z]``) that align the body
+%   frame vectors ``V1_B``/``V2_B`` with the reference vectors
+%   ``V1_N``/``V2_N`` in the NED frame.
+
+    M_b = triad_basis(v1_b, v2_b);
+    M_n = triad_basis(v1_n, v2_n);
+    R_bn = M_n * M_b';
+    q_bn = rotm2quat_custom(R_bn);
+end
+
+function M = triad_basis(v1, v2)
+    t1 = v1 / norm(v1);
+    t2 = cross(t1, v2);
+    t2 = t2 / norm(t2);
+    t3 = cross(t1, t2);
+    M = [t1(:), t2(:), t3(:)];
+end
+
+function q = rotm2quat_custom(R)
+    tr = trace(R);
+    if tr > 0
+        S = sqrt(tr + 1.0) * 2;
+        qw = 0.25 * S;
+        qx = (R(3,2) - R(2,3)) / S;
+        qy = (R(1,3) - R(3,1)) / S;
+        qz = (R(2,1) - R(1,2)) / S;
+    else
+        [~, idx] = max([R(1,1), R(2,2), R(3,3)]);
+        switch idx
+            case 1
+                S = sqrt(1 + R(1,1) - R(2,2) - R(3,3)) * 2;
+                qw = (R(3,2) - R(2,3)) / S;
+                qx = 0.25 * S;
+                qy = (R(1,2) + R(2,1)) / S;
+                qz = (R(1,3) + R(3,1)) / S;
+            case 2
+                S = sqrt(1 + R(2,2) - R(1,1) - R(3,3)) * 2;
+                qw = (R(1,3) - R(3,1)) / S;
+                qx = (R(1,2) + R(2,1)) / S;
+                qy = 0.25 * S;
+                qz = (R(2,3) + R(3,2)) / S;
+            case 3
+                S = sqrt(1 + R(3,3) - R(1,1) - R(2,2)) * 2;
+                qw = (R(2,1) - R(1,2)) / S;
+                qx = (R(1,3) + R(3,1)) / S;
+                qy = (R(2,3) + R(3,2)) / S;
+                qz = 0.25 * S;
+        end
+    end
+    q = [qw, qx, qy, qz];
+end


### PR DESCRIPTION
## Summary
- implement MATLAB equivalent of `run_triad_only.py`
- loop through default dataset pairs and run simplified Task 1
- utilities for reading data, converting frames and running TRIAD
- save orientation results and plot initial axes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884f59ddbb883259b3cc27ddf6514c4