### PR TITLE
Fix Task 5 result naming and ensure x_log saved

### DIFF
--- a/MATLAB/GNSS_IMU_Fusion_single.m
+++ b/MATLAB/GNSS_IMU_Fusion_single.m
@@ -928,10 +928,11 @@ results = struct('method', method, 'rmse_pos', rmse_pos, 'rmse_vel', rmse_vel, .
 perf_file = fullfile(results_dir, 'IMU_GNSS_bias_and_performance.mat');
 if isfile(perf_file); save(perf_file, '-append', 'results_dir'); else; save(perf_file, 'results_dir'); end
 summary_file = fullfile(results_dir, 'IMU_GNSS_summary.txt'); fid_sum = fopen(summary_file, 'a'); fprintf(fid_sum, '%s\n', summary_line); fclose(fid_sum);
-results_file = fullfile(results_dir, sprintf('Task5_results_%s.mat', pair_tag));
+% Store the fused state using the standard naming scheme
+results_file = fullfile(results_dir, sprintf('%s_task5_results.mat', tag));
 save(results_file, 'gnss_pos_ned', 'gnss_vel_ned', 'gnss_accel_ned', ...
     'x_log', 'vel_log', 'accel_from_vel', 'euler_log', 'zupt_log');
-method_file = fullfile(results_dir, [tag '_task5_results.mat']);
+method_file = results_file;
 save(method_file, 'gnss_pos_ned', 'gnss_vel_ned', 'gnss_accel_ned', ...
     'x_log', 'vel_log', 'accel_from_vel', 'euler_log', 'zupt_log');
 

--- a/MATLAB/Task_5.m
+++ b/MATLAB/Task_5.m
@@ -590,7 +590,9 @@ vel_ned = x_log(4:6,:)';
 ref_lat = deg2rad(lat_deg); %#ok<NASGU>
 ref_lon = deg2rad(lon_deg); %#ok<NASGU>
 
-results_file = fullfile(results_dir, sprintf('Task5_results_%s.mat', pair_tag));
+% Save using the same naming convention as the Python pipeline
+% <IMU>_<GNSS>_<METHOD>_task5_results.mat
+results_file = fullfile(results_dir, sprintf('%s_task5_results.mat', tag));
 save(results_file, 'gnss_pos_ned', 'gnss_vel_ned', 'gnss_accel_ned', ...
     'gnss_pos_ecef', 'gnss_vel_ecef', 'gnss_accel_ecef', ...
     'x_log', 'vel_log', 'accel_from_vel', 'euler_log', 'zupt_log', ...

--- a/docs/AdvancedTopics.md
+++ b/docs/AdvancedTopics.md
@@ -68,7 +68,7 @@ Task_1(imu, gnss, 'TRIAD');   % -> results/Task1_init_IMU_X001_GNSS_X001_TRIAD.m
 Task_2(imu, gnss, 'TRIAD');   % -> results/Task2_body_IMU_X001_GNSS_X001_TRIAD.mat
 Task_3(imu, gnss, 'TRIAD');   % uses Task1/2 output, writes results/Task3_results_IMU_X001_GNSS_X001.mat
 Task_4(imu, gnss, 'TRIAD');   % uses Task3 results, writes results/Task4_results_IMU_X001_GNSS_X001.mat
-Task_5(imu, gnss, 'TRIAD');   % uses Task4 results, writes results/Task5_results_IMU_X001_GNSS_X001.mat
+Task_5(imu, gnss, 'TRIAD');   % uses Task4 results, writes results/IMU_X001_GNSS_X001_TRIAD_task5_results.mat
 ```
 
 ### MATLAB-only pipeline

--- a/docs/DebuggingDrift.md
+++ b/docs/DebuggingDrift.md
@@ -9,7 +9,7 @@ All example paths assume results are written to `results/` for the Python code a
 1. **Plot the NED position error** over time. Compare the IMU-derived trajectory against GNSS ground truth to see when the drift begins and whether it grows linearly or quadratically.
 
    ```matlab
-   load('results/Task5_results_IMU_X001_GNSS_X001.mat', ...
+   load('results/IMU_X001_GNSS_X001_TRIAD_task5_results.mat', ...
         'pos_ned', 'pos_gnss', 't_imu');
    figure;
    plot(t_imu, pos_ned - pos_gnss);


### PR DESCRIPTION
## Summary
- save Task 5 results using `<IMU>_<GNSS>_<METHOD>_task5_results.mat`
- update `GNSS_IMU_Fusion_single` to save with the same filename
- fix documentation references to the new naming scheme
- keep logs using `x_log` for Task 6/7

## Testing
- `pytest tests/test_naming.py -q`
- `pytest tests/test_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6886bff540f083259fcd9ad5a22f2db5