### PR TITLE
Align body vector scaling strategy

### DIFF
--- a/docs/MATLAB/Task2_MATLAB.md
+++ b/docs/MATLAB/Task2_MATLAB.md
@@ -26,7 +26,8 @@ Body-frame gravity g_body and Earth rate ω_ie_body
 - Apply a Butterworth low‑pass filter (cut-off around `5 Hz`).
 - Call `detect_static_interval` to find a quiet window and compute mean accelerometer and gyroscope vectors.
 - Save the indices and statistics to `results/triad_init_log.txt`.
-- Optionally scale the accelerometer vector so its magnitude equals `9.81`.
+- Optionally scale **only** the mean accelerometer vector so its magnitude equals `9.81`.
+- The rest of the IMU data is left unscaled to preserve dynamic measurements.
 - Plot the detected interval with `plot_zupt_and_variance` and save the PDF.
 - When labelling the plot refer to the [standardized legend terms](../PlottingChecklist.md#standardized-legend-terms).
 - After detection, the code prints the duration of the static window and

--- a/docs/Python/Task2_Python.md
+++ b/docs/Python/Task2_Python.md
@@ -26,7 +26,8 @@ Body-frame gravity g_body and Earth rate ω_ie_body
 - Apply a Butterworth low‑pass filter around `5 Hz` to suppress high‑frequency noise.
 - Use `detect_static_interval` to find a low‑motion window and compute mean accelerometer and gyroscope vectors.
 - Log the interval indices, means and variances to `triad_init_log.txt`.
-- Optionally scale the accelerometer vector so its magnitude is exactly `9.81 m/s²`.
+- Optionally scale **only** the mean accelerometer vector so its magnitude is exactly `9.81 m/s²`.
+- The rest of the IMU data is left unscaled to preserve dynamic measurements.
 - Plot the detected interval with `plot_zupt_and_variance()` and save the PDF to `results/<tag>_ZUPT_variance.pdf`.
 - Refer to the [standardized legend terms](../PlottingChecklist.md#standardized-legend-terms) when labelling the curves.
 

--- a/src/gnss_imu_fusion/init.py
+++ b/src/gnss_imu_fusion/init.py
@@ -87,8 +87,10 @@ def measure_body_vectors(
     """Estimate gravity and Earth rotation in the body frame.
 
     The function detects a static IMU segment, logs its duration relative
-    to the full dataset and warns when the static portion exceeds 90% of
-    all samples, mirroring the MATLAB implementation.
+    to the full dataset and warns when the static portion exceeds 90%% of
+    all samples, mirroring the MATLAB implementation.  The mean
+    accelerometer vector of the static interval is scaled so that its
+    magnitude equals ``GRAVITY``.  The raw dataset is left unchanged.
     """
     data = np.loadtxt(imu_file)
     if data.shape[1] < 10:
@@ -138,9 +140,11 @@ def measure_body_vectors(
             "or adjust detection thresholds.",
             ratio_static * 100,
         )
+    # Only scale the mean of the static interval so that its magnitude
+    # matches ``GRAVITY``.  This preserves the raw measurements for later
+    # processing while keeping parity with the MATLAB implementation.
     scale = GRAVITY / np.linalg.norm(static_acc)
-    acc *= scale
-    static_acc *= scale
+    static_acc = static_acc * scale
     g_body = -static_acc
     omega_ie_body = static_gyro
 


### PR DESCRIPTION
## Summary
- scale only the static interval mean in `measure_body_vectors`
- clarify scaling approach in Task 2 docs for Python and MATLAB

## Testing
- `pytest -q` *(fails: KeyboardInterrupt after 75 s but 22 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6886034d10308325aea5be10bfa3cc0b