### PR TITLE
Unify docs output directory

### DIFF
--- a/MATLAB/README_pipeline.md
+++ b/MATLAB/README_pipeline.md
@@ -25,7 +25,7 @@ MATLAB/
     Task_4.m
     Task_5.m
     data/
-output_matlab/
+results/
 ```
 
 ### Installing FilterPy (Ubuntu)
@@ -45,8 +45,8 @@ pip install filterpy --no-binary :all:
 ```
 
 Place your `.dat` and `.csv` data files inside the `data/` folder. If the folder is
-missing, the scripts will also look for the files in the repository root. The
-scripts save outputs and plots in `output_matlab/`.
+missing, the scripts will also look for the files in the repository root. Both
+MATLAB and Python scripts save outputs and plots in `results/`.
 
 Run the entire pipeline from MATLAB by executing `main.m`. The script now
 accepts optional file names **and** a list of methods so you can run:
@@ -65,11 +65,11 @@ method (TRIAD, Davenport and SVD by default). Output files include the
 method name so results are preserved for every run.
 
 `Task_4` expects the rotation matrices produced by `Task_3` to be saved as
-`output_matlab/task3_results.mat`. Make sure `Task_3` completes before running
+`results/task3_results.mat`. Make sure `Task_3` completes before running
 `Task_4` separately.
 
 `Task_4` also saves the NED-converted GNSS position array `gnss_pos_ned` to
-`output_matlab/task4_results.mat`.
+`results/task4_results.mat`.
 `Task_5` looks for this file when started or you can pass `gnss_pos_ned`
 directly as an argument.
 
@@ -82,7 +82,7 @@ Task_2('IMU_X001.dat','GNSS_X001.csv','TRIAD')
 
 
 ### Batch processing
-The helper script `run_all_datasets.m` iterates over every `IMU_X*.dat` and `GNSS_X*.csv` pair and runs all three methods. After each run the Task 5 results are loaded into workspace variables such as `result_IMU_X001_GNSS_X001_TRIAD` and saved in `output_matlab/` as `.mat` files.
+The helper script `run_all_datasets.m` iterates over every `IMU_X*.dat` and `GNSS_X*.csv` pair and runs all three methods. After each run the Task 5 results are loaded into workspace variables such as `result_IMU_X001_GNSS_X001_TRIAD` and saved in `results/` as `.mat` files.
 
 ```matlab
 run_all_datasets
@@ -104,7 +104,7 @@ results = TRIAD_batch();
 `TRIAD_batch` resolves file names with `get_data_file`, so the bundled logs are
 found even if you run the command from another folder.  When more than one
 pair is processed the function returns a cell array of result structs, each
-matching the corresponding `output_matlab/Result_<IMU>_<GNSS>_TRIAD.mat` file.
+matching the corresponding `results/Result_<IMU>_<GNSS>_TRIAD.mat` file.
 
 Dedicated wrappers `run_triad_only.m`, `run_svd_only.m` and
 `run_davenport_only.m` behave like the Python helpers of the same name and
@@ -120,7 +120,7 @@ run_davenport_only  % Davenport method
 
 Use `GNSS_IMU_Fusion_single` when you only need to process one IMU/GNSS pair.
 The function mirrors `run_triad_only.py` and generates the same location map,
-Task 3/4/5 results, residuals and attitude plots in the `output_matlab/` folder.
+Task 3/4/5 results, residuals and attitude plots in the `results/` folder.
 After saving the results, `plot_task5_results_all_methods` produces a
 summary of the fused GNSS/IMU trajectory for Task 5.
 
@@ -143,7 +143,7 @@ python src/validate_with_truth.py --est-file <kf.mat> --truth-file STATE_X001.tx
 ```
 
 The comparison figures `<method>_<frame>_overlay_truth.pdf` are stored in the
-`output_matlab/` directory next to the Kalman filter output.
+`results/` directory next to the Kalman filter output.
 
 ### Task 6 – Truth Overlay
 
