### PR TITLE
Update static intervals for IMU datasets

### DIFF
--- a/MATLAB/GNSS_IMU_Fusion_single.m
+++ b/MATLAB/GNSS_IMU_Fusion_single.m
@@ -630,7 +630,16 @@ imu_time = (0:size(imu_raw_data,1)-1)' * dt_imu + gnss_time(1);
 acc_body_raw = imu_raw_data(:, 6:8) / dt_imu;
 acc_body_filt = butter_lowpass_filter(acc_body_raw, 5.0, 1/dt_imu);
 gyro_body_filt = butter_lowpass_filter(imu_raw_data(:, 3:5) / dt_imu, 5.0, 1/dt_imu);
-[start_idx, end_idx] = detect_static_interval(acc_body_filt, gyro_body_filt);
+dataset_map = containers.Map( ...
+    {'IMU_X001','IMU_X002','IMU_X003'}, ...
+    {[296, 479907],[296, 479907],[296, 479907]});
+if isKey(dataset_map, imu_name)
+    w = dataset_map(imu_name);
+    start_idx = w(1);
+    end_idx   = min(w(2), size(acc_body_filt,1));
+else
+    [start_idx, end_idx] = detect_static_interval(acc_body_filt, gyro_body_filt);
+end
 static_acc  = mean(acc_body_filt(start_idx:end_idx, :), 1);
 static_gyro = mean(gyro_body_filt(start_idx:end_idx, :), 1);
 

--- a/MATLAB/Task_4.m
+++ b/MATLAB/Task_4.m
@@ -183,7 +183,16 @@ acc_rms  = sqrt(mean(acc_body_raw(:).^2));
 gyro_rms = sqrt(mean((imu_raw_data(:,3:5)/dt_imu).^2,'all'));
 fprintf('   Acc raw RMS=%.4f, Gyro raw RMS=%.6f\n', acc_rms, gyro_rms);
 
-[start_idx, end_idx] = detect_static_interval(acc_body_filt, gyro_body_filt);
+dataset_map = containers.Map( ...
+    {'IMU_X001','IMU_X002','IMU_X003'}, ...
+    {[296, 479907],[296, 479907],[296, 479907]});
+if isKey(dataset_map, imu_name)
+    w = dataset_map(imu_name);
+    start_idx = w(1);
+    end_idx   = min(w(2), size(acc_body_filt,1));
+else
+    [start_idx, end_idx] = detect_static_interval(acc_body_filt, gyro_body_filt);
+end
 static_acc  = mean(acc_body_filt(start_idx:end_idx, :), 1);
 static_gyro = mean(gyro_body_filt(start_idx:end_idx, :), 1);
 acc_var = var(acc_body_filt(start_idx:end_idx, :), 0, 1);

--- a/src/GNSS_IMU_Fusion.py
+++ b/src/GNSS_IMU_Fusion.py
@@ -725,6 +725,8 @@ def main():
         end_idx = args.static_end
         if start_idx is None and end_idx is None:
             dataset_window = {
+                "IMU_X001.dat": (296, 479907),
+                "IMU_X002.dat": (296, 479907),
                 "IMU_X003.dat": (296, 479907),
             }.get(Path(imu_file).name)
             if dataset_window and len(acc_body) >= dataset_window[1]:


### PR DESCRIPTION
## Summary
- apply IMU dataset windows for X001 and X002 in `GNSS_IMU_Fusion.py`
- apply the same static intervals in MATLAB scripts

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'plot_path')*

------
https://chatgpt.com/codex/tasks/task_e_68862cb7056c8325a4c4bb0d3cbd8b6f