### PR TITLE
Fix stray end in MATLAB script

### DIFF
--- a/MATLAB/run_triad_only.m
+++ b/MATLAB/run_triad_only.m
@@ -72,7 +72,6 @@ writematrix(C_B_N, fullfile(out_dir,'C_B_N.csv'));
 writematrix(eul_deg, fullfile(out_dir,'euler_angles_deg.csv'));
 
 fprintf('Results saved to %s\n', out_dir);
-end
 
 %% -------------------------------------------------------------------------
 % Helper functions


### PR DESCRIPTION
## Summary
- remove a stray `end` from `run_triad_only.m`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68864c390fb48325acb9a7bdd27e2dad