### PR TITLE
Align Task 7 plots with Task 6 timeline

### DIFF
--- a/MATLAB/task7_ecef_residuals_plot.m
+++ b/MATLAB/task7_ecef_residuals_plot.m
@@ -5,7 +5,8 @@ function task7_ecef_residuals_plot(est_file, imu_file, gnss_file, truth_file, da
 %   mirrors the Python script ``task7_ecef_residuals_plot.py``. The IMU and GNSS
 %   file paths are currently unused but included for interface parity. The truth
 %   data is interpolated to the estimator timestamps and residuals in position,
-%   velocity and acceleration are plotted. Figures are saved under
+%   velocity and acceleration are plotted. The time axis is shifted so the
+%   first sample corresponds to ``t=0`` matching Task 6. Figures are saved under
 %   ``output_dir`` using ``dataset`` as part of the filename.
 
 if nargin < 6 || isempty(output_dir)
@@ -17,12 +18,15 @@ if ~exist(out_dir, 'dir'); mkdir(out_dir); end
 [t_est, pos_est, vel_est, ~] = load_est(est_file);
 [t_truth, pos_truth, vel_truth, ~] = load_est(truth_file);
 
+% Use relative time to match Task 6 plots
+t_rel = t_est - t_est(1);
+
 pos_truth_i = interp1(t_truth, pos_truth, t_est, 'linear', 'extrap');
 vel_truth_i = interp1(t_truth, vel_truth, t_est, 'linear', 'extrap');
 
-[res_pos, res_vel, res_acc] = compute_residuals(t_est, pos_est, vel_est, pos_truth_i, vel_truth_i);
+[res_pos, res_vel, res_acc] = compute_residuals(t_rel, pos_est, vel_est, pos_truth_i, vel_truth_i);
 
-plot_residuals(t_est, res_pos, res_vel, res_acc, dataset, out_dir);
+plot_residuals(t_rel, res_pos, res_vel, res_acc, dataset, out_dir);
 
 end
 

--- a/MATLAB/task7_ned_residuals_plot.m
+++ b/MATLAB/task7_ned_residuals_plot.m
@@ -3,8 +3,10 @@ function task7_ned_residuals_plot(est_file, truth_file, dataset, output_dir)
 %   TASK7_NED_RESIDUALS_PLOT(EST_FILE, TRUTH_FILE, DATASET, OUTPUT_DIR) loads
 %   a fused estimator result and the ground truth trajectory. Truth data is
 %   converted from ECEF to NED using the reference coordinates stored in
-%   EST_FILE. Position, velocity and acceleration residuals are then plotted
-%   and saved under OUTPUT_DIR using DATASET as part of the filename.
+%   EST_FILE. Position, velocity and acceleration residuals are then plotted.
+%   The time vector is shifted so the first sample occurs at t=0 to match
+%   Task 6. Figures are saved under OUTPUT_DIR using DATASET as part of the
+%   filename.
 %
 %   Usage:
 %       task7_ned_residuals_plot('fused_results.mat', 'STATE_X001.txt', ...
@@ -21,13 +23,16 @@ if ~exist(output_dir, 'dir'); mkdir(output_dir); end
 [t_est, pos_est, vel_est, acc_est, ref_lat, ref_lon, ref_r0] = load_est_ned(est_file);
 [t_truth, pos_truth, vel_truth, acc_truth] = load_truth_ned(truth_file, ref_lat, ref_lon, ref_r0);
 
+% Align time to start at zero for comparison with Task 6
+t_rel = t_est - t_est(1);
+
 pos_truth_i = interp1(t_truth, pos_truth, t_est, 'linear', 'extrap');
 vel_truth_i = interp1(t_truth, vel_truth, t_est, 'linear', 'extrap');
 acc_truth_i = interp1(t_truth, acc_truth, t_est, 'linear', 'extrap');
 
-[res_pos, res_vel, res_acc] = compute_residuals(t_est, pos_est, vel_est, pos_truth_i, vel_truth_i);
+[res_pos, res_vel, res_acc] = compute_residuals(t_rel, pos_est, vel_est, pos_truth_i, vel_truth_i);
 
-plot_residuals(t_est, res_pos, res_vel, res_acc, dataset, output_dir);
+plot_residuals(t_rel, res_pos, res_vel, res_acc, dataset, output_dir);
 
 end
 

--- a/MATLAB/task7_plot_error_fused_vs_truth.m
+++ b/MATLAB/task7_plot_error_fused_vs_truth.m
@@ -4,8 +4,8 @@ function task7_plot_error_fused_vs_truth(fused_file, truth_file, output_dir)
 %   TASK7_PLOT_ERROR_FUSED_VS_TRUTH(FUSED_FILE, TRUTH_FILE, OUTPUT_DIR) loads
 %   the fused estimator output in FUSED_FILE and the reference trajectory in
 %   TRUTH_FILE. The difference ``FUSED - Truth`` is computed for each velocity
-%   component and plotted over time. The figure is saved as both PDF and PNG
-%   under OUTPUT_DIR.
+%   component and plotted over time. The time vector starts at zero so results
+%   match Task 6 plots. The figure is saved as both PDF and PNG under OUTPUT_DIR.
 %
 %   Corresponds to src/task7_plot_error_fused_vs_truth.py
 %
@@ -27,6 +27,7 @@ else
 end
 
 time = F.time_s(:);
+time = time - time(1); % align with Task 6
 if isfield(F, 'vel_ned_ms')
     vel_f = F.vel_ned_ms;
 else

--- a/src/evaluate_filter_results.py
+++ b/src/evaluate_filter_results.py
@@ -201,6 +201,9 @@ def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) ->
         n = len(t)
     quat = quat[:n]
 
+    # Use relative time for all Task 7 plots so results align with Task 6
+    t_rel = t - t[0]
+
     # Reconstruct GNSS position and derive smoother velocity
     fused_time = data.get("time")
     fused_pos = data.get("pos_ned")
@@ -236,11 +239,11 @@ def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) ->
     labels = ["X", "Y", "Z"]
     fig, axes = plt.subplots(2, 3, figsize=(12, 6), sharex=True)
     for i in range(3):
