### PR TITLE
Fix dataset reference in triad runner

### DIFF
--- a/src/run_triad_only.py
+++ b/src/run_triad_only.py
@@ -161,7 +161,7 @@ def main(argv: Iterable[str] | None = None) -> None:
         kv = dict(re.findall(r"(\w+)=\s*([^\s]+)", summary))
         results.append(
             {
-                "dataset": pathlib.Path(imu).stem,
+                "dataset": pathlib.Path(imu_file).stem,
                 "method": kv.get("method", method),
                 "rmse_pos": float(kv.get("rmse_pos", "nan").replace("m", "")),
                 "final_pos": float(kv.get("final_pos", "nan").replace("m", "")),


### PR DESCRIPTION
## Summary
- reference `imu_file` correctly when parsing summary stats in `run_triad_only.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68864fabdf8c83258fda58a3d1b1e36a