### PR TITLE
Fix trailing whitespace in MATLAB script

### DIFF
--- a/MATLAB/run_all_datasets_matlab.m
+++ b/MATLAB/run_all_datasets_matlab.m
@@ -18,7 +18,7 @@ else
     method_list = method;
 end
 
-here = fileparts(mfilename('fullpath')); 
+here = fileparts(mfilename('fullpath'));
 root = fileparts(here);
 % Ensure this file's folder is on the MATLAB path so Task_* functions are
 % found even after changing directories. This mirrors the behaviour of the


### PR DESCRIPTION
## Summary
- ensure no trailing whitespace near line continuations in `run_all_datasets_matlab.m`

## Testing
- `matlab -batch "addpath('MATLAB'); run_all_datasets_matlab"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688544ff57c08325a9272735027ae129