### PR TITLE
Fix syntax comment in run_triad_only

### DIFF
--- a/src/run_triad_only.py
+++ b/src/run_triad_only.py
@@ -333,8 +333,8 @@ def main(argv: Iterable[str] | None = None) -> None:
     # ----------------------------
     # Task 7: Evaluation
     # ----------------------------
-    % Task 7 plots are now saved directly under the ``results``
-    % directory without subfolders for easier navigation.
+    # Task 7 plots are now saved directly under the ``results``
+    # directory without subfolders for easier navigation.
     task7_dir = results_dir
     with open(log_path, "a") as log:
         log.write("\nTASK 7: Evaluate residuals\n")


### PR DESCRIPTION
## Summary
- fix MATLAB-style comment that broke run_triad_only.py

## Testing
- `scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68868ed5f5588325817203c060f039ec