### PR TITLE
Save plots directly in results folders

### DIFF
--- a/MATLAB/task6_overlay_plot.m
+++ b/MATLAB/task6_overlay_plot.m
@@ -206,14 +206,20 @@ for ax = 1:3
 end
 set(f,'PaperPositionMode','auto');
 run_id = sprintf('%s_%s', dataset, method);
-task_dir = fullfile(out_dir, run_id);
-if ~exist(task_dir,'dir'); mkdir(task_dir); end
-pdf_path = fullfile(task_dir, sprintf('%s_task6_overlay_state_%s.pdf', run_id, frame));
-png_path = fullfile(task_dir, sprintf('%s_task6_overlay_state_%s.png', run_id, frame));
+if ~exist(out_dir,'dir'); mkdir(out_dir); end
+pdf_path = fullfile(out_dir, sprintf('%s_task6_overlay_state_%s.pdf', run_id, frame));
+png_path = fullfile(out_dir, sprintf('%s_task6_overlay_state_%s.png', run_id, frame));
 print(f, pdf_path, '-dpdf', '-bestfit');
 print(f, png_path, '-dpng', '-bestfit');
 close(f);
 fprintf('Saved overlay figure to %s\n', pdf_path);
+files = dir(fullfile(out_dir, sprintf('%s_task6_*.pdf', run_id)));
+if ~isempty(files)
+    fprintf('Files saved in %s\n', out_dir);
+    for k=1:numel(files)
+        fprintf(' - %s\n', files(k).name);
+    end
+end
 end
 
 % -------------------------------------------------------------------------
@@ -245,5 +251,12 @@ print(f, pdf_path, '-dpdf', '-bestfit');
 print(f, png_path, '-dpng', '-bestfit');
 close(f);
 fprintf('Saved RMSE figure to %s\n', pdf_path);
+files = dir(fullfile(out_dir, sprintf('%s_%s_Task6_*_RMSE.pdf', dataset, method)));
+if ~isempty(files)
+    fprintf('Files saved in %s\n', out_dir);
+    for k=1:numel(files)
+        fprintf(' - %s\n', files(k).name);
+    end
+end
 end
 

--- a/MATLAB/task7_ecef_residuals_plot.m
+++ b/MATLAB/task7_ecef_residuals_plot.m
@@ -9,9 +9,9 @@ function task7_ecef_residuals_plot(est_file, imu_file, gnss_file, truth_file, da
 %   ``output_dir`` using ``dataset`` as part of the filename.
 
 if nargin < 6 || isempty(output_dir)
-    output_dir = 'output_matlab';
+    output_dir = 'MATLAB/results';
 end
-out_dir = fullfile(output_dir, dataset);
+out_dir = output_dir;
 if ~exist(out_dir, 'dir'); mkdir(out_dir); end
 
 [t_est, pos_est, vel_est, ~] = load_est(est_file);
@@ -111,5 +111,12 @@ pngn = fullfile(out_dir, sprintf('%s_task7_ecef_residual_norms.png', dataset));
 print(f, pdfn, '-dpdf', '-bestfit');
 print(f, pngn, '-dpng', '-bestfit');
 close(f);
+files = dir(fullfile(out_dir, sprintf('%s_task7_ecef_residual*.pdf', dataset)));
+if ~isempty(files)
+    fprintf('Files saved in %s\n', out_dir);
+    for k=1:numel(files)
+        fprintf(' - %s\n', files(k).name);
+    end
+end
 end
 

--- a/plot_task6_results.py
+++ b/plot_task6_results.py
@@ -83,6 +83,12 @@ def main() -> None:
         out_dir,
     )
 
+    saved = sorted(out_dir.glob(f"{dataset}_{method}_task6_*.pdf"))
+    if saved:
+        print("Files saved in", out_dir)
+        for f in saved:
+            print(" -", f.name)
+
 
 if __name__ == "__main__":
     main()

--- a/src/task6_plot_truth.py
+++ b/src/task6_plot_truth.py
@@ -98,7 +98,7 @@ def main() -> None:
     tag = args.tag or f"{m.group(1)}_{m.group(2)}_{method}"
 
     # output directory for overlay figures
-    out_dir = Path(args.output) / tag
+    out_dir = Path(args.output)
     out_dir.mkdir(parents=True, exist_ok=True)
 
     # Remove any old Task 6 truth overlay PDFs in this directory
@@ -295,6 +295,11 @@ def main() -> None:
             "FinalAcc",
         ]
         print(tabulate(summary_rows, headers=headers, floatfmt=".3f"))
+    saved = sorted(out_dir.glob(f"{tag}_task6_*.pdf"))
+    if saved:
+        print("Files saved in", out_dir)
+        for f in saved:
+            print(" -", f.name)
     runtime = time.time() - start_time
     print(f"Task 6 runtime: {runtime:.2f} s")
 

--- a/src/task7_ned_residuals_plot.py
+++ b/src/task7_ned_residuals_plot.py
@@ -163,6 +163,12 @@ def plot_residuals(
     fig.savefig(norm_png)
     plt.close(fig)
 
+    saved = sorted(out_dir.glob(f"{dataset}_task7_ned_residual*.pdf"))
+    if saved:
+        print("Files saved in", out_dir)
+        for f in saved:
+            print(" -", f.name)
+
 
 def main() -> None:
     ap = argparse.ArgumentParser(description="Plot NED residuals for Task 7")
@@ -188,8 +194,13 @@ def main() -> None:
         t_est, pos_est, vel_est, pos_truth_i, vel_truth_i
     )
 
