### PR TITLE
Log final NED velocity after integration

### DIFF
--- a/MATLAB/GNSS_IMU_Fusion_single.m
+++ b/MATLAB/GNSS_IMU_Fusion_single.m
@@ -712,6 +712,9 @@ for i = 1:length(methods)
         pos(k,:) = pos(k-1,:) + (vel(k,:) + vel(k-1,:)) * 0.5 * dt_imu;
     end
     pos_integ.(method_i) = pos; vel_integ.(method_i) = vel; acc_integ.(method_i) = acc;
+    final_vel = vel(end, :);
+    fprintf('Final integrated NED velocity [%s | %s]: [%.3f %.3f %.3f] m/s\n', ...
+        pair_tag, method_i, final_vel(1), final_vel(2), final_vel(3));
 end
 
 fprintf('\nSubtask 4.13: Validating and plotting data.\n');

--- a/src/GNSS_IMU_Fusion.py
+++ b/src/GNSS_IMU_Fusion.py
@@ -1274,6 +1274,11 @@ def main():
                 imu_pos[m][i - 1] + 0.5 * (imu_vel[m][i] + imu_vel[m][i - 1]) * dt
             )
         logging.info(f"Method {m}: IMU data integrated.")
+        final_vel = imu_vel[m][-1]
+        logging.info(
+            f"[{summary_tag} | {m}] Final integrated NED velocity: "
+            f"[{final_vel[0]:.3f}, {final_vel[1]:.3f}, {final_vel[2]:.3f}] m/s"
+        )
 
     # ZUPT handled dynamically during Kalman filtering
 


### PR DESCRIPTION
## Summary
- report final integrated NED velocity in `GNSS_IMU_Fusion.py`
- mirror the logging in `GNSS_IMU_Fusion_single.m`

## Testing
- `pytest -q` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6886c092f2908325a7d18bdc864b908f