### PR TITLE
Add static interval ratio logging

### DIFF
--- a/src/gnss_imu_fusion/init.py
+++ b/src/gnss_imu_fusion/init.py
@@ -84,7 +84,12 @@ def measure_body_vectors(
     static_end: Optional[int] = None,
     mag_file: Optional[str] = None,
 ) -> Tuple[float, np.ndarray, np.ndarray, Optional[np.ndarray]]:
-    """Estimate gravity and Earth rotation in the body frame."""
+    """Estimate gravity and Earth rotation in the body frame.
+
+    The function detects a static IMU segment, logs its duration relative
+    to the full dataset and warns when the static portion exceeds 90% of
+    all samples, mirroring the MATLAB implementation.
+    """
     data = np.loadtxt(imu_file)
     if data.shape[1] < 10:
         raise ValueError("Unexpected IMU data format")
@@ -115,6 +120,24 @@ def measure_body_vectors(
         static_end = min(static_end or len(acc), len(acc))
     static_acc = np.mean(acc[static_start:static_end], axis=0)
     static_gyro = np.mean(gyro[static_start:static_end], axis=0)
+
+    # --- Compute ratio of static to total samples and log duration
+    n_static = static_end - static_start
+    static_duration = n_static * dt
+    total_duration = len(acc) * dt
+    ratio_static = static_duration / total_duration
+    logging.info(
+        "Static interval duration: %.2f s of %.2f s total (%.1f%%)",
+        static_duration,
+        total_duration,
+        ratio_static * 100,
+    )
+    if ratio_static > 0.90:
+        logging.warning(
+            "Static interval covers %.1f%% of the dataset. Verify motion data "
+            "or adjust detection thresholds.",
+            ratio_static * 100,
+        )
     scale = GRAVITY / np.linalg.norm(static_acc)
     acc *= scale
     static_acc *= scale


### PR DESCRIPTION
## Summary
- log duration and warn when static ratio exceeds 0.9 in `measure_body_vectors`

## Testing
- `ruff check src/gnss_imu_fusion/init.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885fe6bc1d88325a588823be41ebfe2