### PR TITLE
Fix Task6 filename docs

### DIFF
--- a/docs/MATLAB/Task6_MATLAB.md
+++ b/docs/MATLAB/Task6_MATLAB.md
@@ -28,7 +28,7 @@ Convert the ECEF truth trajectory to NED using the reference latitude, longitude
 Align IMU, GNSS and truth samples on the filter time grid.
 
 ### 6.4 Plot and Save
-Call `plot_overlay` for the three frames. Overlay PDFs are stored in ``results/task6/<dataset>/`` as ``<dataset>_<method>_task6_4_overlay_state_<frame>.pdf``. The ``--show-measurements`` flag mirrors the Python implementation.
+Call `plot_overlay` for the three frames. Overlay PDFs are stored in ``results/task6/<dataset>/`` as ``<dataset>_<method>_task6_overlay_state_<frame>.pdf``. The ``--show-measurements`` flag mirrors the Python implementation.
 
 ## Result
 

--- a/docs/Python/Task6_Python.md
+++ b/docs/Python/Task6_Python.md
@@ -28,7 +28,7 @@ Use :func:`assemble_frames` to align IMU, GNSS and truth data in NED, ECEF and b
 Call :func:`plot_overlay` for each frame to produce overlay figures. The ``--show-measurements`` flag adds the raw IMU and GNSS curves.
 
 ### 6.4 Save Overlay Figures
-Overlay PDFs are stored in ``results/task6/<dataset>/`` as ``<dataset>_<method>_task6_4_overlay_state_<frame>.pdf``.
+Overlay PDFs are stored in ``results/task6/<dataset>/`` as ``<dataset>_<method>_task6_overlay_state_<frame>.pdf``.
 
 ## Result
 


### PR DESCRIPTION
## Summary
- correct Task 6 overlay filename in Python and MATLAB docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68861a2d426c83258f75b7153e7e598c