### PR TITLE
Ensure Task 7 outputs saved under results

### DIFF
--- a/src/evaluate_filter_results.py
+++ b/src/evaluate_filter_results.py
@@ -397,7 +397,7 @@ if __name__ == "__main__":
     ap.add_argument("--gnss")
     ap.add_argument("--attitude")
     ap.add_argument("--npz", help="NPZ file produced by GNSS_IMU_Fusion.py")
-    ap.add_argument("--output", default="plots/task7/")
+    ap.add_argument("--output", default="results/task7/")
     ap.add_argument("--tag", help="Dataset tag used as filename prefix")
     args = ap.parse_args()
     if args.npz:

--- a/src/run_all_methods.py
+++ b/src/run_all_methods.py
@@ -142,7 +142,7 @@ def main(argv=None):
             prediction_file="outputs/predicted_states.csv",
             gnss_file="outputs/gnss_measurements.csv",
             attitude_file="outputs/estimated_attitude.csv",
-            save_path="plots/task7/",
+            save_path="results/task7/",
         )
         return
 

--- a/src/run_triad_only.py
+++ b/src/run_triad_only.py
@@ -93,7 +93,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             prediction_file="outputs/predicted_states.csv",
             gnss_file="outputs/gnss_measurements.csv",
             attitude_file="outputs/estimated_attitude.csv",
-            save_path="plots/task7/",
+            save_path="results/task7/",
         )
         return
 


### PR DESCRIPTION
## Summary
- point Task 7 helper scripts at `results/task7/`
- update CLI defaults accordingly

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: KeyboardInterrupt after 178s with 44 passed, 8 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6886601d27748325a1bb6d22c93b0cd2