### PR TITLE
Fix Task 7 time alignment

### DIFF
--- a/docs/MATLAB/Task7_MATLAB.md
+++ b/docs/MATLAB/Task7_MATLAB.md
@@ -6,6 +6,11 @@
 
 The script loads residual and attitude data, computes basic statistics and writes figures under ``results/<TAG>/``.
 
+As of *October 2023* the evaluation aligns all residuals to the fused IMU time
+vector. Earlier versions used the GNSS update times which produced shortened
+plots compared to Task 6. Residuals and truth are now interpolated so that the
+Task 7 timeline matches the Task 6 overlays.
+
 ## Subtasks
 
 ### 7.1 Load Data


### PR DESCRIPTION
## Summary
- align evaluate_filter_results residuals with fused timeline
- document the new alignment behaviour in Task7 documentation

## Testing
- `pytest -q tests/test_task7_ned_residuals_plot.py`
- `pytest -q tests/test_evaluate_filter_results.py::test_run_evaluation_npz_diff_plot`


------
https://chatgpt.com/codex/tasks/task_e_688695be51dc83258da5342935a099df