### PR TITLE
Ensure all outputs saved flat in results/

### DIFF
--- a/MATLAB/naming_utils.m
+++ b/MATLAB/naming_utils.m
@@ -31,8 +31,20 @@ function name = script_name(dataset, method, task, ext)
 end
 
 function dir = output_dir(task, dataset, gnss, method)
-    tag = make_tag(dataset, gnss, method);
-    dir = fullfile('results', sprintf('task%d', task), tag);
+    %OUTPUT_DIR  Return the base results directory.
+    %   Historically the pipeline used results/taskN/<tag> but all outputs are
+    %   now written directly inside ``results`` with the task number embedded in
+    %   the filename. This function therefore just returns ``'results'`` so
+    %   existing code continues to work.
+
+    %#ok<INUSD> -- parameters retained for compatibility
+    dir = 'results';
+end
+
+function p = results_path(filename)
+    %RESULTS_PATH  Return path to FILENAME inside the results folder.
+    if nargin < 1, filename = ''; end
+    p = fullfile('results', filename);
 end
 
 function fname = plot_filename(dataset, gnss, method, task, subtask, out_type, ext)

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Typical result PDFs:
 - `<tag>_task6_attitude_angles.pdf` – attitude angles over time
 - `<tag>_<frame>_overlay_truth.pdf` – fused output vs reference. Here `<tag>` is
   the dataset pair and method concatenated, e.g. `IMU_X002_GNSS_X002_Davenport`.
- - ``results/<tag>/<tag>_task6_overlay_state_<frame>.pdf`` – Task 6 overlay with GNSS, IMU and raw state (PDF/PNG)
+ - ``results/<tag>_task6_overlay_state_<frame>.pdf`` – Task 6 overlay with GNSS, IMU and raw state (PDF/PNG)
   Example: ``IMU_X002_GNSS_X002_Davenport_task6_ECEF_overlay_state.pdf``
 - `<tag>_task7_3_residuals_position_velocity.pdf` – Task 7 position/velocity residuals
   Example: ``IMU_X002_GNSS_X002_Davenport_task7_3_residuals_position_velocity.pdf``
@@ -300,14 +300,14 @@ python src/task6_plot_truth.py --est-file results/IMU_X001_GNSS_X001_TRIAD_kf_ou
 ```
 
 Passing `--show-measurements` adds the raw IMU and GNSS curves.  The resulting
- figures are written as ``results/<tag>/<tag>_task6_overlay_state_<frame>.pdf`` and ``.png`` files (both formats are saved).
+ figures are written as ``results/<tag>_task6_overlay_state_<frame>.pdf`` and ``.png`` files (both formats are saved).
 Here `<tag>` concatenates the IMU dataset, the GNSS dataset and the method,
 for example `IMU_X002_GNSS_X002_Davenport` yielding
 ``IMU_X002_GNSS_X002_Davenport_task6_ECEF_overlay_state.pdf``.
 
 ### Output
 
-* ``results/<tag>/<tag>_task6_overlay_state_<frame>.pdf`` – fused output vs raw state file (PDF/PNG)
+* ``results/<tag>_task6_overlay_state_<frame>.pdf`` – fused output vs raw state file (PDF/PNG)
   Example: ``IMU_X002_GNSS_X002_Davenport_task6_ECEF_overlay_state.pdf``
 
 ## Task 7: Evaluation of Filter Results
@@ -330,8 +330,8 @@ python src/run_all_methods.py --task 7
 
 ### Output:
 
-* When running `run_all_methods.py`, plots are stored in
-  `results/<tag>/` as
+* When running `run_all_methods.py`, plots are stored directly in
+  `results/` as
   `<tag>_task7_3_residuals_position_velocity.pdf` and
   `<tag>_task7_4_attitude_angles_euler.pdf` (PDF/PNG). Here `<tag>` is the
   concatenation of the IMU dataset, GNSS dataset and method name, e.g.
@@ -340,7 +340,7 @@ python src/run_all_methods.py --task 7
 * The helper script `src/task7_plot_error_fused_vs_truth.py` produces
   `task7_fused_vs_truth_error.pdf` showing the fused minus truth velocity error.
 * The script `task7_ecef_residuals_plot.py` plots ECEF frame residuals and
-  writes figures to ``results/<tag>/``:
+  writes figures to ``results/``:
   `python task7_ecef_residuals_plot.py --est-file <fused.npz> --imu-file <IMU.dat> \
   --gnss-file <GNSS.csv> --truth-file <STATE_X.txt> --dataset <tag>`
 * Subtask 7.5 generates `<tag>_task7_5_diff_truth_fused_over_time.pdf` (NED frame) with the
@@ -388,9 +388,9 @@ Running the script without `--config` processes all bundled data sets
 (`IMU_X001`–`IMU_X003`).
 Provide a YAML configuration to process additional logs.
 Task 6 (truth overlay) and Task 7 (evaluation) are performed automatically for
-each run.  The additional figures are written to `results/` with the evaluation
-plots placed inside `results/<tag>/`. Task 7 uses the dataset tag as a
-prefix where `<tag>` concatenates the IMU file, GNSS file and method. Example:
+each run.  All additional figures are written directly to `results/`. Task 7 uses
+the dataset tag as a prefix where `<tag>` concatenates the IMU file, GNSS file
+and method. Example:
 `IMU_X002_GNSS_X002_Davenport_task7_3_residuals_position_velocity.pdf`
 will appear in that folder.
 The helper module `src/naming.py` provides :func:`build_tag` and
@@ -534,7 +534,7 @@ run_batch(datasets, methods)
 ```
 
 The snippet above loads the files using :func:`load_data` and places the
