### PR TITLE
Fix missing results_dir in MATLAB Task_6

### DIFF
--- a/MATLAB/Task_6.m
+++ b/MATLAB/Task_6.m
@@ -7,9 +7,10 @@ function Task_6(task5_file, imu_path, gnss_path, truth_file)
 %   frames.  Truth data in the ECEF frame is first converted to the
 %   estimator's local NED coordinates using ``compute_C_ECEF_to_NED`` so
 %   that residuals are expressed in a consistent frame.  The resulting
-%   ``*_overlay_truth.pdf`` files are stored under ``output_matlab/``.  This
-%   function expects the initialization output from Task 1 and the filter
-%   output from Task 5 to be present in the ``results`` directory.
+%   ``*_overlay_truth.pdf`` files are stored under ``output_matlab/`` located
+%   at the repository root.  This function expects the initialization output
+%   from Task 1 and the filter output from Task 5 to reside in that same
+%   directory.
 
 if nargin < 4
     error('Task_6:BadArgs', 'Expected TASK5_FILE, IMU_PATH, GNSS_PATH, TRUTH_FILE');
@@ -23,6 +24,9 @@ start_time = tic;
 
 here = fileparts(mfilename('fullpath'));
 root = fileparts(here);
+% Results directory under repository root
+results_dir = fullfile(root, 'output_matlab');
+if ~exist(results_dir, 'dir'); mkdir(results_dir); end
 
 
 if ~isfile(task5_file)


### PR DESCRIPTION
## Summary
- fix undefined `results_dir` in `Task_6.m`
- clarify documentation about output directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68854eba5fc48325bce32973a6aa642b