### PR TITLE
Enable full precision printing in MATLAB scripts

### DIFF
--- a/MATLAB/main.m
+++ b/MATLAB/main.m
@@ -3,9 +3,12 @@ function main(imu_path, gnss_path, methods)
 %   main()                              - use all sample files with all methods
 %   main('imu.dat','gnss.csv')          - run one dataset with all methods
 %   main('imu.dat','gnss.csv','TRIAD')  - run one dataset with a single method
+
 %   main({'IMU_X001.dat','IMU_X002.dat'}, {'GNSS_X001.csv','GNSS_X002.csv'}, ...
 %        {'TRIAD','SVD'})               - iterate over both dataset pairs and
 %                                         selected methods
+
+format long g % mirror Python full-precision printing
 
 % Resolve default data file paths or lists. The pipeline ships with three IMU
 % logs and two GNSS logs. By default we pair them as:

--- a/MATLAB/run_all_datasets.m
+++ b/MATLAB/run_all_datasets.m
@@ -4,7 +4,10 @@
 %   (Tasks 1--5) for the methods TRIAD, Davenport and SVD. After each run
 %   the Task 5 results structure is loaded into the base workspace under
 %   a variable named result_IMU_Xxxx_GNSS_Xxxx_METHOD and also written to
+
 %   ``results/<variable>.mat`` within the directory returned by ``get_results_dir()``.
+
+format long g % mirror Python full-precision printing
 
 imu_files = dir('IMU_X*.dat');
 gnss_files = dir('GNSS_X*.csv');

--- a/MATLAB/run_all_datasets_matlab.m
+++ b/MATLAB/run_all_datasets_matlab.m
@@ -11,7 +11,10 @@ function run_all_datasets_matlab(method)
 %   ``get_results_dir()``.
 %
 % Usage:
+
 %   run_all_datasets_matlab(method)
+
+format long g % mirror Python full-precision printing
 
 if nargin < 1 || isempty(method)
     method_list = {'TRIAD','Davenport','SVD'};

--- a/MATLAB/run_all_datasets_py.m
+++ b/MATLAB/run_all_datasets_py.m
@@ -16,7 +16,10 @@ function run_all_datasets_py(varargin)
 %
 %   This function assumes GNSS_IMU_Fusion.m produces files named
 %   <IMU>_<GNSS>_<METHOD>_kf_output.npz in the current results directory.
+
 %   Metrics are derived from these files to mirror the Python summary.
+
+format long g % mirror Python full-precision printing
 
 % Default dataset list and methods
 DEFAULT_DATASETS = {


### PR DESCRIPTION
## Summary
- mirror Python's numeric printing by enabling `format long g`
- apply this setting in `main.m`, `run_all_datasets.m`, `run_all_datasets_matlab.m`, and `run_all_datasets_py.m`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886c4050a0483258fdb2c4ef0c7ec2c