### PR TITLE
Fix path for MATLAB helper functions

### DIFF
--- a/MATLAB/run_triad_only.m
+++ b/MATLAB/run_triad_only.m
@@ -15,6 +15,11 @@
 % Project structure and naming follow the repository guidelines so that
 % plots, logs and results match between MATLAB and Python.
 
+% Ensure helper functions in this folder are available even when the script is
+% executed via an absolute path.
+script_dir = fileparts(mfilename('fullpath'));
+addpath(script_dir);
+
 %% DATA LOADING
 imu_file  = 'IMU_X002.dat';
 gnss_file = 'GNSS_X002.csv';


### PR DESCRIPTION
## Summary
- add script directory to MATLAB path in `run_triad_only.m`

## Testing
- `pytest -q tests/test_ecef_to_geodetic.py::test_roundtrip -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68865922a7d48325a40bf08f0803046e