### PR TITLE
Align MATLAB outputs with Python layout

### DIFF
--- a/MATLAB/FINAL_demo.m
+++ b/MATLAB/FINAL_demo.m
@@ -1,7 +1,8 @@
 %% FINAL.m - IMU/GNSS alignment and fusion demonstration
 % This script performs IMU/GNSS alignment, dead-reckoning and fusion
 % using the TRIAD method and two alternative Wahba solutions. Results and
-% plots are stored under the 'output_matlab/' directory.
+% plots are stored under the `results/` directory returned by
+% `get_results_dir()`.
 %
 % The dataset filenames can be changed below. Each logical block is
 % annotated with "Subtask X.Y" comments for clarity.

--- a/MATLAB/GNSS_IMU_Fusion.m
+++ b/MATLAB/GNSS_IMU_Fusion.m
@@ -7,7 +7,7 @@ function GNSS_IMU_Fusion(imu_file, gnss_file, method)
 %
 %   When IMU_FILE or GNSS_FILE are omitted the default logs IMU_X001.dat and
 %   GNSS_X001.csv are used.  METHOD defaults to 'Davenport'.  Results are
-%   written to the 'output_matlab' directory in the current folder.
+%   written to the directory returned by ``get_results_dir()``.
 
 if nargin < 1 || isempty(imu_file)
     imu_file = 'IMU_X001.dat';

--- a/MATLAB/GNSS_IMU_Fusion_Single_script.m
+++ b/MATLAB/GNSS_IMU_Fusion_Single_script.m
@@ -2,7 +2,8 @@
 % Mirror of the Python script GNSS_IMU_Fusion_Single_script.py
 % This script performs IMU/GNSS alignment, dead-reckoning and fusion
 % using the TRIAD method and two alternative Wahba solutions. Results and
-% plots are stored under the 'output_matlab/' directory.
+% plots are stored in the `results/` directory returned by
+% `get_results_dir()`.
 % If you run the Python helper scripts, install filterpy with:
 %   pip install filterpy --no-binary :all:
 % and install build tools if required:

--- a/MATLAB/TRIAD_batch.m
+++ b/MATLAB/TRIAD_batch.m
@@ -5,7 +5,8 @@ function results = TRIAD(imu_paths, gnss_paths)
 %   When called without arguments all bundled sample datasets are
 %   processed.  Single file names or cell arrays of names are accepted.
 %   The Task 5 results for each pair are returned as a struct (or a cell
-%   array of structs) and saved in output_matlab/Result_<IMU>_<GNSS>_TRIAD.mat.
+%   array of structs) and saved as `Result_<IMU>_<GNSS>_TRIAD.mat` in the
+%   directory returned by `get_results_dir()`.
 
 if nargin == 0
     imu_paths = {'IMU_X001.dat','IMU_X002.dat','IMU_X003.dat'};

--- a/MATLAB/Task_4.m
+++ b/MATLAB/Task_4.m
@@ -4,7 +4,8 @@ function result = Task_4(imu_path, gnss_path, method)
 %   using the attitude estimates from Task 3. METHOD is unused but kept
 %   for backwards compatibility with older scripts.
 %   Requires that `Task_3` has already saved a dataset-specific
-%   results file such as `output_matlab/Task3_results_IMU_X001_GNSS_X001.mat`.
+%   results file under `results/` such as
+%   `Task3_results_IMU_X001_GNSS_X001.mat`.
 %
 % Usage:
 %   Task_4(imu_path, gnss_path, method)
@@ -19,9 +20,6 @@ if nargin < 3
     method = '';
 end
 
