### PR TITLE
Fix path lookup for run_triad_only.m

### DIFF
--- a/MATLAB/run_triad_only.m
+++ b/MATLAB/run_triad_only.m
@@ -16,8 +16,14 @@
 % plots, logs and results match between MATLAB and Python.
 
 % Ensure helper functions in this folder are available even when the script is
-% executed via an absolute path.
-script_dir = fileparts(mfilename('fullpath'));
+% executed via ``run`` from another directory. ``mfilename`` returns an empty
+% string for scripts, so use the call stack to recover the full path.
+st = dbstack('-completenames');
+if ~isempty(st)
+    script_dir = fileparts(st(1).file);
+else
+    script_dir = fileparts(mfilename('fullpath'));
+end
 addpath(script_dir);
 
 %% DATA LOADING


### PR DESCRIPTION
## Summary
- determine `run_triad_only.m` directory using `dbstack` so `constants` class is found

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68866331ff2c8325963701e396056696