### PR TITLE
Add MATLAB stubs for reference and body vectors

### DIFF
--- a/MATLAB/compute_reference_vectors.m
+++ b/MATLAB/compute_reference_vectors.m
@@ -1,0 +1,29 @@
+function [lat_deg, lon_deg, alt, g_ned, omega_ie_ned, mag_ned, initial_vel_ned, pos_ecef] = compute_reference_vectors(gnss_file, mag_file)
+%COMPUTE_REFERENCE_VECTORS  Stub corresponding to the Python implementation.
+%   [LAT_DEG, LON_DEG, ALT, G_NED, OMEGA_IE_NED, MAG_NED, INITIAL_VEL_NED, POS_ECEF] =
+%   COMPUTE_REFERENCE_VECTORS(GNSS_FILE, MAG_FILE) mirrors the interface of
+%   the Python function of the same name. It will load GNSS data to
+%   establish the reference latitude, longitude and altitude, compute the
+%   gravity and Earth rotation vectors in the NED frame, and optionally use
+%   magnetometer measurements. The full MATLAB implementation is pending.
+%
+%   This stub is provided for API parity only. All outputs are empty.
+%
+%   See also: COMPUTE_REFERENCE_VECTORS in Python.
+
+if nargin < 2
+    mag_file = [];
+end
+
+warning('compute_reference_vectors:NotImplemented', ...
+    'compute_reference_vectors.m is a stub. Full implementation pending.');
+
+lat_deg = [];
+lon_deg = [];
+alt = [];
+g_ned = [];
+omega_ie_ned = [];
+mag_ned = [];
+initial_vel_ned = [];
+pos_ecef = [];
+end

--- a/MATLAB/measure_body_vectors.m
+++ b/MATLAB/measure_body_vectors.m
@@ -1,0 +1,24 @@
+function [dt, g_body, omega_ie_body, mag_body] = measure_body_vectors(imu_file, static_start, static_end, mag_file)
+%MEASURE_BODY_VECTORS  Stub corresponding to the Python implementation.
+%   [DT, G_BODY, OMEGA_IE_BODY, MAG_BODY] = MEASURE_BODY_VECTORS(IMU_FILE,
+%   STATIC_START, STATIC_END, MAG_FILE) mirrors the interface of the Python
+%   function of the same name. It will estimate the gravity and Earth
+%   rotation vectors in the body frame from IMU data and optionally use
+%   magnetometer measurements. The full MATLAB implementation is pending.
+%
+%   This stub is provided for API parity only. All outputs are empty.
+%
+%   See also: MEASURE_BODY_VECTORS in Python.
+
+if nargin < 4
+    mag_file = [];
+end
+
+warning('measure_body_vectors:NotImplemented', ...
+    'measure_body_vectors.m is a stub. Full implementation pending.');
+
+dt = [];
+g_body = [];
+omega_ie_body = [];
+mag_body = [];
+end


### PR DESCRIPTION
## Summary
- add compute_reference_vectors.m stub mirroring Python interface
- add measure_body_vectors.m stub mirroring Python interface

## Testing
- `pytest -q` *(tests pass; interrupted after summary output)*

------
https://chatgpt.com/codex/tasks/task_e_6885fe87a30c83258739f780d3c68350