### PR TITLE
Implement MATLAB Task 2 bias measurement function

### DIFF
--- a/MATLAB/compute_biases.m
+++ b/MATLAB/compute_biases.m
@@ -2,19 +2,20 @@ function [acc_bias, gyro_bias] = compute_biases(acc_body, gyro_body, static_star
 %COMPUTE_BIASES Estimate accelerometer and gyroscope biases.
 %   [ACC_BIAS, GYRO_BIAS] = COMPUTE_BIASES(ACC_BODY, GYRO_BODY, START, END)
 %   returns the mean accelerometer and gyroscope measurements over the
-%   static interval from START to END (inclusive). This mirrors the Python
-%   implementation used in gnss_imu_fusion.measure_body_vectors.
+%   half-open static interval ``[START, END)``.  This mirrors the Python
+%   implementation used in ``gnss_imu_fusion.measure_body_vectors``.
 %
 %   Inputs are assumed to be in body frame units of m/s^2 and rad/s.
-%   START and END are 1-based indices selecting a continuous static block.
+%   START and END are 1-based indices selecting a continuous static block
+%   where END is exclusive.
 %
 %   Example:
 %       [acc_bias, gyro_bias] = compute_biases(acc, gyro, 1, 4000);
 %
 %   See also DETECT_STATIC_INTERVAL.
 
-static_acc  = acc_body(static_start:static_end, :);
-static_gyro = gyro_body(static_start:static_end, :);
+static_acc  = acc_body(static_start:static_end-1, :);
+static_gyro = gyro_body(static_start:static_end-1, :);
 acc_bias = mean(static_acc, 1);
 gyro_bias = mean(static_gyro, 1);
 end

--- a/MATLAB/detect_static_interval.m
+++ b/MATLAB/detect_static_interval.m
@@ -11,7 +11,8 @@ function [static_start, static_end] = detect_static_interval(acc_body, gyro_body
 %       GYRO_VAR_THRESH   - gyroscope variance threshold (default 1e-6)
 %       MIN_LENGTH        - minimum acceptable segment length (default 80)
 %
-%   Returned indices are 1-based and inclusive with respect to ACC_BODY.
+%   Returned indices are 1-based with ``END`` being exclusive, matching the
+%   Python implementation.
 
     if nargin < 3 || isempty(window_size)
         window_size = 80; % Match Python defaults
@@ -50,13 +51,13 @@ function [static_start, static_end] = detect_static_interval(acc_body, gyro_body
 
     longest_len = 0;
     static_start = 1;
-    static_end = window_size;
+    static_end = window_size + 1;
     for k = 1:numel(start_idx)
         len = end_idx(k) - start_idx(k) + 1;
         if len >= min_length && len > longest_len
             longest_len = len;
             static_start = start_idx(k);
-            static_end = end_idx(k) + window_size - 1;
+            static_end = end_idx(k) + window_size;
         end
     end
 

--- a/MATLAB/task2_measure_vectors.m
+++ b/MATLAB/task2_measure_vectors.m
@@ -1,0 +1,32 @@
+function [acc_bias, gyro_bias, static_start, static_end] = task2_measure_vectors(acc_body, gyro_body, results_dir)
+%TASK2_MEASURE_VECTORS Detect static interval and compute IMU biases.
+%   [ACC_BIAS, GYRO_BIAS, START, END] = TASK2_MEASURE_VECTORS(ACC_BODY, GYRO_BODY, RESULTS_DIR)
+%   detects a static interval in the body-frame accelerometer and gyroscope
+%   data using the same parameters as the Python implementation and returns
+%   the computed biases. START and END use 1-based indexing with END
+%   exclusive. The results are saved to ``Task2_IMU_biases.mat`` in
+%   RESULTS_DIR when supplied.
+%
+%   This function mirrors the behaviour of ``gnss_imu_fusion.init.measure_body_vectors``
+%   but operates on already loaded data arrays.
+%
+%   Example:
+%       [acc_b, gyro_b] = task2_measure_vectors(acc, gyro, get_results_dir());
+%
+%   See also DETECT_STATIC_INTERVAL, COMPUTE_BIASES.
+
+    if nargin < 3 || isempty(results_dir)
+        results_dir = get_results_dir();
+    end
+
+    [static_start, static_end] = detect_static_interval(acc_body, gyro_body, 80, 0.01, 1e-6, 80);
+
+    [acc_bias, gyro_bias] = compute_biases(acc_body, gyro_body, static_start, static_end);
+
+    fprintf('Static interval: %d to %d\n', static_start, static_end - 1);
+    fprintf('Computed accelerometer bias: [%.8f, %.8f, %.8f] m/s^2\n', acc_bias(1), acc_bias(2), acc_bias(3));
+    fprintf('Computed gyroscope bias: [%.8e, %.8e, %.8e] rad/s\n', gyro_bias(1), gyro_bias(2), gyro_bias(3));
+
+    if ~exist(results_dir, 'dir'); mkdir(results_dir); end
+    save(fullfile(results_dir, 'Task2_IMU_biases.mat'), 'acc_bias', 'gyro_bias', 'static_start', 'static_end');
+end

--- a/src/task2_measure_vectors.py
+++ b/src/task2_measure_vectors.py
@@ -1,0 +1,14 @@
+"""MATLAB equivalent for Task 2 bias computation (stub).
+
+This module mirrors :file:`MATLAB/task2_measure_vectors.m`. The full
+implementation lives in the MATLAB code base.  The Python version is
+provided as a stub for API compatibility.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+
+def task2_measure_vectors(acc_body: np.ndarray, gyro_body: np.ndarray, results_dir: str) -> None:
+    """Detect static interval and compute biases (not implemented in Python)."""
+    raise NotImplementedError("Use the MATLAB implementation of task2_measure_vectors")


### PR DESCRIPTION
## Summary
- clarify compute_biases.m semantics and use half-open interval
- update detect_static_interval.m to return exclusive end index
- add new MATLAB helper `task2_measure_vectors` mirroring Python behaviour
- provide Python stub for cross-language parity

## Testing
- `pytest tests/test_compute_biases.py::test_compute_biases_basic -q`
- `pytest -q` *(fails: missing `rich`; `GNSS_IMU_Fusion` exits early)*

------
https://chatgpt.com/codex/tasks/task_e_6886ca9766288325af14a27485a3cc03