-        axes[0, i].plot(t, res_pos[:, i])
+        axes[0, i].plot(t_rel, res_pos[:, i])
         axes[0, i].set_title(labels[i])
         axes[0, i].set_ylabel("Pos Residual [m]")
         axes[0, i].grid(True)
-        axes[1, i].plot(t, res_vel[:, i])
+        axes[1, i].plot(t_rel, res_vel[:, i])
         axes[1, i].set_xlabel("Time [s]")
         axes[1, i].set_ylabel("Vel Residual [m/s]")
         axes[1, i].grid(True)
@@ -257,7 +260,7 @@ def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) ->
     fig, axs = plt.subplots(3, 1, figsize=(8, 6), sharex=True)
     names = ["Roll", "Pitch", "Yaw"]
     for i in range(3):
-        axs[i].plot(t, euler[:, i])
+        axs[i].plot(t_rel, euler[:, i])
         axs[i].set_ylabel(f"{names[i]} [deg]")
         axs[i].grid(True)
     axs[2].set_xlabel("Time [s]")
@@ -271,13 +274,13 @@ def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) ->
     # Error norm plots
     norm_pos = np.linalg.norm(res_pos, axis=1)
     norm_vel = np.linalg.norm(res_vel, axis=1)
-    res_acc = np.gradient(res_vel, t, axis=0)
+    res_acc = np.gradient(res_vel, t_rel, axis=0)
     norm_acc = np.linalg.norm(res_acc, axis=1)
 
     fig, ax = plt.subplots()
-    ax.plot(t, norm_pos, label="|pos error|")
-    ax.plot(t, norm_vel, label="|vel error|")
-    ax.plot(t, norm_acc, label="|acc error|")
+    ax.plot(t_rel, norm_pos, label="|pos error|")
+    ax.plot(t_rel, norm_vel, label="|vel error|")
+    ax.plot(t_rel, norm_acc, label="|acc error|")
     ax.set_xlabel("Time [s]")
     ax.set_ylabel("Error Norm")
     ax.legend()
