### PR TITLE
Implement TRIAD basis, Butterworth filter and NED residual plots

### DIFF
--- a/src/gnss_imu_fusion/init_vectors.py
+++ b/src/gnss_imu_fusion/init_vectors.py
@@ -47,10 +47,31 @@ def triad_basis(vec1: np.ndarray, vec2: np.ndarray) -> np.ndarray:
 
     Notes
     -----
-    This placeholder mirrors the MATLAB ``triad_basis`` helper and will be
-    expanded to match its functionality.
+    Mirrors the helper used throughout the MATLAB codebase. ``vec1`` forms the
+    primary axis of the basis. ``vec2`` is used to compute the second axis. If
+    the cross product of the two vectors is close to zero (i.e. they are
+    collinear) an arbitrary orthogonal axis is chosen to ensure a valid basis.
     """
-    raise NotImplementedError("triad_basis is not yet implemented")
+
+    v1 = np.asarray(vec1, dtype=float).reshape(3)
+    v2 = np.asarray(vec2, dtype=float).reshape(3)
+
+    t1 = v1 / np.linalg.norm(v1)
+    t2_temp = np.cross(t1, v2)
+
+    if np.linalg.norm(t2_temp) < 1e-10:
+        # Fallback axis roughly orthogonal to t1
+        tmp = (
+            np.array([1.0, 0.0, 0.0])
+            if abs(t1[0]) < abs(t1[1])
+            else np.array([0.0, 1.0, 0.0])
+        )
+        t2_temp = np.cross(t1, tmp)
+
+    t2 = t2_temp / np.linalg.norm(t2_temp)
+    t3 = np.cross(t1, t2)
+
+    return np.column_stack((t1, t2, t3))
 
 
 def triad_svd(
@@ -82,8 +103,55 @@ def butter_lowpass_filter(
 def basic_butterworth_filter(
     data: np.ndarray, cutoff: float = 5.0, fs: float = 400.0, order: int = 4
 ) -> np.ndarray:
-    """Placeholder for MATLAB parity. Not implemented."""
-    raise NotImplementedError("basic_butterworth_filter is MATLAB-only")
+    """Butterworth low-pass filter implemented without design helper functions.
+
+    Parameters
+    ----------
+    data : np.ndarray
+        ``N×M`` array of samples (time along axis 0).
+    cutoff : float, optional
+        Cut-off frequency in Hz, by default 5.0.
+    fs : float, optional
+        Sampling frequency in Hz, by default 400.0.
+    order : int, optional
+        Filter order, by default 4.
+
+    Returns
+    -------
+    np.ndarray
+        Filtered array of the same shape as ``data``.
+
+    Notes
+    -----
+    This mirrors the MATLAB implementation used in the companion code base and
+    is provided for situations where the standard :func:`butter` helper from
+    :mod:`scipy` is unavailable. ``scipy.signal.lfilter`` is still used for the
+    actual filtering steps.
+    """
+
+    from scipy.signal import lfilter
+
+    data = np.asarray(data, dtype=float)
+    if data.ndim == 1:
+        data = data[:, None]
+
+    # Pre-warp frequency for bilinear transform
+    warped = 2 * fs * np.tan(np.pi * cutoff / fs)
+    k = np.arange(order)
+    angles = np.pi / 2 + (2 * k + 1) * np.pi / (2 * order)
+    poles_analog = warped * np.exp(1j * angles)
+    poles_digital = (2 * fs + poles_analog) / (2 * fs - poles_analog)
+    zeros_digital = -np.ones(order)
+    gain_analog = warped**order
+    gain_digital = np.real(gain_analog / np.prod(2 * fs - poles_analog))
+
+    b = np.real(np.poly(zeros_digital)) * gain_digital
+    a = np.real(np.poly(poles_digital))
+
+    y = lfilter(b, a, data, axis=0)
+    filt = lfilter(b, a, y[::-1], axis=0)[::-1]
+
+    return filt.squeeze()
 
 
 def angle_between(a: np.ndarray, b: np.ndarray) -> float:

--- a/src/task7_ned_residuals_plot.py
+++ b/src/task7_ned_residuals_plot.py
@@ -1,8 +1,195 @@
 """Task 7 -- Plot residuals in the NED frame.
 