-generated figures in `results/auto_plots/`.
+generated figures in `results/`.
 
 Interactive exploration lives in the `notebooks/` folder. Open
 `notebooks/demo.ipynb` to try the plotting utilities in Jupyter.

--- a/docs/Python/Task6_Python.md
+++ b/docs/Python/Task6_Python.md
@@ -28,7 +28,7 @@ Use :func:`assemble_frames` to align IMU, GNSS and truth data in NED, ECEF and b
 Call :func:`plot_overlay` for each frame to produce overlay figures. The ``--show-measurements`` flag adds the raw IMU and GNSS curves.
 
 ### 6.4 Save Overlay Figures
-Overlay PDFs are stored in ``results/<dataset>/`` as ``<dataset>_<method>_task6_overlay_state_<frame>.pdf``.
+Overlay PDFs are stored directly in ``results/`` as ``<dataset>_<method>_task6_overlay_state_<frame>.pdf``.
 
 ## Result
 

--- a/docs/Python/Task7_Python.md
+++ b/docs/Python/Task7_Python.md
@@ -1,6 +1,6 @@
 # Python Pipeline – Task 7 Filter Evaluation
 
-Task 7 analyses the filter residuals and attitude history. The Python scripts load the residual arrays produced in Task 5 and create diagnostic figures in ``results/<TAG>/``.
+Task 7 analyses the filter residuals and attitude history. The Python scripts load the residual arrays produced in Task 5 and create diagnostic figures directly in ``results/`` using the dataset tag ``<TAG>`` as part of each filename.
 
 ## Overview
 

--- a/src/auto_plots.py
+++ b/src/auto_plots.py
@@ -20,7 +20,7 @@ from utils import compute_C_ECEF_to_NED
 # ---------------------------------------------------------------------------
 # Where figures and tables should be written
 # ---------------------------------------------------------------------------
-OUTPUT_DIR = "results/auto_plots"
+OUTPUT_DIR = "results"
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 # Collect metrics for the summary table

--- a/src/naming.py
+++ b/src/naming.py
@@ -19,11 +19,36 @@ def script_name(dataset: str, method: str, task: int, ext: str = "py") -> str:
     dname = Path(dataset).stem
     return f"{dname}_{method}_task{task}.{ext}"
 
-def output_dir(task: int, dataset: str, gnss: str, method: str, base_dir: Union[str, Path] = "results") -> Path:
-    """Return the directory path for storing outputs for a given task."""
-    tag = make_tag(dataset, gnss, method)
-    base = Path(base_dir)
-    return base / f"task{task}" / tag
+def output_dir(
+    task: int,
+    dataset: str,
+    gnss: str,
+    method: str,
+    base_dir: Union[str, Path] = "results",
+) -> Path:
+    """Return ``base_dir`` for backward compatibility.
+
+    Historically, outputs were written to subfolders like ``results/taskN/<tag>``
+    but the updated convention stores everything directly under ``results/`` with
+    the task number encoded in the filename.  This helper now simply returns the
+    base directory so existing code continues to work without modification.
+    """
+
+    return Path(base_dir)
+
+
+def results_path(filename: str, base_dir: Union[str, Path] = "results") -> Path:
+    """Return ``Path`` to *filename* inside ``results``.
+
+    Parameters
+    ----------
+    filename : str
+        Name of the file to be saved.
+    base_dir : str or Path, optional
+        Base results directory. Defaults to ``"results"``.
+    """
+
+    return Path(base_dir) / filename
 
 def plot_filename(dataset: str, gnss: str, method: str, task: int, subtask: str, out_type: str, ext: str = "pdf") -> str:
     """Return a plot filename following the standard convention."""

