### PR TITLE
Fix sign_ned in MATLAB Task 6

### DIFF
--- a/MATLAB/Task_6.m
+++ b/MATLAB/Task_6.m
@@ -16,6 +16,10 @@ if nargin < 4
     error('Task_6:BadArgs', 'Expected TASK5_FILE, IMU_PATH, GNSS_PATH, TRUTH_FILE');
 end
 
+% Sign convention for NED -> NEU conversion
+% (mirrors ``task6_plot_truth.py`` in the Python code)
+sign_ned = [1; 1; -1];
+
 fprintf('Starting Task 6 overlay ...\n');
 start_time = tic;
 


### PR DESCRIPTION
## Summary
- define `sign_ned` in `Task_6.m`
- note the Python sign convention in the comments

## Testing
- `octave --no-gui MATLAB/run_all_datasets_matlab.m` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885f643ad448325b0b71dbbc39726d2