### PR TITLE
Add Task4 GNSS+IMU integration helper

### DIFF
--- a/MATLAB/Task_4.m
+++ b/MATLAB/Task_4.m
@@ -235,8 +235,8 @@ else
     warning('Task1 init file %s not found, using default gravity %.3f m/s^2', task1_file, constants.GRAVITY);
     g_NED = [0; 0; constants.GRAVITY];
 end
-% Override with the value used in the Python implementation for consistency
-g_NED = [0; 0; constants.GRAVITY];
+% Gravity vector loaded from Task 1 is used directly to maintain parity with
+% the Python implementation. Do not override with the nominal constant.
 omega_E = constants.EARTH_RATE;                     % rad/s
 omega_ie_NED = omega_E * [cos(ref_lat); 0; -sin(ref_lat)];
 

--- a/MATLAB/task4_gnss_imu_integration.m
+++ b/MATLAB/task4_gnss_imu_integration.m
@@ -1,0 +1,93 @@
+function task4_gnss_imu_integration(gnss_data, imu_data, task1_results, task2_results, task3_results, results_dir, dt)
+%TASK4_GNSS_IMU_INTEGRATION  Integrate IMU data and compare with GNSS.
+%   TASK4_GNSS_IMU_INTEGRATION(GNSS_DATA, IMU_DATA, TASK1_RESULTS,
+%   TASK2_RESULTS, TASK3_RESULTS, RESULTS_DIR, DT) performs the Task 4
+%   operations of the GNSS/IMU fusion pipeline. GNSS_DATA is a table loaded
+%   from the CSV file containing ECEF position and velocity columns.
+%   IMU_DATA is a struct with fields ``accel`` and ``gyro`` in the body
+%   frame. The auxiliary MAT files from Tasks 1--3 are used to apply bias
+%   corrections, obtain the gravity vector and the initial attitude. Plots
+%   and a MAT-file are written to RESULTS_DIR.  The integration is carried
+%   out in the NED frame using the same approach as the Python
+%   implementation.
+%
+%   This function mirrors ``task4_gnss_imu_integration`` in the Python
+%   codebase.
+%
+%   Example:
+%       gnss = readtable('GNSS_X002.csv');
+%       imu  = load('IMU_X002.mat');
+%       task4_gnss_imu_integration(gnss, imu, 'Task1_init_IMU_X002_GNSS_X002_TRIAD.mat', ...
+%                                  'Task2_IMU_biases.mat', 'Task3_results_IMU_X002_GNSS_X002.mat', ...
+%                                  get_results_dir(), 0.0025);
+
+if nargin < 7 || isempty(dt)
+    dt = 0.0025; % default sample period
+end
+
+%% Load previous task outputs
+S1 = load(task1_results, 'gravity_ned', 'latitude', 'longitude');
+S2 = load(task2_results, 'acc_bias', 'gyro_bias');
+S3 = load(task3_results, 'C_b2n');
+if isfield(S1, 'gravity_ned'); g_ned = S1.gravity_ned(:); else; error('gravity_ned missing'); end
+if isfield(S2, 'acc_bias'); acc_bias = S2.acc_bias(:)'; else; error('acc_bias missing'); end
+if isfield(S2, 'gyro_bias'); gyro_bias = S2.gyro_bias(:)'; else; error('gyro_bias missing'); end
+if isfield(S3, 'C_b2n'); C_b2n = S3.C_b2n; else; error('C_b2n missing'); end
+
+%% GNSS processing
+ecef_pos = [gnss_data.X_ECEF_m, gnss_data.Y_ECEF_m, gnss_data.Z_ECEF_m];
+ecef_vel = [gnss_data.VX_ECEF_mps, gnss_data.VY_ECEF_mps, gnss_data.VZ_ECEF_mps];
+lat_ref = deg2rad(gnss_data.Latitude_deg(1));
+lon_ref = deg2rad(gnss_data.Longitude_deg(1));
+r0 = ecef_pos(1,:).';
+C_e2n = compute_C_ECEF_to_NED(lat_ref, lon_ref);
+C_n2e = C_e2n';
+M = size(ecef_pos,1);
+pos_ned_gnss = zeros(M,3);
+vel_ned_gnss = zeros(M,3);
+for k=1:M
+    pos_ned_gnss(k,:) = (C_e2n*(ecef_pos(k,:).'-r0)).';
+    vel_ned_gnss(k,:) = (C_e2n*ecef_vel(k,:).').';
+end
+accel_ned_gnss = [zeros(1,3); diff(vel_ned_gnss)./diff(gnss_data.Posix_Time)];
+
+%% IMU correction
+scale_factor = 0.8368;
+accel_corrected = (imu_data.accel - acc_bias).*scale_factor;
+gyro_corrected  = imu_data.gyro - gyro_bias;
+accel_ned = (C_b2n*accel_corrected.').';
+
+%% IMU integration
+N = size(accel_ned,1);
+pos_imu_ned = zeros(N,3);
+vel_imu_ned = zeros(N,3);
+vel_imu_ned(1,:) = vel_ned_gnss(1,:);
+for i=2:N
+    vel_imu_ned(i,:) = vel_imu_ned(i-1,:) + (accel_ned(i,:) - g_ned.')*dt;
+    pos_imu_ned(i,:) = pos_imu_ned(i-1,:) + vel_imu_ned(i,:)*dt;
+end
+
+%% Validation information
+rms_acc = sqrt(mean(sum(accel_ned_gnss.^2,2)));
+fprintf('GNSS NED pos first=[%.2f %.2f %.2f], last=[%.2f %.2f %.2f]\n', ...
+        pos_ned_gnss(1,:), pos_ned_gnss(end,:));
+fprintf('GNSS accel RMS = %.4f m/s^2\n', rms_acc);
+fprintf('Applied accelerometer scale factor = %.4f, bias = [%.4f %.4f %.4f]\n', ...
+        scale_factor, acc_bias);
+
+%% Plotting
+fig = figure('Visible','off');
+for i=1:3
+    subplot(3,1,i); hold on;
+    plot(pos_ned_gnss(:,i),'b');
+    plot(pos_imu_ned(:,i),'r');
+    grid on; xlabel('Sample'); ylabel('m');
+    if i==1, title('North Position'); elseif i==2, title('East Position'); else, title('Down Position'); end
+end
+save_plot(fig, 'IMU', 'GNSS', 'TRIAD', 4);
+
+%% Save results
+out_file = fullfile(results_dir,'Task4_results_IMU_GNSS.mat');
+save(out_file,'pos_ned_gnss','vel_ned_gnss','accel_ned_gnss', ...
+                 'pos_imu_ned','vel_imu_ned','accel_ned','C_e2n','C_n2e','r0','lat_ref','lon_ref');
+end

--- a/src/task4_gnss_imu_integration.py
+++ b/src/task4_gnss_imu_integration.py
@@ -1,0 +1,46 @@
+"""GNSS and IMU integration task (MATLAB counterpart).
+
+This module mirrors :func:`task4_gnss_imu_integration` implemented in
+``MATLAB/task4_gnss_imu_integration.m``.  A Python implementation is not
+yet provided.  The function signature is included for API parity.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Any
+
+
+def task4_gnss_imu_integration(
+    gnss_data: Any,
+    imu_data: Any,
+    task1_results: Path | str,
+    task2_results: Path | str,
+    task3_results: Path | str,
+    results_dir: Path | str,
+    dt: float = 0.0025,
+) -> Dict[str, Any]:
+    """Placeholder for the Task 4 Python implementation.
+
+    Parameters
+    ----------
+    gnss_data : Any
+        Table or array of GNSS measurements.
+    imu_data : Any
+        Body-frame IMU measurements.
+    task1_results : path-like
+        MAT-file containing ``gravity_ned``.
+    task2_results : path-like
+        MAT-file containing ``acc_bias`` and ``gyro_bias``.
+    task3_results : path-like
+        MAT-file containing ``C_b2n`` rotation matrix.
+    results_dir : path-like
+        Directory to write output files.
+    dt : float, optional
+        IMU sample interval in seconds, by default 0.0025.
+
+    Returns
+    -------
+    dict
+        Dictionary of integration results.
+    """
+    raise NotImplementedError("Python version pending; see MATLAB implementation")


### PR DESCRIPTION
## Summary
- keep gravity vector from Task 1 in Task_4
- add `task4_gnss_imu_integration` MATLAB function implementing GNSS/IMU integration
- provide Python stub `task4_gnss_imu_integration.py` for API parity

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_6886cc3aed1883258e126df77746b7f0