### PR TITLE
Add naming utilities for standardized output filenames

### DIFF
--- a/MATLAB/naming.m
+++ b/MATLAB/naming.m
@@ -1,0 +1,36 @@
+function path = naming(varargin)
+%NAMING Utility helpers for standardised filenames.
+%   TAG = NAMING('build_tag', IMU_FILE, GNSS_FILE, METHOD) returns a dataset
+%   tag such as 'IMU_X001_GNSS_X001_TRIAD'.
+%   FILE = NAMING('plot_path', DIR, TAG, TASK, SUBTASK, TYPE, EXT) builds a
+%   full path for plots or results.
+%
+%   Example:
+%       tag = naming('build_tag', 'IMU_X001.dat', 'GNSS_X001.csv', 'TRIAD');
+%       f = naming('plot_path', 'results', tag, 7, '3', 'residuals_position_velocity');
+
+op = varargin{1};
+if strcmp(op, 'build_tag')
+    imu_file = varargin{2};
+    gnss_file = varargin{3};
+    method = varargin{4};
+    [~, ibase, ~] = fileparts(imu_file);
+    [~, gbase, ~] = fileparts(gnss_file);
+    path = sprintf('%s_%s_%s', ibase, gbase, method);
+elseif strcmp(op, 'plot_path')
+    dir = varargin{2};
+    tag = varargin{3};
+    task = varargin{4};
+    subtask = varargin{5};
+    type = varargin{6};
+    if nargin < 7
+        ext = '.pdf';
+    else
+        ext = varargin{7};
+    end
+    fname = sprintf('%s_task%d_%s_%s%s', tag, task, subtask, type, ext);
+    path = fullfile(dir, fname);
+else
+    error('Unknown operation');
+end
+end

--- a/README.md
+++ b/README.md
@@ -392,6 +392,8 @@ plots placed inside `results/task7/<tag>/`. Task 7 uses the dataset tag as a
 prefix where `<tag>` concatenates the IMU file, GNSS file and method. Example:
 `IMU_X002_GNSS_X002_Davenport_task7_3_residuals_position_velocity.pdf`
 will appear in that folder.
+The helper module `src/naming.py` provides :func:`build_tag` and
+:func:`plot_path` utilities to create such filenames programmatically.
 
 
 #### run_all_datasets.py

--- a/src/evaluate_filter_results.py
+++ b/src/evaluate_filter_results.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import os
 from typing import Sequence
 
