### PR TITLE
Fix performance file saving

### DIFF
--- a/MATLAB/Task_5.m
+++ b/MATLAB/Task_5.m
@@ -571,7 +571,9 @@ perf_file = fullfile(results_dir, 'IMU_GNSS_bias_and_performance.mat');
 % Result Logging -- store the metrics struct under the variable name
 % ``results`` to stay in sync with the Python pipeline.
 if isfile(perf_file)
-
+    save(perf_file, '-append', 'results');
+else
+    save(perf_file, 'results');
 end
 
 summary_file = fullfile(results_dir, 'IMU_GNSS_summary.txt');


### PR DESCRIPTION
## Summary
- remove empty conditional and append results when perf file exists

## Testing
- `pytest -q` *(fails: KeyboardInterrupt after success message)*
- `pytest tests/test_utils.py::test_rotation_matrix_orthonormal -q`

------
https://chatgpt.com/codex/tasks/task_e_6886c1b29d488325934ef743e67d1e0f