### PR TITLE
Add compute_biases helper

### DIFF
--- a/src/GNSS_IMU_Fusion.py
+++ b/src/GNSS_IMU_Fusion.py
@@ -37,6 +37,7 @@ from utils import (
     ecef_to_geodetic,
 )
 from constants import GRAVITY, EARTH_RATE
+from .compute_biases import compute_biases
 from scripts.validate_filter import compute_residuals, plot_residuals
 from scipy.spatial.transform import Rotation as R
 from .gnss_imu_fusion.init_vectors import (
@@ -800,8 +801,12 @@ def main():
                 f"Insufficient static samples for bias estimation; require at least {MIN_STATIC_SAMPLES}."
             )
 
-        static_acc = np.mean(acc_body[start_idx:end_idx], axis=0)
-        static_gyro = np.mean(gyro_body[start_idx:end_idx], axis=0)
+        static_acc, static_gyro = compute_biases(
+            acc_body,
+            gyro_body,
+            start_idx,
+            end_idx,
+        )
 
         dataset_bias_map = {
             "IMU_X001.dat": np.array([0.57755067, -6.8366253, 0.91021879]),

--- a/src/compute_biases.py
+++ b/src/compute_biases.py
@@ -1,0 +1,38 @@
+"""IMU bias estimation utilities."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+
+
+def compute_biases(
+    acc_body: np.ndarray,
+    gyro_body: np.ndarray,
+    start: int,
+    end: int,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Return mean accelerometer and gyroscope measurements over a static interval.
+
+    Parameters
+    ----------
+    acc_body : ndarray, shape (N, 3)
+        Accelerometer samples in the body frame (m/s^2).
+    gyro_body : ndarray, shape (N, 3)
+        Gyroscope samples in the body frame (rad/s).
+    start : int
+        Inclusive index of the static interval start.
+    end : int
+        Exclusive index of the static interval end.
+
+    Returns
+    -------
+    tuple of ndarray
+        ``(acc_bias, gyro_bias)`` arrays of shape ``(3,)``.
+    """
+    static_acc = acc_body[start:end]
+    static_gyro = gyro_body[start:end]
+    acc_bias = np.mean(static_acc, axis=0)
+    gyro_bias = np.mean(static_gyro, axis=0)
+    return acc_bias, gyro_bias

--- a/src/gnss_imu_fusion/init.py
+++ b/src/gnss_imu_fusion/init.py
@@ -13,6 +13,7 @@ from ..utils import (
     compute_C_ECEF_to_NED,
     validate_gravity_vector,
 )
+from ..compute_biases import compute_biases
 from .init_vectors import butter_lowpass_filter
 
 
@@ -126,8 +127,12 @@ def measure_body_vectors(
         static_end,
         static_end - static_start,
     )
-    static_acc = np.mean(acc[static_start:static_end], axis=0)
-    static_gyro = np.mean(gyro[static_start:static_end], axis=0)
+    static_acc, static_gyro = compute_biases(
+        acc,
+        gyro,
+        static_start,
+        static_end,
+    )
 
     # --- Compute ratio of static to total samples and log duration
     n_static = static_end - static_start

--- a/tests/test_compute_biases.py
+++ b/tests/test_compute_biases.py
@@ -1,0 +1,14 @@
+import pytest
+from src.compute_biases import compute_biases
+
+np = pytest.importorskip("numpy")
+
+
+def test_compute_biases_basic():
+    rng = np.random.default_rng(0)
+    acc = rng.normal(0, 0.1, size=(100, 3))
+    gyro = rng.normal(0, 0.01, size=(100, 3))
+    start, end = 10, 60
+    a_b, g_b = compute_biases(acc, gyro, start, end)
+    assert np.allclose(a_b, acc[start:end].mean(axis=0))
+    assert np.allclose(g_b, gyro[start:end].mean(axis=0))


### PR DESCRIPTION
## Summary
- add `compute_biases()` helper mirroring MATLAB implementation
- use helper in attitude initialisation modules
- expose in `GNSS_IMU_Fusion.py`
- unit test for the new helper

## Testing
- `pytest tests/test_compute_biases.py::test_compute_biases_basic -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886c489bea483259e4c55f03b935881