### PR TITLE
Align MATLAB Kalman filter parameters with Python

### DIFF
--- a/MATLAB/Task_5.m
+++ b/MATLAB/Task_5.m
@@ -199,22 +199,16 @@ P = eye(15);                         % Larger initial uncertainty
 P(7:9,7:9)   = eye(3) * deg2rad(5)^2; % Attitude uncertainty (5 deg)
 P(10:15,10:15) = eye(6) * 1e-4;      % Bias uncertainty
 
-Q = eye(15) * 0.01;                  % Base process noise
-Q(4:6,4:6) = eye(3) * 0.1;           % Velocity process noise
-% Define bias random walk terms based on IMU specs
-accel_bias_noise = 1e-3;             % Example value
-gyro_bias_noise  = 1e-4;             % Example value
-Q(10:12,10:12) = eye(3) * (accel_bias_noise^2);
-Q(13:15,13:15) = eye(3) * (gyro_bias_noise^2);
-if pos_proc_noise ~= 0
-    Q(1:3,1:3) = Q(1:3,1:3) + eye(3) * (pos_proc_noise^2);
-end
-if vel_proc_noise ~= 0
-    Q(4:6,4:6) = Q(4:6,4:6) + eye(3) * (vel_proc_noise^2);
-end
+% Process noise terms use the same convention as the Python implementation.
+Q = zeros(15);
+Q(1:3,1:3)   = eye(3) * (pos_proc_noise^2);                   % Position process
+Q(4:6,4:6)   = eye(3) * ((accel_noise^2) + (vel_proc_noise^2));
+Q(10:12,10:12) = eye(3) * (accel_bias_noise^2);               % Accel bias random walk
+Q(13:15,13:15) = eye(3) * (gyro_bias_noise^2);                % Gyro bias random walk
 
-R = eye(6) * 0.1;                    % GNSS position noise
-R(4:6,4:6) = eye(3) * 0.25;          % GNSS velocity noise
+R = zeros(6);                                                   % Measurement noise
+R(1:3,1:3) = eye(3) * (pos_meas_noise^2);                      % GNSS position noise
+R(4:6,4:6) = eye(3) * (vel_meas_noise^2);                      % GNSS velocity noise
 H = [eye(6), zeros(6,9)];
 
 % --- Attitude Initialization ---

--- a/docs/MATLAB/Task5_MATLAB.md
+++ b/docs/MATLAB/Task5_MATLAB.md
@@ -18,6 +18,10 @@ Default parameters:
 | `accel_bias_noise`  | `1e-5` |
 | `gyro_bias_noise`   | `1e-5` |
 
+The MATLAB filter reads these values via optional name/value pairs and applies
+them identically to the Python `GNSSIMUKalman` class. Ensure any tuning changes
+remain in sync across both languages.
+
 ```text
 IMU integration (Task 4)
        ↓


### PR DESCRIPTION
## Summary
- tune process and measurement noise in `MATLAB/Task_5.m` using the same
  defaults as the Python `GNSSIMUKalman`
- clarify parameter parity in `docs/MATLAB/Task5_MATLAB.md`

## Testing
- `pytest tests/test_ecef_to_geodetic.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6886bf6cd14483258815a088fe2ddbad