### PR TITLE
Add usage notes to MATLAB tasks

### DIFF
--- a/MATLAB/Task_1.m
+++ b/MATLAB/Task_1.m
@@ -2,6 +2,9 @@ function result = Task_1(imu_path, gnss_path, method)
 % TASK 1: Define Reference Vectors in NED Frame
 % This function translates Task 1 from the Python file GNSS_IMU_Fusion.py
 % into MATLAB.
+%
+% Usage:
+%   Task_1(imu_path, gnss_path, method)
 
 if nargin < 3 || isempty(method)
     method = '';

--- a/MATLAB/Task_2.m
+++ b/MATLAB/Task_2.m
@@ -5,6 +5,9 @@ function result = Task_2(imu_path, gnss_path, method)
 %
 % This function translates Task 2 from the Python file GNSS_IMU_Fusion.py
 % into MATLAB.
+%
+% Usage:
+%   Task_2(imu_path, gnss_path, method)
 % =========================================================================
 
 if nargin < 3 || isempty(method)

--- a/MATLAB/Task_3.m
+++ b/MATLAB/Task_3.m
@@ -5,6 +5,9 @@ function task3_results = Task_3(imu_path, gnss_path, method)
 % approaches (TRIAD, Davenport, SVD). It loads the reference and measured
 % vectors saved by Tasks 1 and 2 and stores the resulting rotation
 % matrices for later tasks.
+%
+% Usage:
+%   Task_3(imu_path, gnss_path, method)
 
 if nargin < 1 || isempty(imu_path)
     error('IMU file not specified');

--- a/MATLAB/Task_4.m
+++ b/MATLAB/Task_4.m
@@ -5,6 +5,9 @@ function result = Task_4(imu_path, gnss_path, method)
 %   for backwards compatibility with older scripts.
 %   Requires that `Task_3` has already saved a dataset-specific
 %   results file such as `output_matlab/Task3_results_IMU_X001_GNSS_X001.mat`.
+%
+% Usage:
+%   Task_4(imu_path, gnss_path, method)
 
 if nargin < 1 || isempty(imu_path)
     error('IMU file not specified');

--- a/MATLAB/Task_5.m
+++ b/MATLAB/Task_5.m
@@ -2,6 +2,9 @@ function result = Task_5(imu_path, gnss_path, method, gnss_pos_ned)
 %TASK_5  Run 15-state EKF using IMU & GNSS NED positions
 %   Expects Task 1 outputs saved in the results directory for gravity
 %   initialization.
+%
+% Usage:
+%   Task_5(imu_path, gnss_path, method, gnss_pos_ned)
     if nargin < 1 || isempty(imu_path)
         error('IMU path not specified');
     end

--- a/MATLAB/Task_6.m
+++ b/MATLAB/Task_6.m
@@ -11,6 +11,9 @@ function Task_6(task5_file, imu_path, gnss_path, truth_file)
 %   at the repository root.  This function expects the initialization output
 %   from Task 1 and the filter output from Task 5 to reside in that same
 %   directory.
+%
+% Usage:
+%   Task_6(task5_file, imu_path, gnss_path, truth_file)
 
 if nargin < 4
     error('Task_6:BadArgs', 'Expected TASK5_FILE, IMU_PATH, GNSS_PATH, TRUTH_FILE');

--- a/MATLAB/run_all_datasets_matlab.m
+++ b/MATLAB/run_all_datasets_matlab.m
@@ -8,6 +8,9 @@ function run_all_datasets_matlab(method)
 %   is called on each file to recreate the standard figures. A summary table
 %   mirroring ``src/run_all_datasets.py`` is printed and saved as
 %   output_matlab/summary.csv.
+%
+% Usage:
+%   run_all_datasets_matlab(method)
 
 if nargin < 1 || isempty(method)
     method_list = {'TRIAD','Davenport','SVD'};


### PR DESCRIPTION
## Summary
- document sample invocation for Task_1–Task_6
- document usage for the MATLAB batch runner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885feae91e083258b53da4a028e5eae