### PR TITLE
Fix MATLAB TRIAD init parity

### DIFF
--- a/MATLAB/compute_reference_vectors.m
+++ b/MATLAB/compute_reference_vectors.m
@@ -1,29 +1,71 @@
 function [lat_deg, lon_deg, alt, g_ned, omega_ie_ned, mag_ned, initial_vel_ned, pos_ecef] = compute_reference_vectors(gnss_file, mag_file)
-%COMPUTE_REFERENCE_VECTORS  Stub corresponding to the Python implementation.
-%   [LAT_DEG, LON_DEG, ALT, G_NED, OMEGA_IE_NED, MAG_NED, INITIAL_VEL_NED, POS_ECEF] =
-%   COMPUTE_REFERENCE_VECTORS(GNSS_FILE, MAG_FILE) mirrors the interface of
-%   the Python function of the same name. It will load GNSS data to
-%   establish the reference latitude, longitude and altitude, compute the
-%   gravity and Earth rotation vectors in the NED frame, and optionally use
-%   magnetometer measurements. The full MATLAB implementation is pending.
+%COMPUTE_REFERENCE_VECTORS  Return NED reference vectors from GNSS data.
+%   This function mirrors ``compute_reference_vectors`` used by the Python
+%   pipeline.  It reads the first valid ECEF coordinates from GNSS_FILE,
+%   converts them to geodetic latitude and longitude and computes the
+%   gravity and Earth rotation vectors in the NED frame.  If MAG_FILE is
+%   provided the mean magnetometer vector is returned as MAG_NED.
 %
-%   This stub is provided for API parity only. All outputs are empty.
+%   [LAT_DEG, LON_DEG, ALT, G_NED, OMEGA_IE_NED, MAG_NED, INITIAL_VEL_NED, POS_ECEF]
+%   = COMPUTE_REFERENCE_VECTORS(GNSS_FILE, MAG_FILE)
 %
-%   See also: COMPUTE_REFERENCE_VECTORS in Python.
+%   Inputs
+%   ------
+%   GNSS_FILE : string
+%       Path to the GNSS CSV file containing ECEF coordinates in the columns
+%       ``X_ECEF_m``, ``Y_ECEF_m`` and ``Z_ECEF_m`` as well as ECEF
+%       velocities ``VX_ECEF_mps``, ``VY_ECEF_mps`` and ``VZ_ECEF_mps``.
+%   MAG_FILE  : string, optional
+%       Optional CSV file with magnetometer measurements.  When supplied, the
+%       mean of the first three columns is returned in MAG_NED.
+%
+%   Outputs mirror the Python implementation and use column vectors.
 
-if nargin < 2
-    mag_file = [];
+if nargin < 2 || isempty(mag_file)
+    mag_file = '';
 end
 
-warning('compute_reference_vectors:NotImplemented', ...
-    'compute_reference_vectors.m is a stub. Full implementation pending.');
+T = readtable(gnss_file);
 
-lat_deg = [];
-lon_deg = [];
-alt = [];
-g_ned = [];
-omega_ie_ned = [];
+valid_idx = find(T.X_ECEF_m ~= 0 | T.Y_ECEF_m ~= 0 | T.Z_ECEF_m ~= 0, 1, 'first');
+if isempty(valid_idx)
+    error('compute_reference_vectors:NoValidRows', ...
+          'No valid ECEF coordinates found in %s', gnss_file);
+end
+
+x_ecef = T.X_ECEF_m(valid_idx);
+y_ecef = T.Y_ECEF_m(valid_idx);
+z_ecef = T.Z_ECEF_m(valid_idx);
+
+[lat_deg, lon_deg, alt] = ecef_to_geodetic(x_ecef, y_ecef, z_ecef);
+lat_rad = deg2rad(lat_deg);
+lon_rad = deg2rad(lon_deg);
+
+% Gravity vector in NED using the same helper as Python
+g_ned = [0; 0; constants.GRAVITY];
+
+% Earth rotation rate vector in NED frame
+omega_ie_ned = constants.EARTH_RATE * [cos(lat_rad); 0; -sin(lat_rad)];
+
+% Initial velocity in NED from the first valid GNSS row
+vel_ecef = [T.VX_ECEF_mps(valid_idx); T.VY_ECEF_mps(valid_idx); T.VZ_ECEF_mps(valid_idx)];
+C_e2n = compute_C_ECEF_to_NED(lat_rad, lon_rad);
+initial_vel_ned = C_e2n * vel_ecef;
+
+% Position of the first sample in ECEF for later use
+pos_ecef = [x_ecef; y_ecef; z_ecef];
+
 mag_ned = [];
