### PR TITLE
Fix dash encoding in MATLAB titles

### DIFF
--- a/MATLAB/task6_overlay_plot.m
+++ b/MATLAB/task6_overlay_plot.m
@@ -170,7 +170,7 @@ for ax = 1:3
     switch ax
         case 1
             ylabel('Position [m]');
-            title(sprintf('%s Task 6 Overlay \x2013 %s (%s frame)', dataset, method, upper(frame)));
+            title(sprintf('%s Task 6 Overlay - %s (%s frame)', dataset, method, upper(frame)));
         case 2
             ylabel('Velocity [m/s]');
         otherwise
@@ -214,7 +214,7 @@ xlabel('Time [s]');
 ylabel('Error magnitude');
 grid on;
 legend('Location','northeast');
-title(sprintf('%s Task 6 RMSE \x2013 %s (%s frame)', dataset, method, upper(frame)));
+title(sprintf('%s Task 6 RMSE - %s (%s frame)', dataset, method, upper(frame)));
 set(f,'PaperPositionMode','auto');
 if ~exist(out_dir,'dir'); mkdir(out_dir); end
 pdf_path = fullfile(out_dir, sprintf('%s_%s_Task6_%s_RMSE.pdf', dataset, method, upper(frame)));

--- a/MATLAB/task7_fused_truth_error_analysis.m
+++ b/MATLAB/task7_fused_truth_error_analysis.m
@@ -215,7 +215,7 @@ function plot_residuals(t, res_pos, res_vel, out_dir)
         subplot(2,3,3+j); plot(t, res_vel(:,j));
         xlabel('Time [s]'); ylabel('Vel Residual [m/s]'); grid on;
     end
-    sgtitle('Task 7 \x2013 GNSS - Predicted Residuals');
+    sgtitle('Task 7 - GNSS - Predicted Residuals');
     set(f,'PaperPositionMode','auto');
     pdf = fullfile(out_dir,'task7_3_residuals_position_velocity.pdf');
     print(f,pdf,'-dpdf');


### PR DESCRIPTION
## Summary
- correct `sgtitle` dash character in Task 7 residual plot
- fix dash character in Task 6 overlay plot titles

## Testing
- `pytest -q` *(fails: KeyboardInterrupt but shows 21 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6885fe97b64c832599b650c300a87a87