### PR TITLE
Fix Task7 loader for missing position fields

### DIFF
--- a/MATLAB/task7_fused_truth_error_analysis.m
+++ b/MATLAB/task7_fused_truth_error_analysis.m
@@ -172,7 +172,17 @@ function [t, pos, vel, acc, lat, lon, r0] = load_est(file)
             elseif isfield(S,'imu_time')
                 t = S.imu_time(:);
             else
-                t = (0:size(S.pos_ecef,1)-1)';
+                % Derive the time vector from any available position field
+                if isfield(S,'pos_ecef_m')
+                    len = size(S.pos_ecef_m,1);
+                elseif isfield(S,'pos_ecef')
+                    len = size(S.pos_ecef,1);
+                elseif isfield(S,'pos_ned')
+                    len = size(S.pos_ned,1);
+                else
+                    error('Task7:BadData','Estimate lacks position data');
+                end
+                t = (0:len-1)';
             end
             if isfield(S,'pos_ecef_m')
                 pos = S.pos_ecef_m;


### PR DESCRIPTION
## Summary
- avoid crashing in `task7_fused_truth_error_analysis` when `pos_ecef` is absent by deriving the time vector from any available position field
- add guard for missing data to mirror Python behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886b18097248325bd16c5139703dfd2