@@ -151,7 +151,7 @@ The comparison figures `<method>_<frame>_overlay_truth.pdf` are stored in the
 Task 5 result file and the associated data paths:
 
 ```matlab
-task5 = fullfile('output_matlab','IMU_X001_GNSS_X001_TRIAD_task5_results.mat');
+task5 = fullfile('results','IMU_X001_GNSS_X001_TRIAD_task5_results.mat');
 Task_6(task5,'IMU_X001.dat','GNSS_X001.csv','STATE_X001.txt');
 ```
 
@@ -159,7 +159,7 @@ The function loads `<IMU>_<GNSS>_<METHOD>_kf_output.mat`, reads the matching
 `STATE_*.txt` file and interpolates all series to a common time vector. It
 then calls `plot_overlay` for the NED, ECEF and body frames, saving the
 figures `<METHOD>_NED_overlay_truth.pdf`, `<METHOD>_ECEF_overlay_truth.pdf`
-and `<METHOD>_Body_overlay_truth.pdf` in `output_matlab/`.
+and `<METHOD>_Body_overlay_truth.pdf` in `results/`.
 
 ### Compatibility notes
 
@@ -200,8 +200,8 @@ modifying or extending the code so both implementations stay aligned:
    position/velocity RMSE and the final position error. Save these in a struct
    called `results` along with the biases.
 5. **Result Logging** – Write the struct to
-   `output_matlab/IMU_GNSS_bias_and_performance.mat` and optionally append the printed
-   summary to `output_matlab/IMU_GNSS_summary.txt`.
+   `results/IMU_GNSS_bias_and_performance.mat` and optionally append the printed
+   summary to `results/IMU_GNSS_summary.txt`.
 
 Add comments in the code where each step occurs (e.g. `% Task 2.3: Gravity and
 Bias`) to help future maintainers keep the MATLAB and Python versions

--- a/Report/getting_started.md
+++ b/Report/getting_started.md
@@ -43,7 +43,7 @@ python src/run_triad_only.py        # quick demo
 # or
 python src/run_all_datasets.py      # full pipeline
 ```
-The results and validation plots appear inside the newly created `results/run_triad_only/` or `results/run_all_datasets/` folder depending on the script.
+The results and validation plots appear inside the newly created `results/run_triad_only/` or `results/run_all_datasets/` folder depending on the script. MATLAB writes to the same `results/` directory.
 
 ### MATLAB
 
@@ -55,7 +55,7 @@ The results and validation plots appear inside the newly created `results/run_tr
    % or
    run_all_datasets_matlab('TRIAD')
    ```
-   MATLAB saves the figures to the `MATLAB/results/` folder as well. The batch runner lives in `MATLAB/run_all_datasets_matlab.m`.
+   MATLAB saves the figures to the `results/` folder as well. The batch runner lives in `MATLAB/run_all_datasets_matlab.m`.
 
 ## 5. Validate the output
 

--- a/docs/AdvancedTopics.md
+++ b/docs/AdvancedTopics.md
@@ -57,7 +57,7 @@ imu  = get_data_file('IMU_X001.dat');
 gnss = get_data_file('GNSS_X001.csv');
 TRIAD(imu, gnss);
 ```
-`get_data_file` searches `MATLAB/data/` first and falls back to the repository root.
+`get_data_file` searches `MATLAB/data/` first and falls back to the repository root. Both the MATLAB and Python versions store their outputs in the shared `results/` directory.
 
 ### Sequential Task Execution
 
@@ -66,18 +66,18 @@ To replicate the Python pipeline step by step, call each `Task_1`–`Task_5` fun
 imu  = get_data_file('IMU_X001.dat');
 gnss = get_data_file('GNSS_X001.csv');
 
