### PR TITLE
Fix Task 6 NED sign vector broadcasting

### DIFF
--- a/MATLAB/Task_6.m
+++ b/MATLAB/Task_6.m
@@ -18,7 +18,8 @@ end
 
 % Sign convention for NED -> NEU conversion
 % (mirrors ``task6_plot_truth.py`` in the Python code)
-sign_ned = [1; 1; -1];
+% Use a row vector so element-wise operations broadcast correctly
+sign_ned = [1, 1, -1];
 
 fprintf('Starting Task 6 overlay ...\n');
 start_time = tic;


### PR DESCRIPTION
## Summary
- fix sign_ned orientation in MATLAB Task_6 to avoid size mismatch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885fc72038c8325b9b962b300a21013