### PR TITLE
Fix TRIAD MATLAB pipeline

### DIFF
--- a/MATLAB/Task_3.m
+++ b/MATLAB/Task_3.m
@@ -138,6 +138,10 @@ R_tri = M_ned_1 * M_body';
 R_tri = U*V';
 fprintf('Rotation matrix (TRIAD method, Case 1):\n');
 disp(R_tri);
+expected_C_b_n = [0.23364698, -0.04540352, 0.971260835; ...
+                   0.0106220955, 0.998968728, 0.0441435243; ...
+                  -0.972263472, 2.82418914e-06, 0.233888307];
+assert(norm(R_tri - expected_C_b_n) < 1e-6, 'TRIAD matrix mismatch');
 
 % Case 2
 M_ned_2 = triad_basis(v1_N, v2_N_doc);

--- a/MATLAB/Task_4.m
+++ b/MATLAB/Task_4.m
@@ -181,16 +181,7 @@ acc_rms  = sqrt(mean(acc_body_raw(:).^2));
 gyro_rms = sqrt(mean((imu_raw_data(:,3:5)/dt_imu).^2,'all'));
 fprintf('   Acc raw RMS=%.4f, Gyro raw RMS=%.6f\n', acc_rms, gyro_rms);
 
-dataset_map = containers.Map( ...
-    {'IMU_X001','IMU_X002','IMU_X003'}, ...
-    {[296, 479907],[296, 479907],[296, 479907]});
-if isKey(dataset_map, imu_name)
-    w = dataset_map(imu_name);
-    start_idx = w(1);
-    end_idx   = min(w(2), size(acc_body_filt,1));
-else
-    [start_idx, end_idx] = detect_static_interval(acc_body_filt, gyro_body_filt);
-end
+[start_idx, end_idx] = detect_static_interval(acc_body_filt, gyro_body_filt);
 static_acc  = mean(acc_body_filt(start_idx:end_idx, :), 1);
 static_gyro = mean(gyro_body_filt(start_idx:end_idx, :), 1);
 acc_var = var(acc_body_filt(start_idx:end_idx, :), 0, 1);

--- a/MATLAB/run_triad_method.m
+++ b/MATLAB/run_triad_method.m
@@ -11,12 +11,6 @@ function run_triad_method(imu_file, gnss_file)
     data_dir = 'Data';
     imu_path = fullfile(data_dir, imu_file);
     gnss_path = fullfile(data_dir, gnss_file);
-    if ~exist(imu_path, 'file')
-        imu_path = imu_file;
-    end
-    if ~exist(gnss_path, 'file')
-        gnss_path = gnss_file;
-    end
     if ~exist(imu_path, 'file') || ~exist(gnss_path, 'file')
         error('File not found: %s or %s', imu_path, gnss_path);
     end


### PR DESCRIPTION
## Summary
- ensure run_triad_method uses relative paths and errors if files missing
- check TRIAD rotation matrix in Task_3 against Python
- detect static interval in Task_4 and Task_5 dynamically
- compute ZUPT bounds from the detected interval and print concise summary

## Testing
- `pip install -e .[tests]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688655ed223083259c16d8b2fc5e1923