### PR TITLE
Add MATLAB Task 5 KF demo

### DIFF
--- a/MATLAB/run_triad_only.m
+++ b/MATLAB/run_triad_only.m
@@ -40,6 +40,10 @@ Task_2(imu_path, gnss_path, method);
 Task_3(imu_path, gnss_path, method);
 Task_4(imu_path, gnss_path, method);
 Task_5(imu_path, gnss_path, method);
+% Demonstration: run simplified Kalman filter loop and save ``x_log`` only
+% This mirrors the Python stub ``task5_kf_state_log.py`` and shows how to
+% persist the state history matrix to ``MATLAB/results``.
+task5_kf_state_log();
 
 % ------------------------------------------------------------------
 % Tasks 6 and 7: validation and residual analysis

--- a/MATLAB/task5_kf_state_log.m
+++ b/MATLAB/task5_kf_state_log.m
@@ -1,0 +1,53 @@
+function task5_kf_state_log()
+%TASK5_KF_STATE_LOG Example 15-state Kalman Filter loop storing x_log.
+%   This simplified demonstration mirrors the Python stub
+%   ``task5_kf_state_log.py``. It pre-allocates a history matrix, runs a
+%   dummy filter loop and saves ``x_log`` under ``MATLAB/results``.
+%
+%   Usage:
+%       task5_kf_state_log
+
+    fprintf('--- Starting Task 5: Sensor Fusion with Kalman Filter ---\n');
+
+    % Configure Kalman Filter (placeholder setup)
+    num_states = 15;      % 15-state filter
+    num_samples = 500000; % Total IMU samples
+    x = zeros(num_states, 1);
+
+    fprintf('Task 5: Initializing state history matrix...\n');
+    x_log = zeros(num_states, num_samples);
+    fprintf('Task 5: x_log initialized with size %dx%d\n', num_states, num_samples);
+
+    fprintf('Task 5: Starting Kalman Filter loop over %d IMU samples...\n', num_samples);
+    for t = 1:num_samples
+        % Placeholder for prediction and update steps
+        x_log(:, t) = x;  %#ok<SAGROW> - example store
+        if mod(t, 100000) == 0
+            fprintf('Task 5: Processed sample %d/%d\n', t, num_samples);
+        end
+    end
+    fprintf('Task 5: Completed state logging for %d samples\n', num_samples);
+
+    % Save results under repository results directory
+    results_dir = get_results_dir();
+    if ~exist(results_dir, 'dir'); mkdir(results_dir); end
+    results_file = fullfile(results_dir, 'IMU_X002_GNSS_X002_TRIAD_task5_results.mat');
+    fprintf('Task 5: Saving results to %s...\n', results_file);
+    if isfile(results_file)
+        data = load(results_file);
+        data.x_log = x_log; %#ok<STRNU>
+        save(results_file, '-struct', 'data');
+    else
+        save(results_file, 'x_log');
+    end
+    fprintf('Task 5: State history (x_log) saved to %s\n', results_file);
+
+    % Verify save
+    try
+        check = load(results_file, 'x_log');
+        fprintf('Task 5: Verified x_log saved, size: %dx%d\n', size(check.x_log));
+    catch
+        warning('Task 5: Failed to verify x_log save in %s', results_file);
+    end
+    fprintf('Task 5: Completed successfully\n');
+end

--- a/task5_kf_state_log.py
+++ b/task5_kf_state_log.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Placeholder for Task 5 Kalman Filter demonstration.
+
+This stub mirrors the MATLAB function ``task5_kf_state_log`` and is kept
+for cross-language parity. It simply initialises an empty ``x_log`` array
+and saves it under ``results/``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import numpy as np
+
+
+def task5_kf_state_log(results_file: str | Path = "results/task5_kf_state_log.npz") -> None:
+    """Save an empty ``x_log`` array to *results_file*.
+
+    Parameters
+    ----------
+    results_file : str or Path, optional
+        Output path for the ``x_log`` state history.
+    """
+    results_path = Path(results_file)
+    results_path.parent.mkdir(parents=True, exist_ok=True)
+    x_log = np.empty((15, 0))
+    np.savez(results_path, x_log=x_log)
+    print(f"Saved placeholder x_log to {results_path}")
+
+
+if __name__ == "__main__":
+    task5_kf_state_log()


### PR DESCRIPTION
## Summary
- add `task5_kf_state_log` demo with state logging to results directory
- call demo from `run_triad_only.m`
- provide Python stub `task5_kf_state_log.py` for parity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886efb185cc8325b650d10ebdf727ce