-if ~exist('output_matlab','dir')
-    mkdir('output_matlab');
-end
 if ~isfile(gnss_path)
     error('Task_4:GNSSFileNotFound', ...
           'Could not find GNSS data at:\n  %s\nCheck path or filename.', ...

--- a/MATLAB/Task_6.m
+++ b/MATLAB/Task_6.m
@@ -7,8 +7,8 @@ function Task_6(task5_file, imu_path, gnss_path, truth_file)
 %   frames.  Truth data in the ECEF frame is first converted to the
 %   estimator's local NED coordinates using ``compute_C_ECEF_to_NED`` so
 %   that residuals are expressed in a consistent frame.  The resulting
-%   ``*_overlay_truth.pdf`` files are stored under ``output_matlab/`` located
-%   at the repository root.  This function expects the initialization output
+%   ``*_overlay_truth.pdf`` files are written to the directory returned by
+%   ``get_results_dir()``.  This function expects the initialization output
 %   from Task 1 and the filter output from Task 5 to reside in that same
 %   directory.
 %

--- a/MATLAB/run_all_datasets.m
+++ b/MATLAB/run_all_datasets.m
@@ -4,7 +4,7 @@
 %   (Tasks 1--5) for the methods TRIAD, Davenport and SVD. After each run
 %   the Task 5 results structure is loaded into the base workspace under
 %   a variable named result_IMU_Xxxx_GNSS_Xxxx_METHOD and also written to
-%   output_matlab/<variable>.mat.
+%   ``results/<variable>.mat`` within the directory returned by ``get_results_dir()``.
 
 imu_files = dir('IMU_X*.dat');
 gnss_files = dir('GNSS_X*.csv');

--- a/MATLAB/run_all_datasets_matlab.m
+++ b/MATLAB/run_all_datasets_matlab.m
@@ -7,7 +7,8 @@ function run_all_datasets_matlab(method)
 %   <IMU>_<GNSS>_<METHOD>_kf_output.mat in the results directory. plot_results
 %   is called on each file to recreate the standard figures. A summary table
 %   mirroring ``src/run_all_datasets.py`` is printed and saved as
-%   output_matlab/summary.csv.
+%   ``results/summary.csv`` within the directory returned by
+%   ``get_results_dir()``.
 %
 % Usage:
 %   run_all_datasets_matlab(method)

--- a/MATLAB/run_all_methods.m
+++ b/MATLAB/run_all_methods.m
@@ -2,10 +2,11 @@ function run_all_methods(imu_file, gnss_file)
 %RUN_ALL_METHODS Process one dataset with TRIAD, Davenport and SVD.
 %   RUN_ALL_METHODS(IMU_FILE, GNSS_FILE) executes Tasks 1--5 for the
 %   specified IMU/GNSS pair using all three initialisation methods.
-%   Per-method Task 5 plots are saved as output_matlab/<tag>_task5_results_<method>.pdf
-%   where <tag> is the dataset identifier extracted from the filenames
-%   (e.g. X002).  An overlay comparing all methods is saved as
-%   output_matlab/<tag>_task5_results_all_methods.pdf.
+%   Per-method Task 5 plots are saved as ``<tag>_task5_results_<method>.pdf``
+%   in the directory returned by ``get_results_dir()`` where ``<tag>`` is the
+%   dataset identifier extracted from the filenames (e.g. X002). An overlay
+%   comparing all methods is saved as
+%   ``<tag>_task5_results_all_methods.pdf`` in the same location.
 %
 %   When IMU_FILE or GNSS_FILE are omitted the X002 sample data is used.
 

--- a/MATLAB/run_triad_only.m
+++ b/MATLAB/run_triad_only.m
@@ -2,12 +2,13 @@
 % This helper mirrors the behaviour of ``src/run_triad_only.py``.
 % It first executes the full MATLAB pipeline for the TRIAD method via
 % ``run_all_datasets_matlab`` and then aggregates the Task 5 summaries into a
-% concise ``output_matlab/summary.csv``.
+% concise ``results/summary.csv`` within the directory returned by
+% ``get_results_dir()``.
 %
 % Usage:
 %   run_triad_only
 %
-% The routine parses ``output_matlab/IMU_GNSS_summary.txt`` for lines beginning with
+% The routine parses ``results/IMU_GNSS_summary.txt`` for lines beginning with
 % ``[SUMMARY]`` and extracts the metrics for the TRIAD runs.  It also
 % approximates the runtime from the time vector saved in
 % ``<IMU>_<GNSS>_TRIAD_task5_results.mat``.

--- a/MATLAB/task6_overlay_plot.m
+++ b/MATLAB/task6_overlay_plot.m
@@ -8,7 +8,8 @@ function pdf_path = task6_overlay_plot(est_file, truth_file, method, frame, data
 %   ground truth respectively. ``frame`` is either ``'ECEF'`` or ``'NED'``.
 %   The interpolated truth is overlaid on the estimate for position,
 %   velocity and acceleration and the figure saved under
-%   ``output_matlab/task6/<run_id>/`` as ``<run_id>_task6_overlay_state_<frame>.pdf``.
+%   ``results/task6/<run_id>/`` as ``<run_id>_task6_overlay_state_<frame>.pdf`` 
+%   within the directory returned by ``get_results_dir()``.
 %   ``run_id`` combines the dataset and method, e.g.,
 %   ``IMU_X003_GNSS_X002_TRIAD``.
 

--- a/MATLAB/task6_plot_fused_trajectory.m
+++ b/MATLAB/task6_plot_fused_trajectory.m
@@ -4,8 +4,9 @@ function quat_logs = task6_plot_fused_trajectory(method, imu_file, gnss_file, qu
 %   quat_logs = TASK6_PLOT_FUSED_TRAJECTORY(method, imu_file, gnss_file, quat_logs)
 %   replicates ``plot_task6_fused_trajectory`` from the Python code. The fused
 %   estimate ``<imu_file>_<gnss_file>_<method>.mat`` and corresponding truth
-%   ``<imu_file>_<gnss_file>_truth.mat`` must exist under ``output_matlab/``. Overlay
-%   plots in NED and ECEF are produced together with a position error plot. The
+%   ``<imu_file>_<gnss_file>_truth.mat`` must exist in the directory returned by
+%   ``get_results_dir()``. Overlay plots in NED and ECEF are produced together
+%   with a position error plot. The
 %   quaternion history for the method is returned in ``quat_logs``.
 
 if nargin < 4 || isempty(quat_logs)

--- a/MATLAB/task7_ned_residuals_plot.m
+++ b/MATLAB/task7_ned_residuals_plot.m
@@ -8,7 +8,7 @@ function task7_ned_residuals_plot(est_file, truth_file, dataset, output_dir)
 %
 %   Usage:
 %       task7_ned_residuals_plot('fused_results.mat', 'STATE_X001.txt', ...
-%           'IMU_X001_GNSS_X001', 'output_matlab')
+%           'IMU_X001_GNSS_X001', get_results_dir())
 %
 %   This MATLAB function mirrors the intended behaviour of the Python
 %   counterpart ``task7_ned_residuals_plot.py``.

--- a/MATLAB/task7_plot_error_fused_vs_truth.m
+++ b/MATLAB/task7_plot_error_fused_vs_truth.m
@@ -11,7 +11,7 @@ function task7_plot_error_fused_vs_truth(fused_file, truth_file, output_dir)
 %
 %   Usage:
 %       task7_plot_error_fused_vs_truth('fused_results.mat', ...
-%           'truth_results.mat', 'output_matlab');
+%           'truth_results.mat', get_results_dir());
 
 if nargin < 3 || isempty(output_dir)
     output_dir = 'output_matlab';


### PR DESCRIPTION
## Summary
- drop outdated `output_matlab` folder creation in `Task_4.m`
- write documentation that all MATLAB outputs go under `get_results_dir()`
- adjust numerous script headers to mention the `results/` directory

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ImportError in tests/test_evaluate_filter_results.py)*

------
https://chatgpt.com/codex/tasks/task_e_68862e91c4b88325a826d2a4fa6ddaf7