+from naming import plot_path
+
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
@@ -49,7 +51,6 @@ def run_evaluation(
     """
     out_dir = Path(save_path)
     out_dir.mkdir(parents=True, exist_ok=True)
-    prefix = f"{tag}_" if tag else ""
 
     pred = pd.read_csv(prediction_file)
     gnss = pd.read_csv(gnss_file)
@@ -122,7 +123,7 @@ def run_evaluation(
         axes[1, i].grid(True)
     fig.suptitle("Task 7 – GNSS - Predicted Residuals")
     fig.tight_layout(rect=[0, 0, 1, 0.95])
-    out_path = out_dir / f"{prefix}task7_3_residuals_position_velocity.pdf"
+    out_path = plot_path(out_dir, tag or "", 7, "3", "residuals_position_velocity")
     fig.savefig(out_path)
     print(f"Saved {out_path}")
     plt.close(fig)
@@ -137,7 +138,7 @@ def run_evaluation(
             axes[i].grid(True)
         fig.suptitle(f"Task 7 – Histogram of {name} residuals")
         fig.tight_layout(rect=[0, 0, 1, 0.95])
-        hist_path = out_dir / f"{prefix}task7_hist_{name}_residuals.pdf"
+        hist_path = plot_path(out_dir, tag or "", 7, f"hist_{name}", "residuals")
         fig.savefig(hist_path)
         print(f"Saved {hist_path}")
         plt.close(fig)
@@ -156,7 +157,8 @@ def run_evaluation(
     axs[2].set_xlabel("Time [s]")
     fig.suptitle("Task 7 – Attitude Angles")
     fig.tight_layout(rect=[0, 0, 1, 0.95])
-    fig.savefig(out_dir / f"{prefix}task7_4_attitude_angles_euler.pdf")
+    att_out = plot_path(out_dir, tag or "", 7, "4", "attitude_angles_euler")
+    fig.savefig(att_out)
     plt.close(fig)
 
 
@@ -175,7 +177,6 @@ def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) ->
     start_time = time.time()
     out_dir = Path(save_path)
     out_dir.mkdir(parents=True, exist_ok=True)
-    prefix = f"{tag}_" if tag else ""
 
     data = np.load(npz_file)
     res_pos = data.get("residual_pos")
@@ -242,7 +243,7 @@ def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) ->
         axes[1, i].grid(True)
     fig.suptitle("Task 7 – GNSS - Predicted Residuals")
     fig.tight_layout(rect=[0, 0, 1, 0.95])
-    out_path = out_dir / f"{prefix}task7_3_residuals_position_velocity.pdf"
+    out_path = plot_path(out_dir, tag or "", 7, "3", "residuals_position_velocity")
     fig.savefig(out_path)
     print(f"Saved {out_path}")
     plt.close(fig)
@@ -259,7 +260,7 @@ def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) ->
     axs[2].set_xlabel("Time [s]")
     fig.suptitle("Task 7 – Attitude Angles")
     fig.tight_layout(rect=[0, 0, 1, 0.95])
-    att_path = out_dir / f"{prefix}task7_4_attitude_angles_euler.pdf"
+    att_path = plot_path(out_dir, tag or "", 7, "4", "attitude_angles_euler")
     fig.savefig(att_path)
     print(f"Saved {att_path}")
     plt.close(fig)
@@ -279,7 +280,7 @@ def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) ->
     ax.legend()
     ax.grid(True)
     fig.tight_layout()
-    norm_path = out_dir / f"{prefix}task7_3_error_norms.pdf"
+    norm_path = plot_path(out_dir, tag or "", 7, "3", "error_norms")
     fig.savefig(norm_path)
     print(f"Saved {norm_path}")
     plt.close(fig)
@@ -297,7 +298,7 @@ def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) ->
             out_dir,
         )
         print(
-            f"Saved {Path(out_dir) / (run_id + '_task7_5_diff_truth_fused_over_time.pdf')}"
+            f"Saved {plot_path(out_dir, run_id, 7, '5', 'diff_truth_fused_over_time')}"
         )
     else:
         print("Subtask 7.5 skipped: missing fused or truth data")
@@ -356,7 +357,7 @@ def subtask7_5_diff_plot(
 
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
-    pdf = out_dir / f"{run_id}_task7_5_diff_truth_fused_over_time.pdf"
+    pdf = plot_path(out_dir, run_id, 7, "5", "diff_truth_fused_over_time")
     png = pdf.with_suffix(".png")
     fig.savefig(pdf)
     fig.savefig(png)

--- a/src/naming.py
+++ b/src/naming.py
@@ -1,0 +1,35 @@
+"""Utility helpers to standardise output filenames.
+
+These functions centralise how dataset tags and figure paths are
+constructed so that both Python and MATLAB scripts produce
+consistent results.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def build_tag(imu_file: str, gnss_file: str, method: str) -> str:
+    """Return dataset tag ``IMU_Xnnn_GNSS_Xnnn_METHOD``."""
+    imu_base = Path(imu_file).stem
+    gnss_base = Path(gnss_file).stem
+    return f"{imu_base}_{gnss_base}_{method}"
+
+
+def prefix_filename(tag: str | None, filename: str) -> str:
+    """Prepend ``tag`` to ``filename`` if provided."""
+    return f"{tag}_{filename}" if tag else filename
+
+
+def plot_path(
+    results_dir: str | Path,
+    tag: str,
+    task: int,
+    subtask: str,
+    output_type: str,
+    ext: str = ".pdf",
+) -> Path:
+    """Compose a plot filename following the repository convention."""
+    results_dir = Path(results_dir)
+    fname = f"{tag}_task{task}_{subtask}_{output_type}{ext}"
+    return results_dir / fname


### PR DESCRIPTION
## Summary
- add `src/naming.py` with helpers for dataset tags and plot paths
- mirror functionality in `MATLAB/naming.m`
- apply `plot_path` helper in `evaluate_filter_results.py`
- document naming helper usage in README

## Testing
- `ruff check src/naming.py src/evaluate_filter_results.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68861b4f44608325a9f41b2dc9605be8