-initial_vel_ned = [];
-pos_ecef = [];
+if ~isempty(mag_file) && isfile(mag_file)
+    try
+        mag_data = readmatrix(mag_file);
+        if ismatrix(mag_data) && size(mag_data,2) >= 3
+            mag_ned = mean(mag_data(:,1:3), 1)';
+        end
+    catch ME %#ok<NASGU>
+        % Ignore magnetometer failures just like the Python code
+        mag_ned = [];
+    end
+end
+
 end

--- a/MATLAB/detect_static_interval.m
+++ b/MATLAB/detect_static_interval.m
@@ -1,21 +1,29 @@
-function [static_start, static_end] = detect_static_interval(acc_body, gyro_body, window_size, accel_var_thresh, gyro_var_thresh)
-%DETECT_STATIC_INTERVAL Detect a static interval in IMU data.
-%   [STATIC_START, STATIC_END] = DETECT_STATIC_INTERVAL(ACC_BODY, GYRO_BODY)
-%   returns the indices of the first and last samples of a segment where both
-%   accelerometer and gyroscope variance stay below fixed thresholds.  This
-%   mirrors the Python implementation used by ``run_all_methods.py``.
+function [static_start, static_end] = detect_static_interval(acc_body, gyro_body, window_size, accel_var_thresh, gyro_var_thresh, min_length)
+%DETECT_STATIC_INTERVAL  Find a static IMU segment using variance thresholds.
+%   [START, END] = DETECT_STATIC_INTERVAL(ACC_BODY, GYRO_BODY) searches for the
+%   longest contiguous segment where both the accelerometer and gyroscope
+%   variances remain below fixed thresholds.  This mirrors the helper used in
+%   the Python pipeline.
 %
 %   Optional arguments match the Python defaults:
-%       window_size       - variance window length (default 80 samples)
-%       accel_var_thresh  - accelerometer variance threshold (default 0.01)
-%       gyro_var_thresh   - gyroscope variance threshold (default 1e-6)
+%       WINDOW_SIZE       - length of the rolling variance window (default 80)
+%       ACCEL_VAR_THRESH  - accelerometer variance threshold (default 0.01)
+%       GYRO_VAR_THRESH   - gyroscope variance threshold (default 1e-6)
+%       MIN_LENGTH        - minimum acceptable segment length (default 80)
 %
-%   The returned indices are 1-based and inclusive.
+%   Returned indices are 1-based and inclusive with respect to ACC_BODY.
 
     if nargin < 3 || isempty(window_size)
-        window_size = 80; % Match Python
+        window_size = 80; % Match Python defaults
+    end
+    if nargin < 4 || isempty(accel_var_thresh)
         accel_var_thresh = 0.01;
+    end
+    if nargin < 5 || isempty(gyro_var_thresh)
         gyro_var_thresh = 1e-6;
+    end
+    if nargin < 6 || isempty(min_length)
+        min_length = 80;
     end
 
     if size(acc_body,1) < window_size
@@ -23,28 +31,33 @@ function [static_start, static_end] = detect_static_interval(acc_body, gyro_body
               'window_size larger than data length');
     end
 
-    if exist('movvar','file') == 2
-        accel_var = movvar(acc_body, window_size, 0, 'Endpoints','discard');
-        gyro_var  = movvar(gyro_body,  window_size, 0, 'Endpoints','discard');
-    else
-        num_win = size(acc_body,1) - window_size + 1;
-        accel_var = zeros(num_win, size(acc_body,2));
-        gyro_var  = zeros(num_win, size(gyro_body,2));
-        for i = 1:num_win
-            accel_var(i,:) = var(acc_body(i:i+window_size-1,:), 0, 1);
-            gyro_var(i,:)  = var(gyro_body(i:i+window_size-1,:), 0, 1);
+    num_win = size(acc_body,1) - window_size;
+    accel_var = zeros(num_win, size(acc_body,2));
+    gyro_var  = zeros(num_win, size(gyro_body,2));
+    for i = 1:num_win
+        accel_var(i,:) = var(acc_body(i:i+window_size-1,:), 0, 1);
+        gyro_var(i,:)  = var(gyro_body(i:i+window_size-1,:), 0, 1);
+    end
+
+    max_accel_var = max(accel_var, [], 2);
+    max_gyro_var  = max(gyro_var,  [], 2);
+
+    static_mask = (max_accel_var < accel_var_thresh) & (max_gyro_var < gyro_var_thresh);
+
+    d = diff([false; static_mask(:); false]);
+    start_idx = find(d==1);
+    end_idx   = find(d==-1) - 1;
+
+    longest_len = 0;
+    static_start = 1;
+    static_end = window_size;
+    for k = 1:numel(start_idx)
+        len = end_idx(k) - start_idx(k) + 1;
+        if len >= min_length && len > longest_len
+            longest_len = len;
+            static_start = start_idx(k);
+            static_end = end_idx(k) + window_size - 1;
         end
     end
 