-Task_1(imu, gnss, 'TRIAD');   % -> MATLAB/results/Task1_init_IMU_X001_GNSS_X001_TRIAD.mat
-Task_2(imu, gnss, 'TRIAD');   % -> MATLAB/results/Task2_body_IMU_X001_GNSS_X001_TRIAD.mat
-Task_3(imu, gnss, 'TRIAD');   % uses Task1/2 output, writes MATLAB/results/Task3_results_IMU_X001_GNSS_X001.mat
-Task_4(imu, gnss, 'TRIAD');   % uses Task3 results, writes MATLAB/results/Task4_results_IMU_X001_GNSS_X001.mat
-Task_5(imu, gnss, 'TRIAD');   % uses Task4 results, writes MATLAB/results/Task5_results_IMU_X001_GNSS_X001.mat
+Task_1(imu, gnss, 'TRIAD');   % -> results/Task1_init_IMU_X001_GNSS_X001_TRIAD.mat
+Task_2(imu, gnss, 'TRIAD');   % -> results/Task2_body_IMU_X001_GNSS_X001_TRIAD.mat
+Task_3(imu, gnss, 'TRIAD');   % uses Task1/2 output, writes results/Task3_results_IMU_X001_GNSS_X001.mat
+Task_4(imu, gnss, 'TRIAD');   % uses Task3 results, writes results/Task4_results_IMU_X001_GNSS_X001.mat
+Task_5(imu, gnss, 'TRIAD');   % uses Task4 results, writes results/Task5_results_IMU_X001_GNSS_X001.mat
 ```
 
 ### MATLAB-only pipeline
 ```matlab
 run_all_datasets_matlab('TRIAD')
 ```
-The script `MATLAB/run_all_datasets_matlab.m` accepts the initialisation method as an optional argument. It scans `Data/` (or the repository root if that folder is missing) for matching IMU and GNSS logs, executes `Task_1` through `Task_5` for each pair and saves the results as `IMU_<id>_GNSS_<id>_<METHOD>_kf_output.mat` in `MATLAB/results/`. `plot_results` is invoked automatically to export the standard PDF figures.
+The script `MATLAB/run_all_datasets_matlab.m` accepts the initialisation method as an optional argument. It scans `Data/` (or the repository root if that folder is missing) for matching IMU and GNSS logs, executes `Task_1` through `Task_5` for each pair and saves the results as `IMU_<id>_GNSS_<id>_<METHOD>_kf_output.mat` in `results/`. `plot_results` is invoked automatically to export the standard PDF figures.
 
 Prerequisites: MATLAB R2023a or newer. The **Signal Processing Toolbox** is strongly
 recommended for the MATLAB pipeline. If the toolbox is missing, Task&nbsp;2 falls back to

--- a/docs/DebuggingDrift.md
+++ b/docs/DebuggingDrift.md
@@ -2,12 +2,14 @@
 
 This guide explains how to track down extremely large position errors (tens of kilometres) when running the `MATLAB` pipeline. The Python implementation normally finishes with a final position error around **1 cm**, so any huge discrepancy is a strong indicator of a bug in the MATLAB code or its configuration.
 
+All example paths assume results are written to the shared `results/` directory used by both MATLAB and Python.
+
 ## 1. Detecting the Root Cause
 
 1. **Plot the NED position error** over time. Compare the IMU-derived trajectory against GNSS ground truth to see when the drift begins and whether it grows linearly or quadratically.
 
    ```matlab
-   load('MATLAB/results/Task5_results_IMU_X001_GNSS_X001.mat', ...
+   load('results/Task5_results_IMU_X001_GNSS_X001.mat', ...
         'pos_ned', 'pos_gnss', 't_imu');
    figure;
    plot(t_imu, pos_ned - pos_gnss);


### PR DESCRIPTION
## Summary
- replace `output_matlab/` and `MATLAB/results/` references
- clarify that Python and MATLAB both use the shared `results/` folder

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6885feab8fc883258f925e75a4b67622