### PR TITLE
Fix variable assignment in MATLAB Task_2

### DIFF
--- a/MATLAB/Task_2.m
+++ b/MATLAB/Task_2.m
@@ -65,6 +65,7 @@ function body_data = Task_2(imu_path, gnss_path, method)
     static_gyro = mean(gyro_filt(static_start:static_end, :), 1); % 1x3
     g_body_raw = -static_acc';
     g_body = (g_body_raw / norm(g_body_raw)) * constants.GRAVITY;
+    g_body_scaled = g_body; % legacy variable for compatibility with old scripts
     omega_ie_body = static_gyro';
 
     % Use consistent variable names across all MATLAB tasks


### PR DESCRIPTION
## Summary
- define `g_body_scaled` in `Task_2.m` to avoid save errors

## Testing
- `pytest -q` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688699278b0483258e4cda1f731caeaf