### PR TITLE
Align MATLAB IMU tasks with Python methods

### DIFF
--- a/MATLAB/Task_1.m
+++ b/MATLAB/Task_1.m
@@ -99,7 +99,14 @@ end
 % ================================
 fprintf('\nSubtask 1.2: Defining gravity vector in NED frame.\n');
 
-% Compute gravity magnitude using WGS-84 model and print validation line
+% Use the same gravity magnitude as the Python implementation. This value
+% comes from the WGS-84 normal gravity formula evaluated at the initial
+% latitude and altitude of the dataset. It ensures cross-language
+% consistency when comparing results.
+g_NED = [0; 0; constants.GRAVITY];
+
+% Print validation line to mirror the Python script behaviour
+fprintf('Gravity magnitude set to %.8f m/s^2\n', constants.GRAVITY);
 
 
 % ================================

--- a/MATLAB/Task_4.m
+++ b/MATLAB/Task_4.m
@@ -237,16 +237,6 @@ gyro_body_corrected = struct();
 acc_biases = struct();
 gyro_biases = struct();
 scale_factors = struct();
-switch upper(imu_name)
-    case 'IMU_X001'
-        dataset_acc_bias = [0.57755067; -6.8366253; 0.91021879];
-    case 'IMU_X002'
-        dataset_acc_bias = [0.57757295; -6.83671274; 0.91029003];
-    case 'IMU_X003'
-        dataset_acc_bias = [0.58525893; -6.8367178; 0.9084152];
-    otherwise
-        dataset_acc_bias = [];
-end
 
 for i = 1:length(methods)
     method = methods{i};
@@ -259,9 +249,6 @@ for i = 1:length(methods)
     % Compute biases using the static interval as in the Python pipeline
     % Accelerometer bias: static_acc should equal -g_body_expected
     acc_bias = static_acc' + g_body_expected;
-    if ~isempty(dataset_acc_bias)
-        acc_bias = dataset_acc_bias;
-    end
     % Gyroscope bias: static_gyro should equal expected earth rate in body frame
     omega_ie_body_expected = C_N_B * omega_ie_NED;
     gyro_bias = static_gyro' - omega_ie_body_expected;

--- a/MATLAB/Task_5.m
+++ b/MATLAB/Task_5.m
@@ -144,19 +144,9 @@ function result = Task_5(imu_path, gnss_path, method, gnss_pos_ned, varargin)
             scale_factor = d4.scale_factors.(method);
         end
     end
-    switch upper(imu_name)
-        case 'IMU_X001'
-            dataset_accel_bias = [0.57755067; -6.8366253; 0.91021879];
-        case 'IMU_X002'
-            dataset_accel_bias = [0.57757295; -6.83671274; 0.91029003];
-        case 'IMU_X003'
-            dataset_accel_bias = [0.58525893; -6.8367178; 0.9084152];
-        otherwise
-            dataset_accel_bias = [];
-    end
-    if ~isempty(dataset_accel_bias)
-        accel_bias = dataset_accel_bias;
-    end
+    % Biases are provided by Task 2. Do not override them with
+    % dataset-specific constants so that both MATLAB and Python remain
+    % consistent.
     fprintf('Method %s: Bias computed: [%.7f %.7f %.7f]\n', method, accel_bias);
     fprintf('Method %s: Scale factor: %.4f\n', method, scale_factor);
 


### PR DESCRIPTION
## Summary
- use constants.GRAVITY in Task_1 to match Python pipeline
- drop dataset‐specific bias overrides in Tasks 4 and 5
- keep bias estimation helper `compute_biases`
- update related documentation in Tasks 1, 4 and 5

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: KeyboardInterrupt, but 45 tests pass before interruption)*

------
https://chatgpt.com/codex/tasks/task_e_688646990120832581ba0356f08d65a7