### PR TITLE
Handle length mismatch after interpolation

### DIFF
--- a/MATLAB/task6_overlay_plot.m
+++ b/MATLAB/task6_overlay_plot.m
@@ -40,6 +40,9 @@ pos_truth_i = interp1(t_truth, pos_truth, t_est, 'linear', 'extrap');
 vel_truth_i = interp1(t_truth, vel_truth, t_est, 'linear', 'extrap');
 acc_truth_i = interp1(t_truth, acc_truth, t_est, 'linear', 'extrap');
 
+[t_est, pos_est, vel_est, acc_est, pos_truth_i, vel_truth_i, acc_truth_i] = ...
+    ensure_equal_length(t_est, pos_est, vel_est, acc_est, pos_truth_i, vel_truth_i, acc_truth_i);
+
 pdf_path = plot_overlay(t_est, pos_est, vel_est, acc_est, pos_truth_i, ...
     vel_truth_i, acc_truth_i, frame, method, dataset, output_dir);
 
@@ -144,6 +147,24 @@ dv_truth = diff(vel_truth(:,1));
 dv_est = diff(vel_est(:,1));
 fprintf('Max velocity jump in truth (X): %.3f\n', max(abs(dv_truth)));
 fprintf('Max velocity jump in fused (X): %.3f\n', max(abs(dv_est)));
+end
+
+% -------------------------------------------------------------------------
+function [t_est, pos_est, vel_est, acc_est, pos_truth, vel_truth, acc_truth] = ...
+    ensure_equal_length(t_est, pos_est, vel_est, acc_est, pos_truth, vel_truth, acc_truth)
+%ENSURE_EQUAL_LENGTH Truncate arrays to the common minimum length.
+if size(pos_est,1) ~= size(pos_truth,1)
+    n = min(size(pos_est,1), size(pos_truth,1));
+    warning('Length mismatch after interpolation (est %d, truth %d); truncating to %d', size(pos_est,1), size(pos_truth,1), n);
+    t_est = t_est(1:n);
+    pos_est = pos_est(1:n,:);
+    vel_est = vel_est(1:n,:);
+    acc_est = acc_est(1:n,:);
+    pos_truth = pos_truth(1:n,:);
+    vel_truth = vel_truth(1:n,:);
+    acc_truth = acc_truth(1:n,:);
+end
+assert(size(pos_est,1) == size(pos_truth,1));
 end
 
 % -------------------------------------------------------------------------

--- a/tests/test_task6_length_handling.py
+++ b/tests/test_task6_length_handling.py
@@ -1,0 +1,45 @@
+import numpy as np
+import warnings
+
+from task6_overlay_plot import interpolate_truth, ensure_equal_length
+
+
+def test_truncate_to_shorter_length():
+    t_est_full = np.linspace(0, 4, 5)
+    pos_est = np.vstack([t_est_full, t_est_full, t_est_full]).T
+    vel_est = np.zeros_like(pos_est)
+    acc_est = np.zeros_like(pos_est)
+
+    t_truth = np.linspace(0, 2, 3)
+    pos_truth = np.vstack([t_truth, t_truth, t_truth]).T
+    vel_truth = np.zeros_like(pos_truth)
+    acc_truth = np.zeros_like(pos_truth)
+
+    # simulate aligning to shorter truth time vector
+    t_est = t_est_full[: len(t_truth)]
+    pos_truth_i = interpolate_truth(t_est, t_truth, pos_truth)
+    vel_truth_i = interpolate_truth(t_est, t_truth, vel_truth)
+    acc_truth_i = interpolate_truth(t_est, t_truth, acc_truth)
+
+    with warnings.catch_warnings(record=True) as w:
+        (
+            t_out,
+            pos_est_out,
+            vel_est_out,
+            acc_est_out,
+            pos_truth_out,
+            vel_truth_out,
+            acc_truth_out,
+        ) = ensure_equal_length(
+            t_est,
+            pos_est,
+            vel_est,
+            acc_est,
+            pos_truth_i,
+            vel_truth_i,
+            acc_truth_i,
+        )
+        assert len(w) == 1
+
+    assert len(pos_est_out) == len(pos_truth_out) == len(t_out)
+    assert len(t_out) == len(t_truth)


### PR DESCRIPTION
## Summary
- add `ensure_equal_length` helper and truncate estimate/truth arrays when lengths differ
- emit runtime warnings when truncation happens
- mirror the logic in MATLAB `task6_overlay_plot.m`
- test length handling with shortened truth vectors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886042db3dc832585f144a9825a3861