### PR TITLE
Fix MATLAB fprintf escape sequence

### DIFF
--- a/MATLAB/Task_1.m
+++ b/MATLAB/Task_1.m
@@ -33,7 +33,7 @@ else
     tag = [imu_name '_' gnss_name '_' method];
 end
 
-fprintf('\u25B6 %s\n', tag); % \u25B6 is the triangle symbol
+fprintf('%s %s\n', char(hex2dec('25B6')), tag); % \u25B6 is the triangle symbol
 fprintf('Ensured ''output_matlab/'' directory exists.\n');
 if ~isempty(method)
     fprintf('Running attitude-estimation method: %s\n', method);


### PR DESCRIPTION
## Summary
- fix MATLAB printf for Task 1 to avoid escape warnings

## Testing
- `pytest -k matlab -q`

------
https://chatgpt.com/codex/tasks/task_e_6885f644a8f48325a360c52243a80821