-This is a placeholder matching the MATLAB function
-``task7_ned_residuals_plot``. The implementation is pending.
+Usage:
+    python src/task7_ned_residuals_plot.py --est-file fused.npz \
+        --truth-file STATE_X001.txt --dataset IMU_GNSS_X001 \
+        --output-dir results
+
+This implements the functionality of ``task7_ned_residuals_plot.m`` from the
+MATLAB code base. Figures are written under ``results/task7/<dataset>/``.
 """
 
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from src.utils import compute_C_ECEF_to_NED
+
+
+def load_est_ned(
+    file: Path,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, float, float, np.ndarray]:
+    """Load estimator output and convert to NED if required."""
+    data = np.load(file)
+    t = data.get("time_s")
+    if t is None:
+        t = data.get("time")
+    if t is None:
+        raise KeyError("Missing time vector in estimator file")
+    pos_ned = data.get("pos_ned_m")
+    vel_ned = data.get("vel_ned_ms")
+    acc_ned = data.get("acc_ned_ms2")
+
+    lat = data.get("ref_lat_rad")
+    if lat is None:
+        lat = data.get("ref_lat")
+    lon = data.get("ref_lon_rad")
+    if lon is None:
+        lon = data.get("ref_lon")
+    r0 = data.get("ref_r0_m")
+    if r0 is None:
+        r0 = data.get("ref_r0")
+
+    if lat is None or lon is None or r0 is None:
+        raise KeyError("Estimator file missing reference location")
+
+    lat = float(np.asarray(lat))
+    lon = float(np.asarray(lon))
+    r0 = np.asarray(r0).reshape(3)
+
+    if pos_ned is None or vel_ned is None:
+        pos_ecef = data["pos_ecef_m"]
+        vel_ecef = data["vel_ecef_ms"]
+        C = compute_C_ECEF_to_NED(lat, lon)
+        pos_ned = np.array([C @ (p - r0) for p in pos_ecef])
+        vel_ned = np.array([C @ v for v in vel_ecef])
+
+    if acc_ned is None:
+        acc_ned = np.gradient(vel_ned, t, axis=0)
+
+    return t, pos_ned, vel_ned, acc_ned, lat, lon, r0
+
+
+def load_truth_ned(
+    file: Path, lat: float, lon: float, r0: np.ndarray
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Load truth trajectory and convert to NED."""
+    if file.suffix == ".npz":
+        d = np.load(file)
+        t = d["time_s"]
+        pos_ecef = d["pos_ecef_m"]
+        vel_ecef = d["vel_ecef_ms"]
+        acc_ecef = d.get("acc_ecef_ms2")
+        if acc_ecef is None:
+            acc_ecef = np.gradient(vel_ecef, t, axis=0)
+    else:
+        raw = np.loadtxt(file)
+        t = raw[:, 0]
+        pos_ecef = raw[:, 1:4]
+        vel_ecef = raw[:, 4:7]
+        acc_ecef = np.vstack(
+            (np.zeros(3), np.diff(vel_ecef, axis=0) / np.diff(t)[:, None])
+        )
+
+    C = compute_C_ECEF_to_NED(lat, lon)
+    pos_ned = np.array([C @ (p - r0) for p in pos_ecef])
+    vel_ned = np.array([C @ v for v in vel_ecef])
+    acc_ned = np.array([C @ a for a in acc_ecef])
+    return t, pos_ned, vel_ned, acc_ned
+
+
+def compute_residuals(
+    t: np.ndarray,
+    est_pos: np.ndarray,
+    est_vel: np.ndarray,
+    truth_pos: np.ndarray,
+    truth_vel: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return position, velocity and acceleration residuals."""
+    res_pos = est_pos - truth_pos
+    res_vel = est_vel - truth_vel
+    acc_est = np.gradient(est_vel, t, axis=0)
+    acc_truth = np.gradient(truth_vel, t, axis=0)
+    res_acc = acc_est - acc_truth
+    return res_pos, res_vel, res_acc
+
+
+def plot_residuals(
+    t: np.ndarray,
+    res_pos: np.ndarray,
+    res_vel: np.ndarray,
+    res_acc: np.ndarray,
+    dataset: str,
+    out_dir: Path,
+) -> None:
+    """Plot residual components and norms in the NED frame."""
+    labels = ["North", "East", "Down"]
+    fig, axes = plt.subplots(3, 3, figsize=(12, 9), sharex=True)
+
+    for i, (arr, ylabel) in enumerate(
+        [
+            (res_pos, "Position Residual [m]"),
+            (res_vel, "Velocity Residual [m/s]"),
+            (res_acc, "Acceleration Residual [m/s$^2$]"),
+        ]
+    ):
+        for j in range(3):
+            ax = axes[i, j]
+            ax.plot(t, arr[:, j])
+            if i == 0:
+                ax.set_title(labels[j])
+            if j == 0:
+                ax.set_ylabel(ylabel)
+            if i == 2:
+                ax.set_xlabel("Time [s]")
+            ax.grid(True)
+
+    fig.suptitle(f"{dataset} Task 7 NED Residuals")
+    fig.tight_layout(rect=[0, 0, 1, 0.95])
+    out_dir.mkdir(parents=True, exist_ok=True)
+    pdf = out_dir / f"{dataset}_task7_ned_residuals.pdf"
+    png = out_dir / f"{dataset}_task7_ned_residuals.png"
+    fig.savefig(pdf)
+    fig.savefig(png)
+    plt.close(fig)
+
+    fig, ax = plt.subplots()
+    ax.plot(t, np.linalg.norm(res_pos, axis=1), label="|pos|")
+    ax.plot(t, np.linalg.norm(res_vel, axis=1), label="|vel|")
+    ax.plot(t, np.linalg.norm(res_acc, axis=1), label="|acc|")
+    ax.set_xlabel("Time [s]")
+    ax.set_ylabel("Residual Norm")
+    ax.legend()
+    ax.grid(True)
+    fig.tight_layout()
+    norm_pdf = out_dir / f"{dataset}_task7_ned_residual_norms.pdf"
+    norm_png = out_dir / f"{dataset}_task7_ned_residual_norms.png"
+    fig.savefig(norm_pdf)
+    fig.savefig(norm_png)
+    plt.close(fig)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Plot NED residuals for Task 7")
+    ap.add_argument("--est-file", type=Path, required=True, help="fused estimator npz")
+    ap.add_argument("--truth-file", type=Path, required=True, help="ground truth file")
+    ap.add_argument("--dataset", required=True, help="dataset identifier")
+    ap.add_argument(
+        "--output-dir", type=Path, default=Path("results"), help="output base directory"
+    )
+    args = ap.parse_args()
+
+    t_est, pos_est, vel_est, _acc_est, lat, lon, r0 = load_est_ned(args.est_file)
+    t_truth, pos_truth, vel_truth, _ = load_truth_ned(args.truth_file, lat, lon, r0)
+
+    pos_truth_i = np.vstack(
+        [np.interp(t_est, t_truth, pos_truth[:, i]) for i in range(3)]
+    ).T
+    vel_truth_i = np.vstack(
+        [np.interp(t_est, t_truth, vel_truth[:, i]) for i in range(3)]
+    ).T
+
+    res_pos, res_vel, res_acc = compute_residuals(
+        t_est, pos_est, vel_est, pos_truth_i, vel_truth_i
+    )
+
+    out_dir = args.output_dir / "task7" / args.dataset
+    plot_residuals(t_est, res_pos, res_vel, res_acc, args.dataset, out_dir)
+
+
 if __name__ == "__main__":
-    raise NotImplementedError("task7_ned_residuals_plot is not yet implemented")
+    main()

--- a/tests/test_basic_butterworth_filter.py
+++ b/tests/test_basic_butterworth_filter.py
@@ -1,0 +1,14 @@
+import numpy as np
+from src.gnss_imu_fusion.init_vectors import basic_butterworth_filter
+
+
+def test_basic_butterworth_filter_effect():
+    fs = 100.0
+    t = np.linspace(0, 1, int(fs) + 1)
+    sig = np.sin(2 * np.pi * 1 * t) + 0.5 * np.sin(2 * np.pi * 30 * t)
+    pure = np.sin(2 * np.pi * 1 * t)
+    filt = basic_butterworth_filter(sig, cutoff=5.0, fs=fs, order=4)
+    err_before = np.sqrt(np.mean((sig - pure) ** 2))
+    err_after = np.sqrt(np.mean((filt - pure) ** 2))
+    assert err_after < err_before
+    assert filt.shape == sig.shape

--- a/tests/test_task7_ned_residuals_plot.py
+++ b/tests/test_task7_ned_residuals_plot.py
@@ -1,0 +1,21 @@
+import numpy as np
+from pathlib import Path
+import matplotlib
+
+matplotlib.use("Agg")
+from src.task7_ned_residuals_plot import compute_residuals, plot_residuals
+
+
+def test_plot_residuals(tmp_path: Path):
+    t = np.linspace(0, 1, 5)
+    pos_est = np.vstack([t, t, t]).T
+    vel_est = np.gradient(pos_est, t, axis=0)
+    pos_truth = pos_est + 0.1
+    vel_truth = vel_est + 0.1
+    res_pos, res_vel, res_acc = compute_residuals(
+        t, pos_est, vel_est, pos_truth, vel_truth
+    )
+    out_dir = tmp_path / "task7" / "TEST"
+    plot_residuals(t, res_pos, res_vel, res_acc, "TEST", out_dir)
+    assert (out_dir / "TEST_task7_ned_residuals.pdf").exists()
+    assert (out_dir / "TEST_task7_ned_residual_norms.pdf").exists()

--- a/tests/test_triad_basis.py
+++ b/tests/test_triad_basis.py
@@ -1,0 +1,23 @@
+import numpy as np
+from src.gnss_imu_fusion.init_vectors import triad_basis
+
+
+def test_triad_basis_orthonormal():
+    v1 = np.array([1.0, 0.0, 0.0])
+    v2 = np.array([0.0, 1.0, 0.0])
+    M = triad_basis(v1, v2)
+    # First column must align with v1
+    assert np.allclose(M[:, 0], v1)
+    # Columns should be orthonormal
+    I = M.T @ M
+    assert np.allclose(I, np.eye(3), atol=1e-7)
+
+
+def test_triad_basis_collinear():
+    v1 = np.array([0.0, 0.0, 1.0])
+    v2 = np.array([0.0, 0.0, 2.0])  # collinear
+    M = triad_basis(v1, v2)
+    # Should still be orthonormal
+    I = M.T @ M
+    assert np.allclose(I, np.eye(3), atol=1e-7)
+    assert np.allclose(M[:, 0], np.array([0.0, 0.0, 1.0]))


### PR DESCRIPTION
## Summary
- implement `triad_basis` following MATLAB logic
- add Python implementation of `basic_butterworth_filter`
- implement `task7_ned_residuals_plot.py` for NED residual plotting
- add unit tests for new functionality

## Testing
- `pytest -q tests/test_triad_basis.py tests/test_basic_butterworth_filter.py tests/test_task7_ned_residuals_plot.py`
- `pytest -q` *(full test suite)*

------
https://chatgpt.com/codex/tasks/task_e_6886043211948325b68496ef70858af4