### PR TITLE
Add stdout prints for key vectors and plot paths

### DIFF
--- a/MATLAB/GNSS_IMU_Fusion_single.m
+++ b/MATLAB/GNSS_IMU_Fusion_single.m
@@ -384,6 +384,7 @@ fprintf('Measured Earth rotation (omega_ie_body): [%.4e, %.4e, %.4e]'' rad/s\n',
 
 save(fullfile(results_dir, ['Task2_body_' tag '.mat']), 'g_body', 'g_body_scaled', 'omega_ie_body', 'accel_bias', 'gyro_bias');
 fprintf('Body-frame vectors and biases saved to %s\n', fullfile(results_dir, ['Task2_body_' tag '.mat']));
+fprintf('Task 2 g_body = [%.4f %.4f %.4f]'', omega_ie_body = [%.4e %.4e %.4e]''\n', g_body, omega_ie_body);
 
 task2_results = struct('g_body', g_body, 'g_body_scaled', g_body_scaled, ...
                 'omega_ie_body', omega_ie_body, 'accel_bias', accel_bias, ...
@@ -725,6 +726,7 @@ if isfile(task4_file)
 else
     save(task4_file, 'gnss_pos_ned', 'acc_biases', 'gyro_biases', 'scale_factors');
 end
+fprintf('Accelerometer scale factor applied: %.4f\n', scale_factors.(method));
 
 task4_results = struct('gnss_pos_ned', gnss_pos_ned, 'acc_biases', acc_biases, ...
                 'gyro_biases', gyro_biases, 'scale_factors', scale_factors);

--- a/MATLAB/run_triad_only.m
+++ b/MATLAB/run_triad_only.m
@@ -49,8 +49,14 @@ truth_file = fullfile(root_dir, 'STATE_X001.txt');
 if isfile(task5_file) && isfile(truth_file)
     disp('--- Running Task 6: Truth Overlay/Validation ---');
     Task_6(task5_file, imu_path, gnss_path, truth_file);
+    [~, imu_name, ~]  = fileparts(imu_path);
+    [~, gnss_name, ~] = fileparts(gnss_path);
+    run_id = sprintf('%s_%s_%s', imu_name, gnss_name, method);
+    out_dir = fullfile(results_dir, run_id);
+    fprintf('Task 6 overlay plots saved under: %s\n', out_dir);
     disp('--- Running Task 7: Residuals & Summary ---');
     Task_7(task5_file, truth_file);
+    fprintf('Task 7 evaluation plots saved under: %s\n', out_dir);
     disp('Task 6 and Task 7 complete. See results directory for plots and PDF summaries.');
 else
     warning('Task 6 or Task 7 skipped: Missing Task 5 results or truth file.');

--- a/src/GNSS_IMU_Fusion.py
+++ b/src/GNSS_IMU_Fusion.py
@@ -836,6 +836,11 @@ def main():
             logging.debug(f"Method {m}: Gyroscope bias: {gyro_bias}")
 
         logging.info("IMU data corrected for bias for each method.")
+        if methods:
+            logging.info(
+                "Accelerometer scale factor applied: %.4f",
+                scale,
+            )
     except Exception as e:
         logging.error(f"Failed to load IMU data or compute corrections: {e}")
         raise

--- a/src/evaluate_filter_results.py
+++ b/src/evaluate_filter_results.py
@@ -439,6 +439,11 @@ def subtask7_5_diff_plot(
     diff_vel_body = rot.apply(diff_vel_ned, inverse=True)
     _plot(diff_pos_body, diff_vel_body, ["X", "Y", "Z"], "Body")
 
+    print(
+        "Saved Task 7.5 diff-truth plots for NED/ECEF/Body frames under: "
+        f"{out_dir}/"
+    )
+
 
 if __name__ == "__main__":
     import argparse

--- a/src/gnss_imu_fusion/init.py
+++ b/src/gnss_imu_fusion/init.py
@@ -120,6 +120,12 @@ def measure_body_vectors(
     else:
         static_start = max(0, static_start)
         static_end = min(static_end or len(acc), len(acc))
+    logging.info(
+        "Static interval indices: %d to %d (%d samples)",
+        static_start,
+        static_end,
+        static_end - static_start,
+    )
     static_acc = np.mean(acc[static_start:static_end], axis=0)
     static_gyro = np.mean(gyro[static_start:static_end], axis=0)
 
@@ -147,6 +153,11 @@ def measure_body_vectors(
     static_acc = static_acc * scale
     g_body = -static_acc
     omega_ie_body = static_gyro
+    logging.info(
+        "Task 2 vectors: g_body=%s, omega_ie_body=%s",
+        np.array2string(g_body, precision=4),
+        np.array2string(omega_ie_body, precision=4),
+    )
 
     mag_body = None
     if mag_file:


### PR DESCRIPTION
## Summary
- print g_body and omega_ie_body after Task 2 in MATLAB pipeline
- report accelerometer scale factor at end of Task 4
- show overlay/evaluation output paths after Tasks 6 and 7 in MATLAB wrapper
- log static interval indices and vectors in Python init step
- note scale factor and diff-truth plot location in Python scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886aef1dd4c8325993294966b5e9651