--- a/src/run_all_datasets.py
+++ b/src/run_all_datasets.py
@@ -95,7 +95,7 @@ def run_one(imu, gnss, method, verbose=False):
 
 
 def main():
-    results_dir = pathlib.Path('results/run_all_datasets')
+    results_dir = pathlib.Path("results")
     results_dir.mkdir(parents=True, exist_ok=True)
     logging.info("Ensured '%s' directory exists.", results_dir)
     parser = argparse.ArgumentParser()

--- a/src/run_triad_only.py
+++ b/src/run_triad_only.py
@@ -61,7 +61,7 @@ def check_files(imu_file: str, gnss_file: str) -> tuple[pathlib.Path, pathlib.Pa
 
 
 def main(argv: Iterable[str] | None = None) -> None:
-    results_dir = pathlib.Path("results/IMU_X002_GNSS_X002_TRIAD")
+    results_dir = pathlib.Path("results")
     results_dir.mkdir(parents=True, exist_ok=True)
     logger.info("Ensured '%s' directory exists.", results_dir)
 
@@ -149,14 +149,17 @@ def main(argv: Iterable[str] | None = None) -> None:
     if ret != 0:
         raise subprocess.CalledProcessError(ret, cmd)
 
-    # Move generated result files into the dedicated directory
+    # Move generated files when a separate results directory was used in older
+    # versions. With the flat layout ``results_dir`` equals ``base_results`` so
+    # the loop becomes a no-op.
     base_results = pathlib.Path("results")
-    for file in base_results.glob(f"{tag}*"):
-        dest = results_dir / file.name
-        try:
-            file.replace(dest)
-        except Exception:
-            pass
+    if results_dir != base_results:
+        for file in base_results.glob(f"{tag}*"):
+            dest = results_dir / file.name
+            try:
+                file.replace(dest)
+            except Exception:
+                pass
 
     for summary in summaries:
         kv = dict(re.findall(r"(\w+)=\s*([^\s]+)", summary))

--- a/src/summarise_runs.py
+++ b/src/summarise_runs.py
@@ -10,6 +10,7 @@ import pathlib
 import re
 import os
 import logging
+from naming import results_path
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 if __name__ == "__main__":
@@ -49,7 +50,7 @@ for r in rows:
     r["best"] = "\u2713" if best_map[r["dataset"]] is r else ""
 
 # CSV -------------------------------------------------------------------------
-with open(RESULTS_DIR / "summary.csv", "w", newline="") as fh:
+with open(results_path("summary.csv"), "w", newline="") as fh:
     fieldnames = [
         "dataset",
         "method",
@@ -65,7 +66,7 @@ with open(RESULTS_DIR / "summary.csv", "w", newline="") as fh:
         writer.writerow({k: r.get(k, "") for k in fieldnames})
 
 # Markdown table --------------------------------------------------------------
-with open(RESULTS_DIR / "summary.md", "w") as fh:
+with open(results_path("summary.md"), "w") as fh:
     hdr_cols = ["dataset", "method", "imu", "gnss", "rmse_pos", "final_pos", "best"]
     hdr = " | ".join(hdr_cols)
     sep = " | ".join("---" for _ in hdr_cols)

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -14,7 +14,7 @@ def test_script_name():
 
 def test_output_dir(tmp_path):
     d = output_dir(5, "IMU_X001.dat", "GNSS_X001.csv", "TRIAD", tmp_path)
-    assert d == tmp_path / "task5" / "IMU_X001_GNSS_X001_TRIAD"
+    assert d == tmp_path
 
 
 def test_plot_filename():

--- a/tests/test_results_structure.py
+++ b/tests/test_results_structure.py
@@ -1,0 +1,20 @@
+import os
+from pathlib import Path
+
+ALLOWED_SUBDIRS = {"legacy", "archival"}
+
+def test_results_flat_structure(tmp_path):
+    results = tmp_path / "results"
+    results.mkdir()
+    # create sample files
+    (results / "IMU_X001_GNSS_X001_TRIAD_task6_demo.pdf").touch()
+    (results / "sample_task7_plot.png").touch()
+    (results / "legacy").mkdir()
+    (results / "legacy" / "old.txt").touch()
+
+    # scan directory
+    for p in results.iterdir():
+        if p.is_dir():
+            assert p.name in ALLOWED_SUBDIRS, f"Unexpected subdirectory {p.name}"
+        else:
+            assert "task" in p.name, f"Missing task number in {p.name}"


### PR DESCRIPTION
## Summary
- refactor naming utils to remove subfolders
- add `results_path` helper for outputs
- update run scripts and auto plots to use flat `results/`
- document new layout in README and task docs
- adjust tests and add check for results directory structure

## Testing
- `pytest tests/test_naming.py tests/test_results_structure.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68868126888c83258000d5da6a485db2