### PR TITLE
Fix quaternion normalisation in MATLAB task

### DIFF
--- a/MATLAB/Task_5.m
+++ b/MATLAB/Task_5.m
@@ -629,7 +629,8 @@ end % End of main function
         %PROPAGATE_QUATERNION Propagate quaternion using angular rate.
         %   Q_NEW = PROPAGATE_QUATERNION(Q_OLD, W, DT) integrates the rate
         %   vector W over DT and multiplies the result with Q_OLD.  The output
-        %   quaternion is not normalised.
+        %   quaternion is normalised to keep its unit length, matching the
+        %   Python implementation.
         w_norm = norm(w);
         if w_norm > 1e-9
             axis = w / w_norm;
@@ -639,6 +640,8 @@ end % End of main function
             dq = [1; 0; 0; 0];
         end
         q_new = quat_multiply(q_old, dq);
+        % normalise to unit quaternion for numerical stability
+        q_new = q_new / norm(q_new);
     end
 
     function q_out = quat_multiply(q1, q2)


### PR DESCRIPTION
## Summary
- ensure `propagate_quaternion` in MATLAB Task 5 returns a unit quaternion
- mirror Python behaviour

## Testing
- `pytest -k "evaluate_filter_results" -q`

------
https://chatgpt.com/codex/tasks/task_e_6886c1b4e3fc8325b0954e1a5f011016