### PR TITLE
Fix Task_5 result logging

### DIFF
--- a/MATLAB/Task_5.m
+++ b/MATLAB/Task_5.m
@@ -474,10 +474,12 @@ results = struct('method', method, 'rmse_pos', rmse_pos, 'rmse_vel', rmse_vel, .
     'grav_err_mean', grav_err_mean, 'grav_err_max', grav_err_max, ...
     'omega_err_mean', omega_err_mean, 'omega_err_max', omega_err_max);
 perf_file = fullfile(results_dir, 'IMU_GNSS_bias_and_performance.mat');
+% Result Logging -- store the metrics struct under the variable name
+% ``results`` to stay in sync with the Python pipeline.
 if isfile(perf_file)
-    save(perf_file, '-append', 'output_matlab');
+    save(perf_file, '-append', 'results');
 else
-    save(perf_file, 'output_matlab');
+    save(perf_file, 'results');
 end
 
 summary_file = fullfile(results_dir, 'IMU_GNSS_summary.txt');


### PR DESCRIPTION
## Summary
- correct variable name when saving Task 5 metrics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68854988634c83259ca46dba3a20ff91