### PR TITLE
Update Task7 output paths

### DIFF
--- a/src/evaluate_filter_results.py
+++ b/src/evaluate_filter_results.py
@@ -50,6 +50,8 @@ def run_evaluation(
         Optional dataset tag added as a prefix to the plot filenames.
     """
     out_dir = Path(save_path)
+    # All Task 7 plots are written directly into ``results/``
+    # unless a different directory is provided.
     out_dir.mkdir(parents=True, exist_ok=True)
 
     pred = pd.read_csv(prediction_file)
@@ -397,7 +399,8 @@ if __name__ == "__main__":
     ap.add_argument("--gnss")
     ap.add_argument("--attitude")
     ap.add_argument("--npz", help="NPZ file produced by GNSS_IMU_Fusion.py")
-    ap.add_argument("--output", default="results/task7/")
+    # Task 7 plots now default to the top-level ``results`` directory
+    ap.add_argument("--output", default="results")
     ap.add_argument("--tag", help="Dataset tag used as filename prefix")
     args = ap.parse_args()
     if args.npz:

--- a/src/run_all_methods.py
+++ b/src/run_all_methods.py
@@ -138,11 +138,13 @@ def main(argv=None):
     if args.task == 7:
         from evaluate_filter_results import run_evaluation
 
+        # Task 7 results must be stored directly in ``results/``
+        # according to the updated project requirements.
         run_evaluation(
             prediction_file="outputs/predicted_states.csv",
             gnss_file="outputs/gnss_measurements.csv",
             attitude_file="outputs/estimated_attitude.csv",
-            save_path="results/task7/",
+            save_path="results",
         )
         return
 
@@ -382,7 +384,8 @@ def main(argv=None):
             # ----------------------------
             # Task 7: Evaluation
             # ----------------------------
-            task7_dir = pathlib.Path("results") / "task7" / tag
+            # Updated: Task 7 outputs are saved directly in ``results/``
+            task7_dir = pathlib.Path("results")
             with open(log_path, "a") as log:
                 log.write("\nTASK 7: Evaluate residuals\n")
                 msg = "Running Task 7 evaluation ..."

--- a/src/run_method_only.py
+++ b/src/run_method_only.py
@@ -270,7 +270,8 @@ def main(argv=None):
 
                 # -------- Task 7: Residual evaluation --------
                 tag = f"{m2.group(1)}_{m2.group(2)}_{args.method}"
-                task7_dir = results / "task7" / tag
+                # Store Task 7 plots directly in ``results/``
+                task7_dir = results
                 print("Running Task 7 evaluation ...")
                 try:
                     run_evaluation_npz(str(npz_path), str(task7_dir), tag)

--- a/src/run_triad_only.py
+++ b/src/run_triad_only.py
@@ -89,11 +89,12 @@ def main(argv: Iterable[str] | None = None) -> None:
     if args.task == 7:
         from evaluate_filter_results import run_evaluation
 
+        # Save Task 7 output directly under ``results/``
         run_evaluation(
             prediction_file="outputs/predicted_states.csv",
             gnss_file="outputs/gnss_measurements.csv",
             attitude_file="outputs/estimated_attitude.csv",
-            save_path="results/task7/",
+            save_path="results",
         )
         return
 
@@ -335,7 +336,9 @@ def main(argv: Iterable[str] | None = None) -> None:
     # ----------------------------
     # Task 7: Evaluation
     # ----------------------------
-    task7_dir = results_dir / "task7" / tag
+    % Task 7 plots are now saved directly under the ``results``
+    % directory without subfolders for easier navigation.
+    task7_dir = results_dir
     with open(log_path, "a") as log:
         log.write("\nTASK 7: Evaluate residuals\n")
         msg = "Running Task 7 evaluation ..."

--- a/src/validate_with_truth.py
+++ b/src/validate_with_truth.py
@@ -1065,11 +1065,13 @@ def main():
             frames = assemble_frames(
                 est, imu_file, gnss_file, truth_file=args.truth_file
             )
+            tag = f"{m.group(1)}_{m.group(2)}_{method}"
             for frame_name, data in frames.items():
                 t_i, p_i, v_i, a_i = data["imu"]
                 t_g, p_g, v_g, a_g = data["gnss"]
                 t_f, p_f, v_f, a_f = data["fused"]
                 truth = data.get("truth")
+                filename = f"{tag}_task6_overlay_state_{frame_name}.pdf"
                 plot_overlay(
                     frame_name,
                     method,
@@ -1087,6 +1089,7 @@ def main():
                     a_f,
                     args.output,
                     truth,
+                    filename=filename,
                 )
         except Exception as e:
             print(f"Overlay plot failed: {e}")


### PR DESCRIPTION
## Summary
- store Task 7 evaluation output directly in `results/`
- adjust default output directory for evaluation script
- propagate dataset tag for Task 6 overlay plots
- update related scripts accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886807a020c83258645ba7def86373b