### PR TITLE
Handle window size exceeding data length in static detection

### DIFF
--- a/MATLAB/GNSS_IMU_Fusion_single.m
+++ b/MATLAB/GNSS_IMU_Fusion_single.m
@@ -255,6 +255,12 @@ if exist('movvar','file') == 2
     gyro_var  = movvar(gyro_filt, window_size, 0, 'Endpoints', 'discard');
 else
     warning('movvar unavailable. Using manual (slower) moving variance calculation.');
+
+    if size(acc_filt,1) < window_size
+        warning('window_size (%d) larger than data length (%d). Adjusting window size.', ...
+            window_size, size(acc_filt,1));
+        window_size = size(acc_filt,1);
+    end
     num_windows = size(acc_filt, 1) - window_size + 1;
     accel_var = zeros(num_windows, size(acc_filt, 2));
     gyro_var = zeros(num_windows, size(gyro_filt, 2));

--- a/MATLAB/Task_2.m
+++ b/MATLAB/Task_2.m
@@ -191,6 +191,12 @@ if exist('movvar','file') == 2
     gyro_var  = movvar(gyro_filt, window_size, 0, 'Endpoints', 'discard');
 else
     warning('movvar unavailable. Using manual (slower) moving variance calculation.');
+
+    if size(acc_filt,1) < window_size
+        warning('window_size (%d) larger than data length (%d). Adjusting window size.', ...
+            window_size, size(acc_filt,1));
+        window_size = size(acc_filt,1);
+    end
     num_windows = size(acc_filt, 1) - window_size + 1;
     accel_var = zeros(num_windows, size(acc_filt, 2));
     gyro_var = zeros(num_windows, size(gyro_filt, 2));


### PR DESCRIPTION
## Summary
- improve error handling for static interval detection in MATLAB scripts
- warn and adjust `window_size` if data length is too short

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885fe89829483258f802a32ac03e478