### PR TITLE
Define Q/R matrices for Task5 EKF

### DIFF
--- a/MATLAB/Task_5.m
+++ b/MATLAB/Task_5.m
@@ -196,6 +196,7 @@ x(10:12) = accel_bias(:);
 x(13:15) = gyro_bias(:);
 % EKF tuning parameters
 P = blkdiag(eye(9) * 0.01, eye(3) * 1e-4, eye(3) * 1e-8);
+% Process noise
 Q = eye(15) * 1e-4;
 Q(4:6,4:6) = diag([0.1, 0.1, 0.1]);
 Q(10:12,10:12) = eye(3) * (accel_bias_noise^2);
@@ -206,6 +207,7 @@ end
 if vel_proc_noise ~= 0
     Q(4:6,4:6) = Q(4:6,4:6) + eye(3) * (vel_proc_noise^2);
 end
+% Measurement noise
 R = eye(6) * 1;
 R(4:6,4:6) = diag([0.25, 0.25, 0.25]);
 H = [eye(6), zeros(6,9)];


### PR DESCRIPTION
## Summary
- clarify Kalman filter tuning in `Task_5.m`
- add explicit comments for process and measurement noise matrices

## Testing
- `pip install --break-system-packages numpy scipy pandas matplotlib pyyaml tqdm tabulate rich fpdf filterpy cartopy geomaglib pyproj fastdtw`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886be03a7f0832598f38dffa0181d64