-    out_dir = args.output_dir / args.dataset
+    out_dir = args.output_dir
     plot_residuals(t_est, res_pos, res_vel, res_acc, args.dataset, out_dir)
+    saved = sorted(out_dir.glob(f"{args.dataset}_task7_ned_residual*.pdf"))
+    if saved:
+        print("Files saved in", out_dir)
+        for f in saved:
+            print(" -", f.name)
 
 
 if __name__ == "__main__":

--- a/task6_overlay_plot.py
+++ b/task6_overlay_plot.py
@@ -203,10 +203,9 @@ def plot_overlay(
 
     fig.tight_layout()
     run_id = f"{dataset}_{method}"
-    task_dir = out_dir / run_id
-    task_dir.mkdir(parents=True, exist_ok=True)
-    pdf_path = task_dir / f"{run_id}_task6_overlay_state_{frame}.pdf"
-    png_path = task_dir / f"{run_id}_task6_overlay_state_{frame}.png"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    pdf_path = out_dir / f"{run_id}_task6_overlay_state_{frame}.pdf"
+    png_path = out_dir / f"{run_id}_task6_overlay_state_{frame}.png"
     fig.savefig(pdf_path)
     fig.savefig(png_path)
     plt.close(fig)
@@ -337,6 +336,13 @@ def main() -> None:
         args.dataset,
         out_dir,
     )
+
+    run_id = f"{args.dataset}_{args.method}"
+    saved = sorted(out_dir.glob(f"{run_id}_task6_*.pdf"))
+    if saved:
+        print("Saved files under", out_dir)
+        for f in saved:
+            print(" -", f.name)
 
 
 if __name__ == "__main__":

--- a/task7_ecef_residuals_plot.py
+++ b/task7_ecef_residuals_plot.py
@@ -101,6 +101,12 @@ def plot_residuals(
     fig.savefig(norm_png)
     plt.close(fig)
 
+    saved = sorted(out_dir.glob(f"{tag}_task7_*ecef_residual*.pdf"))
+    if saved:
+        print("Files saved in", out_dir)
+        for f in saved:
+            print(" -", f.name)
+
 
 def main() -> None:
     ap = argparse.ArgumentParser(description="Plot ECEF residuals for Task 7")
@@ -131,7 +137,7 @@ def main() -> None:
     )
 
     tag = make_tag(args.dataset, args.gnss, args.method)
-    out_dir = Path(args.output_dir) / tag
+    out_dir = Path(args.output_dir)
     plot_residuals(
         t_est,
         res_pos,

--- a/tests/test_task7_ned_residuals_plot.py
+++ b/tests/test_task7_ned_residuals_plot.py
@@ -15,7 +15,7 @@ def test_plot_residuals(tmp_path: Path):
     res_pos, res_vel, res_acc = compute_residuals(
         t, pos_est, vel_est, pos_truth, vel_truth
     )
-    out_dir = tmp_path / "TEST"
+    out_dir = tmp_path
     plot_residuals(t, res_pos, res_vel, res_acc, "TEST", out_dir)
     assert (out_dir / "TEST_task7_ned_residuals.pdf").exists()
     assert (out_dir / "TEST_task7_ned_residual_norms.pdf").exists()

--- a/tests/test_validate_with_truth.py
+++ b/tests/test_validate_with_truth.py
@@ -233,11 +233,11 @@ def test_overlay_truth_generation(tmp_path, monkeypatch):
     validate_main()
 
     expected = {
-        "TRIAD_NED_overlay_state.pdf",
-        "TRIAD_ECEF_overlay_state.pdf",
-        "TRIAD_Body_overlay_state.pdf",
+        "IMU_X001_small_GNSS_X001_small_TRIAD_task6_overlay_state_NED.pdf",
+        "IMU_X001_small_GNSS_X001_small_TRIAD_task6_overlay_state_ECEF.pdf",
+        "IMU_X001_small_GNSS_X001_small_TRIAD_task6_overlay_state_Body.pdf",
     }
-    produced = {p.name for p in Path("results").glob("*_overlay_state.pdf")}
+    produced = {p.name for p in Path("results").glob("*_task6_overlay_state_*.pdf")}
     assert expected.issubset(produced), f"Missing overlays: {expected - produced}"
 
     # verify raw STATE overlay generation via task6_plot_truth.py
@@ -260,8 +260,11 @@ def test_overlay_truth_generation(tmp_path, monkeypatch):
         ],
     )
     task6_main()
-    state_dir = Path("results") / "IMU_X001_small_GNSS_X001_small_TRIAD"
-    state_files = {p.name for p in state_dir.glob("*_task6_overlay_state_*.pdf")}
+    state_files = {
+        p.name for p in Path("results").glob(
+            "IMU_X001_small_GNSS_X001_small_TRIAD_task6_overlay_state_*.pdf"
+        )
+    }
     assert state_files, "Missing state overlay plots"
 
 


### PR DESCRIPTION
## Summary
- drop dataset subdirectories when saving Python plots
- mirror change in MATLAB plotting utilities
- list saved files for verification
- update tests for new naming scheme

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68867aadc8d48325ad94f7de1d2f8ed5