### PR TITLE
Improve MATLAB logging and reconstruction

### DIFF
--- a/MATLAB/Task_2.m
+++ b/MATLAB/Task_2.m
@@ -56,9 +56,12 @@ function body_data = Task_2(imu_path, gnss_path, method)
     gyro_filt = low_pass_filter(gyro, 10, fs);
 
     [static_start, static_end] = detect_static_interval(acc_filt, gyro_filt);
-    fprintf('Task 2: static interval = [%d..%d]\n', static_start, static_end);
+    fprintf('Static interval indices: %d to %d (%d samples)\n', ...
+            static_start, static_end, static_end-static_start);
     [acc_bias, gyro_bias] = compute_biases(acc_filt, gyro_filt, ...
                                            static_start, static_end);
+    fprintf('Accelerometer bias = [% .6f % .6f % .6f] m/s^2\n', acc_bias);
+    fprintf('Gyroscope bias     = [% .6f % .6f % .6f] rad/s\n', gyro_bias);
 
     validate_gravity_vector(acc_filt, static_start, static_end);
 
@@ -71,6 +74,9 @@ function body_data = Task_2(imu_path, gnss_path, method)
     omega_ie_body = static_gyro';
     fprintf('Task 2: g_body = [% .4f % .4f % .4f]\n', g_body);
     fprintf('Task 2: omega_ie_body = [% .6f % .6f % .6f]\n', omega_ie_body);
+    fprintf(['Task 2 summary: static interval %d:%d, g_body = [% .4f % .4f % .4f],' ...
+            ' omega_ie_body = [% .6f % .6f % .6f]\n'], ...
+            static_start, static_end, g_body, omega_ie_body);
 
     % Use consistent variable names across all MATLAB tasks
     accel_bias = acc_bias';     % 3x1 accelerometer bias in m/s^2

--- a/MATLAB/Task_6.m
+++ b/MATLAB/Task_6.m
@@ -138,10 +138,18 @@ if ~isfield(S, 'gnss_time')
 end
 
 if ~isfield(S,'pos_ned')
-    S.pos_ned = S.x_log(1:3,:)';
+    if isfield(S,'fused_pos')
+        S.pos_ned = S.fused_pos;
+    else
+        S.pos_ned = S.x_log(1:3,:)';
+    end
 end
 if ~isfield(S,'vel_ned')
-    S.vel_ned = S.x_log(4:6,:)';
+    if isfield(S,'fused_vel')
+        S.vel_ned = S.fused_vel;
+    else
+        S.vel_ned = S.x_log(4:6,:)';
+    end
 end
 
 % Interpolate truth data to estimator time

--- a/MATLAB/reconstruct_x_log.m
+++ b/MATLAB/reconstruct_x_log.m
@@ -21,8 +21,12 @@ function S = reconstruct_x_log(S)
     % Determine number of samples from the available fields
     if isfield(S, 'pos_ned')
         N = size(S.pos_ned, 1);
+    elseif isfield(S, 'fused_pos')
+        N = size(S.fused_pos, 1);
     elseif isfield(S, 'vel_ned')
         N = size(S.vel_ned, 1);
+    elseif isfield(S, 'fused_vel')
+        N = size(S.fused_vel, 1);
     elseif isfield(S, 'euler_log')
         N = size(S.euler_log, 2);
     elseif isfield(S, 'quat_log')
@@ -40,9 +44,13 @@ function S = reconstruct_x_log(S)
 
     if isfield(S, 'pos_ned')
         x_log(1:3, :) = S.pos_ned';
+    elseif isfield(S, 'fused_pos')
+        x_log(1:3, :) = S.fused_pos';
     end
     if isfield(S, 'vel_ned')
         x_log(4:6, :) = S.vel_ned';
+    elseif isfield(S, 'fused_vel')
+        x_log(4:6, :) = S.fused_vel';
     end
 
     if isfield(S, 'euler_log')


### PR DESCRIPTION
## Summary
- add explicit static interval and bias printouts in Task_2
- support fused_pos/fused_vel when rebuilding x_log
- let Task_6 fall back to fused_pos/fused_vel when pos/vel are missing

## Testing
- `pytest tests/test_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6886bc7c30fc832587d7d37b4e1275cb