-    is_static = all(accel_var < accel_var_thresh, 2) & ...
-                all(gyro_var < gyro_var_thresh, 2);
-    static_indices = find(is_static);
-    if isempty(static_indices)
-        error('No static intervals detected');
-    end
-    static_start = static_indices(1);
-    static_end   = static_indices(end);
-    duration = (static_end - static_start + 1) * 0.0025; % dt fixed at 400 Hz
-    fprintf('Static interval duration: %.2f s of 1250.00 s total (%.1f%%)\n', ...
-            duration, duration/1250*100);
 end

--- a/MATLAB/measure_body_vectors.m
+++ b/MATLAB/measure_body_vectors.m
@@ -1,24 +1,82 @@
 function [dt, g_body, omega_ie_body, mag_body] = measure_body_vectors(imu_file, static_start, static_end, mag_file)
-%MEASURE_BODY_VECTORS  Stub corresponding to the Python implementation.
-%   [DT, G_BODY, OMEGA_IE_BODY, MAG_BODY] = MEASURE_BODY_VECTORS(IMU_FILE,
-%   STATIC_START, STATIC_END, MAG_FILE) mirrors the interface of the Python
-%   function of the same name. It will estimate the gravity and Earth
-%   rotation vectors in the body frame from IMU data and optionally use
-%   magnetometer measurements. The full MATLAB implementation is pending.
-%
-%   This stub is provided for API parity only. All outputs are empty.
-%
-%   See also: MEASURE_BODY_VECTORS in Python.
+%MEASURE_BODY_VECTORS  Estimate gravity and Earth rotation in body frame.
+%   This function mirrors the behaviour of the Python implementation used in
+%   ``src/run_triad_only.py``.  It loads IMU_FILE, converts incremental
+%   measurements to rates, applies a low-pass filter and then detects a static
+%   interval for averaging.  If STATIC_START and STATIC_END are not provided the
+%   interval is obtained automatically using DETECT_STATIC_INTERVAL.  When a
+%   magnetometer file is supplied the mean of its first three columns is
+%   returned as MAG_BODY.
 
-if nargin < 4
-    mag_file = [];
+if nargin < 4 || isempty(mag_file)
+    mag_file = '';
+end
+if nargin < 3
+    static_end = [];
+end
+if nargin < 2
+    static_start = [];
 end
 
-warning('measure_body_vectors:NotImplemented', ...
-    'measure_body_vectors.m is a stub. Full implementation pending.');
+imu_data = readmatrix(imu_file);
+time_s   = imu_data(:,2);
+gyro_inc = imu_data(:,3:5);
+acc_inc  = imu_data(:,6:8);
 
-dt = [];
-g_body = [];
-omega_ie_body = [];
+if numel(time_s) > 1
+    dt = mean(diff(time_s(1:min(100,end))));
+else
+    dt = 1/400; % default 400 Hz
+end
+
+gyro = gyro_inc / dt; % rad/s
+acc  = acc_inc  / dt; % m/s^2
+
+fs = 1/dt;
+gyro = low_pass_filter(gyro, 5, fs);
+acc  = low_pass_filter(acc, 5, fs);
+
+if isempty(static_start)
+    [static_start, static_end] = detect_static_interval(acc, gyro, 80, 0.01, 1e-6, 80);
+else
+    static_start = max(1, static_start);
+    if isempty(static_end)
+        static_end = size(acc,1);
+    else
+        static_end = min(static_end, size(acc,1));
+    end
+end
+
+static_acc  = mean(acc(static_start:static_end,:),1);   % 1x3
+static_gyro = mean(gyro(static_start:static_end,:),1);  % 1x3
+
+n_static  = static_end - static_start + 1;
+static_dur = n_static * dt;
+total_dur  = size(acc,1) * dt;
+ratio = static_dur / total_dur * 100;
+fprintf('Static interval duration: %.2f s of %.2f s total (%.1f%%)\n', ...
+        static_dur, total_dur, ratio);
+if ratio > 90
+    warning('measure_body_vectors:LargeStatic', ...
+        'Static interval covers %.1f%% of the dataset. Verify motion data or adjust detection thresholds.', ratio);
+end
+
+scale = constants.GRAVITY / norm(static_acc);
+static_acc = static_acc * scale;
+
+g_body = -static_acc';           % column vector
+omega_ie_body = static_gyro';    % column vector
+
 mag_body = [];
+if ~isempty(mag_file) && isfile(mag_file)
+    try
+        md = readmatrix(mag_file);
+        if ismatrix(md) && size(md,2) >= 3
+            mag_body = mean(md(:,1:3),1)';
+        end
+    catch ME %#ok<NASGU>
+        mag_body = [];
+    end
+end
+
 end


### PR DESCRIPTION
## Summary
- update reference vector computation for MATLAB
- port static interval detection and body vector estimation from Python
- use new helpers in `run_triad_only.m`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688672d3ca3883259ef5af4ac51847b5