### PR TITLE
Add run_triad_method usage docs

### DIFF
--- a/MATLAB/run_triad_method.m
+++ b/MATLAB/run_triad_method.m
@@ -1,9 +1,14 @@
 function run_triad_method(imu_file, gnss_file)
 %RUN_TRIAD_METHOD  Run Tasks 1-5 using the TRIAD method on a single dataset.
 %   RUN_TRIAD_METHOD(IMU_FILE, GNSS_FILE) loads the specified files from the
-%   "Data" directory relative to the repository root. An error is raised when
-%   either file does not exist. The helper mirrors the Python check_files
-%   functionality for parity.
+%   "Data" directory relative to the repository root.  Pass both filenames
+%   explicitly.  An error is raised when either file does not exist.  This
+%   helper mirrors the Python ``check_files`` functionality for parity.
+%
+%   Valid dataset pairs bundled with the repository are:
+%       * IMU_X001.dat with GNSS_X001.csv
+%       * IMU_X002.dat with GNSS_X002.csv
+%       * IMU_X003.dat with GNSS_X002.csv (shared GNSS log)
 %
 %   Example:
 %       run_triad_method('IMU_X002.dat', 'GNSS_X002.csv');

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ IMU data processing and initialization tools (Python)
   - [run_all_datasets.py](#run_all_datasetspy)
   - [run_triad_only.py](#run_triad_onlypy)
   - [run_method_only.py](#run_method_onlypy)
+  - [run_triad_method.m](#run_triad_methodm)
   - [GNSS_IMU_Fusion_single](#gnss_imu_fusion_singleimu_file-gnss_file)
 - [Per-Task Overview](#per-task-overview)
 - [Datasets](#datasets)
@@ -472,6 +473,21 @@ python src/plot_compare_all.py
 ```
 This creates one `all_datasets_<method>_comparison.pdf` per method in
 the `results/` directory you ran the script from.
+
+#### run_triad_method.m
+
+Call this MATLAB helper with an explicit IMU/GNSS pair to run the
+TRIAD-based Tasks 1–5 on a single dataset:
+
+```matlab
+run_triad_method('IMU_X002.dat', 'GNSS_X002.csv')
+```
+
+Bundled pairs are:
+
+* `IMU_X001.dat` with `GNSS_X001.csv`
+* `IMU_X002.dat` with `GNSS_X002.csv`
+* `IMU_X003.dat` with `GNSS_X002.csv` (shared GNSS log)
 
 #### GNSS_IMU_Fusion_single(imu_file, gnss_file)
 


### PR DESCRIPTION
## Summary
- document `run_triad_method` usage and dataset pairs in README
- expand `run_triad_method.m` header comments with the same info

## Testing
- `pip install numpy scipy matplotlib pandas --quiet`
- `pip install tabulate filterpy --quiet`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_68865928c3e083258f4bc8c6f7efa12e