@@ -310,7 +313,7 @@ def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) ->
                 ref_lon = np.deg2rad(lon_deg)
 
         subtask7_5_diff_plot(
-            t,
+            t_rel,
             pos_interp,
             truth_pos,
             vel_interp,
@@ -359,6 +362,9 @@ def subtask7_5_diff_plot(
     out_dir: str,
 ) -> None:
     """Plot ``truth - fused`` differences in NED, ECEF and Body frames."""
+
+    # Use relative time for direct comparison with Task 6 plots
+    time = time - time[0]
 
     diff_pos_ned = truth_pos_ned - fused_pos_ned
     diff_vel_ned = truth_vel_ned - fused_vel_ned

--- a/src/task7_ned_residuals_plot.py
+++ b/src/task7_ned_residuals_plot.py
@@ -6,7 +6,9 @@ Usage:
         --output-dir results
 
 This implements the functionality of ``task7_ned_residuals_plot.m`` from the
-MATLAB code base. Figures are written under ``results/<dataset>/``.
+MATLAB code base. The estimator time vector is shifted to start at zero so that
+Task 6 and Task 7 plots share the same x-axis. Figures are written under
+``results/<dataset>/``.
 """
 
 from __future__ import annotations
@@ -183,6 +185,9 @@ def main() -> None:
     t_est, pos_est, vel_est, _acc_est, lat, lon, r0 = load_est_ned(args.est_file)
     t_truth, pos_truth, vel_truth, _ = load_truth_ned(args.truth_file, lat, lon, r0)
 
+    # Use relative time for plotting to align with Task 6
+    t_rel = t_est - t_est[0]
+
     pos_truth_i = np.vstack(
         [np.interp(t_est, t_truth, pos_truth[:, i]) for i in range(3)]
     ).T
@@ -191,11 +196,11 @@ def main() -> None:
     ).T
 
     res_pos, res_vel, res_acc = compute_residuals(
-        t_est, pos_est, vel_est, pos_truth_i, vel_truth_i
+        t_rel, pos_est, vel_est, pos_truth_i, vel_truth_i
     )
 
     out_dir = args.output_dir
-    plot_residuals(t_est, res_pos, res_vel, res_acc, args.dataset, out_dir)
+    plot_residuals(t_rel, res_pos, res_vel, res_acc, args.dataset, out_dir)
     saved = sorted(out_dir.glob(f"{args.dataset}_task7_ned_residual*.pdf"))
     if saved:
         print("Files saved in", out_dir)

--- a/src/task7_plot_error_fused_vs_truth.py
+++ b/src/task7_plot_error_fused_vs_truth.py
@@ -5,8 +5,9 @@ Usage:
         --truth truth_results.npz --output-dir results
 
 This script computes the velocity error ``FUSED - Truth`` for each
-component and plots the error over time. The resulting figure is saved
-as both PDF and PNG under the output directory.
+component and plots the error over time. The estimator time vector is
+shifted to start at zero so plots align with Task 6. The resulting
+figure is saved as both PDF and PNG under the output directory.
 
 Corresponds to MATLAB/task7_plot_error_fused_vs_truth.m
 """
@@ -62,6 +63,8 @@ def main(argv: list[str] | None = None) -> None:
     if time is None:
         raise KeyError("Missing 'time' or 'time_s' in fused file")
 
+    time_rel = np.asarray(time).squeeze() - np.asarray(time).squeeze()[0]
+
     vx = fused.get("vx")
     vy = fused.get("vy")
     vz = fused.get("vz")
@@ -82,7 +85,7 @@ def main(argv: list[str] | None = None) -> None:
 
     err = np.column_stack((vx - tvx, vy - tvy, vz - tvz))
 
-    plot_error(time, err, args.output_dir)
+    plot_error(time_rel, err, args.output_dir)
 
 
 if __name__ == "__main__":

--- a/task7_ecef_residuals_plot.py
+++ b/task7_ecef_residuals_plot.py
@@ -7,9 +7,11 @@ Usage:
 
 This script loads a fused estimator output file and a ground truth
 trajectory, interpolates the truth to the estimator time vector and
-plots position, velocity and acceleration residuals. Figures are saved
-as PDF and PNG under ``results/<tag>/`` within the chosen output
-directory, where ``tag`` combines the dataset, GNSS file and method.
+plots position, velocity and acceleration residuals. The time axis is
+converted to ``t - t[0]`` so Task 6 and Task 7 share the same reference.
+Figures are saved as PDF and PNG under ``results/<tag>/`` within the
+chosen output directory, where ``tag`` combines the dataset, GNSS file
+and method.
 """
 
 from __future__ import annotations
@@ -132,14 +134,17 @@ def main() -> None:
     except KeyError as exc:
         raise ValueError("Truth data required for ECEF residuals") from exc
 
+    # Align time axis to start at zero for direct comparison with Task 6
+    t_rel = t_est - t_est[0]
+
     res_pos, res_vel, res_acc = compute_residuals(
-        t_est, pos_est, vel_est, pos_truth, vel_truth
+        t_rel, pos_est, vel_est, pos_truth, vel_truth
     )
 
     tag = make_tag(args.dataset, args.gnss, args.method)
     out_dir = Path(args.output_dir)
     plot_residuals(
-        t_est,
+        t_rel,
         res_pos,
         res_vel,
         res_acc,


### PR DESCRIPTION
## Summary
- shift Task 7 plotting scripts to use time relative to first sample
- update docstrings explaining aligned time axis
- mirror changes across MATLAB and Python implementations
- ensure evaluation pipeline uses `t_rel` everywhere

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(tests passed with warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68869fb194dc8325a05c1f50d53bcaf6