### PR TITLE
Fix output path for Task 6/7 plots

### DIFF
--- a/MATLAB/Task_6.m
+++ b/MATLAB/Task_6.m
@@ -57,7 +57,7 @@ end
 
 % Build output directory using method and dataset identifiers
 run_id = sprintf('%s_%s_%s', imu_name, gnss_name, method);
-out_dir = fullfile(results_dir, 'task6', run_id);
+out_dir = fullfile(results_dir, run_id);
 if ~exist(out_dir, 'dir'); mkdir(out_dir); end
 
 % Load gravity vector from Task 1 initialisation

--- a/MATLAB/task6_overlay_plot.m
+++ b/MATLAB/task6_overlay_plot.m
@@ -8,7 +8,7 @@ function pdf_path = task6_overlay_plot(est_file, truth_file, method, frame, data
 %   ground truth respectively. ``frame`` is either ``'ECEF'`` or ``'NED'``.
 %   The interpolated truth is overlaid on the estimate for position,
 %   velocity and acceleration and the figure saved under
-%   ``results/task6/<run_id>/`` as ``<run_id>_task6_overlay_state_<frame>.pdf`` 
+%   ``results/<run_id>/`` as ``<run_id>_task6_overlay_state_<frame>.pdf``
 %   within the directory returned by ``get_results_dir()``.
 %   ``run_id`` combines the dataset and method, e.g.,
 %   ``IMU_X003_GNSS_X002_TRIAD``.
@@ -206,7 +206,7 @@ for ax = 1:3
 end
 set(f,'PaperPositionMode','auto');
 run_id = sprintf('%s_%s', dataset, method);
-task_dir = fullfile(out_dir, 'task6', run_id);
+task_dir = fullfile(out_dir, run_id);
 if ~exist(task_dir,'dir'); mkdir(task_dir); end
 pdf_path = fullfile(task_dir, sprintf('%s_task6_overlay_state_%s.pdf', run_id, frame));
 png_path = fullfile(task_dir, sprintf('%s_task6_overlay_state_%s.png', run_id, frame));

--- a/MATLAB/task7_ecef_residuals_plot.m
+++ b/MATLAB/task7_ecef_residuals_plot.m
@@ -11,7 +11,7 @@ function task7_ecef_residuals_plot(est_file, imu_file, gnss_file, truth_file, da
 if nargin < 6 || isempty(output_dir)
     output_dir = 'output_matlab';
 end
-out_dir = fullfile(output_dir, 'task7', dataset);
+out_dir = fullfile(output_dir, dataset);
 if ~exist(out_dir, 'dir'); mkdir(out_dir); end
 
 [t_est, pos_est, vel_est, ~] = load_est(est_file);

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Typical result PDFs:
 - `<method>_attitude_angles.pdf` – attitude angles over time
 - `<tag>_<frame>_overlay_truth.pdf` – fused output vs reference. Here `<tag>` is
   the dataset pair and method concatenated, e.g. `IMU_X002_GNSS_X002_Davenport`.
-- ``results/task6/<tag>/<tag>_task6_overlay_state_<frame>.pdf`` – Task 6 overlay with GNSS, IMU and raw state (PDF/PNG)
+ - ``results/<tag>/<tag>_task6_overlay_state_<frame>.pdf`` – Task 6 overlay with GNSS, IMU and raw state (PDF/PNG)
   Example: ``IMU_X002_GNSS_X002_Davenport_task6_ECEF_overlay_state.pdf``
 - `<tag>_task7_3_residuals_position_velocity.pdf` – Task 7 position/velocity residuals
   Example: ``IMU_X002_GNSS_X002_Davenport_task7_3_residuals_position_velocity.pdf``
@@ -300,14 +300,14 @@ python src/task6_plot_truth.py --est-file results/IMU_X001_GNSS_X001_TRIAD_kf_ou
 ```
 
 Passing `--show-measurements` adds the raw IMU and GNSS curves.  The resulting
-figures are written as ``results/task6/<tag>/<tag>_task6_overlay_state_<frame>.pdf`` and ``.png`` files (both formats are saved).
+ figures are written as ``results/<tag>/<tag>_task6_overlay_state_<frame>.pdf`` and ``.png`` files (both formats are saved).
 Here `<tag>` concatenates the IMU dataset, the GNSS dataset and the method,
 for example `IMU_X002_GNSS_X002_Davenport` yielding
 ``IMU_X002_GNSS_X002_Davenport_task6_ECEF_overlay_state.pdf``.
 
 ### Output
 
-* ``results/task6/<tag>/<tag>_task6_overlay_state_<frame>.pdf`` – fused output vs raw state file (PDF/PNG)
+* ``results/<tag>/<tag>_task6_overlay_state_<frame>.pdf`` – fused output vs raw state file (PDF/PNG)
   Example: ``IMU_X002_GNSS_X002_Davenport_task6_ECEF_overlay_state.pdf``
 
 ## Task 7: Evaluation of Filter Results
@@ -331,7 +331,7 @@ python src/run_all_methods.py --task 7
 ### Output:
 
 * When running `run_all_methods.py`, plots are stored in
-  `results/task7/<tag>/` as
+  `results/<tag>/` as
   `<tag>_task7_3_residuals_position_velocity.pdf` and
   `<tag>_task7_4_attitude_angles_euler.pdf` (PDF/PNG). Here `<tag>` is the
   concatenation of the IMU dataset, GNSS dataset and method name, e.g.
@@ -340,7 +340,7 @@ python src/run_all_methods.py --task 7
 * The helper script `src/task7_plot_error_fused_vs_truth.py` produces
   `task7_fused_vs_truth_error.pdf` showing the fused minus truth velocity error.
 * The script `task7_ecef_residuals_plot.py` plots ECEF frame residuals and
-  writes figures to ``results/task7/<tag>/``:
+  writes figures to ``results/<tag>/``:
   `python task7_ecef_residuals_plot.py --est-file <fused.npz> --imu-file <IMU.dat> \
   --gnss-file <GNSS.csv> --truth-file <STATE_X.txt> --dataset <tag>`
 * Subtask 7.5 generates `<tag>_task7_5_diff_truth_fused_over_time.pdf` (NED frame) with the
@@ -389,7 +389,7 @@ Running the script without `--config` processes all bundled data sets
 Provide a YAML configuration to process additional logs.
 Task 6 (truth overlay) and Task 7 (evaluation) are performed automatically for
 each run.  The additional figures are written to `results/` with the evaluation
-plots placed inside `results/task7/<tag>/`. Task 7 uses the dataset tag as a
+plots placed inside `results/<tag>/`. Task 7 uses the dataset tag as a
 prefix where `<tag>` concatenates the IMU file, GNSS file and method. Example:
 `IMU_X002_GNSS_X002_Davenport_task7_3_residuals_position_velocity.pdf`
 will appear in that folder.

--- a/docs/MATLAB/Task6_MATLAB.md
+++ b/docs/MATLAB/Task6_MATLAB.md
@@ -28,7 +28,7 @@ Convert the ECEF truth trajectory to NED using the reference latitude, longitude
 Align IMU, GNSS and truth samples on the filter time grid.
 
 ### 6.4 Plot and Save
-Call `plot_overlay` for the three frames. Overlay PDFs are stored in ``results/task6/<dataset>/`` as ``<dataset>_<method>_task6_overlay_state_<frame>.pdf``. The ``--show-measurements`` flag mirrors the Python implementation.
+Call `plot_overlay` for the three frames. Overlay PDFs are stored in ``results/<dataset>/`` as ``<dataset>_<method>_task6_overlay_state_<frame>.pdf``. The ``--show-measurements`` flag mirrors the Python implementation.
 
 ## Result
 

--- a/docs/MATLAB/Task7_MATLAB.md
+++ b/docs/MATLAB/Task7_MATLAB.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-The script loads residual and attitude data, computes basic statistics and writes figures under ``results/task7/<TAG>/``.
+The script loads residual and attitude data, computes basic statistics and writes figures under ``results/<TAG>/``.
 
 ## Subtasks
 

--- a/docs/Python/Task6_Python.md
+++ b/docs/Python/Task6_Python.md
@@ -28,7 +28,7 @@ Use :func:`assemble_frames` to align IMU, GNSS and truth data in NED, ECEF and b
 Call :func:`plot_overlay` for each frame to produce overlay figures. The ``--show-measurements`` flag adds the raw IMU and GNSS curves.
 
 ### 6.4 Save Overlay Figures
-Overlay PDFs are stored in ``results/task6/<dataset>/`` as ``<dataset>_<method>_task6_overlay_state_<frame>.pdf``.
+Overlay PDFs are stored in ``results/<dataset>/`` as ``<dataset>_<method>_task6_overlay_state_<frame>.pdf``.
 
 ## Result
 

--- a/docs/Python/Task7_Python.md
+++ b/docs/Python/Task7_Python.md
@@ -1,6 +1,6 @@
 # Python Pipeline – Task 7 Filter Evaluation
 
-Task 7 analyses the filter residuals and attitude history. The Python scripts load the residual arrays produced in Task 5 and create diagnostic figures in ``results/task7/<TAG>/``.
+Task 7 analyses the filter residuals and attitude history. The Python scripts load the residual arrays produced in Task 5 and create diagnostic figures in ``results/<TAG>/``.
 
 ## Overview
 

--- a/src/task6_plot_truth.py
+++ b/src/task6_plot_truth.py
@@ -98,7 +98,7 @@ def main() -> None:
     tag = args.tag or f"{m.group(1)}_{m.group(2)}_{method}"
 
     # output directory for overlay figures
-    out_dir = Path(args.output) / "task6" / tag
+    out_dir = Path(args.output) / tag
     out_dir.mkdir(parents=True, exist_ok=True)
 
     # Remove any old Task 6 truth overlay PDFs in this directory

--- a/src/task7_ned_residuals_plot.py
+++ b/src/task7_ned_residuals_plot.py
@@ -6,7 +6,7 @@ Usage:
         --output-dir results
 
 This implements the functionality of ``task7_ned_residuals_plot.m`` from the
-MATLAB code base. Figures are written under ``results/task7/<dataset>/``.
+MATLAB code base. Figures are written under ``results/<dataset>/``.
 """
 
 from __future__ import annotations
@@ -188,7 +188,7 @@ def main() -> None:
         t_est, pos_est, vel_est, pos_truth_i, vel_truth_i
     )
 
-    out_dir = args.output_dir / "task7" / args.dataset
+    out_dir = args.output_dir / args.dataset
     plot_residuals(t_est, res_pos, res_vel, res_acc, args.dataset, out_dir)
 
 

--- a/task6_overlay_plot.py
+++ b/task6_overlay_plot.py
@@ -9,7 +9,7 @@ Usage:
 This script synchronizes the time bases of the estimator output and ground
 truth, then generates a single figure with position, velocity and acceleration
 components overlaid. Only the fused estimate and truth are shown. Figures are
-written under ``results/task6/<run_id>/`` using the filename pattern
+written under ``results/<run_id>/`` using the filename pattern
 ``<run_id>_task6_overlay_state_<frame>.pdf`` where ``run_id`` combines the
 dataset and method, e.g. ``IMU_X003_GNSS_X002_TRIAD``.
 With ``--debug`` the script prints diagnostic information about the input
@@ -203,7 +203,7 @@ def plot_overlay(
 
     fig.tight_layout()
     run_id = f"{dataset}_{method}"
-    task_dir = out_dir / "task6" / run_id
+    task_dir = out_dir / run_id
     task_dir.mkdir(parents=True, exist_ok=True)
     pdf_path = task_dir / f"{run_id}_task6_overlay_state_{frame}.pdf"
     png_path = task_dir / f"{run_id}_task6_overlay_state_{frame}.png"

--- a/task7_ecef_residuals_plot.py
+++ b/task7_ecef_residuals_plot.py
@@ -8,8 +8,8 @@ Usage:
 This script loads a fused estimator output file and a ground truth
 trajectory, interpolates the truth to the estimator time vector and
 plots position, velocity and acceleration residuals. Figures are saved
-as PDF and PNG under ``results/task7/<dataset>/`` within the chosen
-output directory.
+as PDF and PNG under ``results/<tag>/`` within the chosen output
+directory, where ``tag`` combines the dataset, GNSS file and method.
 """
 
 from __future__ import annotations
@@ -21,6 +21,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from validate_with_truth import load_estimate, assemble_frames
+from naming import make_tag, plot_filename
 
 
 def compute_residuals(
@@ -129,7 +130,8 @@ def main() -> None:
         t_est, pos_est, vel_est, pos_truth, vel_truth
     )
 
-    out_dir = output_dir(7, args.dataset, args.gnss, args.method, args.output_dir)
+    tag = make_tag(args.dataset, args.gnss, args.method)
+    out_dir = Path(args.output_dir) / tag
     plot_residuals(
         t_est,
         res_pos,

--- a/tests/test_task7_ned_residuals_plot.py
+++ b/tests/test_task7_ned_residuals_plot.py
@@ -15,7 +15,7 @@ def test_plot_residuals(tmp_path: Path):
     res_pos, res_vel, res_acc = compute_residuals(
         t, pos_est, vel_est, pos_truth, vel_truth
     )
-    out_dir = tmp_path / "task7" / "TEST"
+    out_dir = tmp_path / "TEST"
     plot_residuals(t, res_pos, res_vel, res_acc, "TEST", out_dir)
     assert (out_dir / "TEST_task7_ned_residuals.pdf").exists()
     assert (out_dir / "TEST_task7_ned_residual_norms.pdf").exists()

--- a/tests/test_validate_with_truth.py
+++ b/tests/test_validate_with_truth.py
@@ -260,7 +260,7 @@ def test_overlay_truth_generation(tmp_path, monkeypatch):
         ],
     )
     task6_main()
-    state_dir = Path("results") / "task6" / "IMU_X001_small_GNSS_X001_small_TRIAD"
+    state_dir = Path("results") / "IMU_X001_small_GNSS_X001_small_TRIAD"
     state_files = {p.name for p in state_dir.glob("*_task6_overlay_state_*.pdf")}
     assert state_files, "Missing state overlay plots"
 


### PR DESCRIPTION
## Summary
- drop the `task6`/`task7` subfolders when writing overlay and residual plots
- update MATLAB helpers to mirror the new output structure
- adjust docs and tests for the new locations

## Testing
- `pytest tests/test_validate_with_truth.py::test_overlay_truth_generation -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886723246808325bda2048e7f410877