### PR TITLE
Align MATLAB results directory with repo root

### DIFF
--- a/MATLAB/Task_3.m
+++ b/MATLAB/Task_3.m
@@ -40,6 +40,9 @@ else
     method_tag = method;
 end
 results_dir = get_results_dir();
+if ~exist(results_dir, 'dir')
+    mkdir(results_dir);
+end
 
 % Load vectors produced by Task 1 and Task 2
 task1_file = fullfile(results_dir, ['Task1_init_' tag '.mat']);

--- a/MATLAB/Task_4.m
+++ b/MATLAB/Task_4.m
@@ -30,6 +30,9 @@ if ~isfile(imu_path)
           imu_path);
 end
 results_dir = get_results_dir();
+if ~exist(results_dir, 'dir')
+    mkdir(results_dir);
+end
 [~, imu_name, ~] = fileparts(imu_path);
 [~, gnss_name, ~] = fileparts(gnss_path);
 pair_tag = [imu_name '_' gnss_name];

--- a/MATLAB/get_results_dir.m
+++ b/MATLAB/get_results_dir.m
@@ -1,8 +1,8 @@
 function dir = get_results_dir()
 %GET_RESULTS_DIR Return path to the results directory.
-%   DIR = GET_RESULTS_DIR() returns the path to the 'results' folder
-%   located alongside this function. MATLAB scripts use this helper to
-%   store logs and figures consistently next to the Python outputs.
+%   DIR = GET_RESULTS_DIR() returns the path to the top-level 'results'
+%   folder within the repository. MATLAB scripts use this helper so that
+%   logs and figures are stored next to the Python outputs.
 %
 %   Example:
 %       out = fullfile(get_results_dir(), 'example.mat');
@@ -10,5 +10,7 @@ function dir = get_results_dir()
 %
 %   See also RUN_ALL_DATASETS_MATLAB, RUN_ALL_METHODS.
 
-    dir = fullfile(fileparts(mfilename('fullpath')), 'results');
+    % Determine the repository root (this file resides in <root>/MATLAB).
+    root = fileparts(fileparts(mfilename('fullpath')));
+    dir  = fullfile(root, 'results');
 end


### PR DESCRIPTION
## Summary
- update `get_results_dir` to resolve `<repo>/results`
- ensure results directory exists in `Task_3` and `Task_4`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885fea9f5bc832595a0a23b66107f43