### PR TITLE
Fix Task 5 argument handling

### DIFF
--- a/MATLAB/Task_5.m
+++ b/MATLAB/Task_5.m
@@ -1,11 +1,22 @@
-function Task_5()
-%TASK_5 Run Kalman Filter, generate plots and save results.
-%   This simplified placeholder replaces the original implementation.
-%   The function loads IMU and GNSS data from fixed paths, runs a dummy
+function Task_5(varargin)
+%TASK_5  Run Kalman Filter, generate plots and save results.
+%   TASK_5(imu_path, gnss_path, method) accepts optional arguments for
+%   compatibility with earlier scripts. They are currently ignored.
+%
+%   Usage:
+%       Task_5()
+%       Task_5(imu_path, gnss_path, method)
+%
+%   This simplified placeholder replaces the original implementation. The
+%   function loads IMU and GNSS data from fixed paths, runs a dummy
 %   15-state Kalman Filter loop, saves the state history and exports a set
 %   of 3x3 subplot PDFs. Paths and logic mirror the provided code snippet.
 
 fprintf('--- Starting Task 5: Sensor Fusion with Kalman Filter ---\n');
+
+if nargin > 0
+    fprintf('Task 5: Ignoring %d input argument(s)\n', nargin);
+end
 
 % Step 1: Configure Kalman Filter
 fprintf('Task 5: Configuring 15-State Kalman Filter...\n');

--- a/MATLAB/run_triad_only.m
+++ b/MATLAB/run_triad_only.m
@@ -39,6 +39,8 @@ Task_1(imu_path, gnss_path, method);
 Task_2(imu_path, gnss_path, method);
 Task_3(imu_path, gnss_path, method);
 Task_4(imu_path, gnss_path, method);
+% Task_5 accepts the file paths for compatibility but ignores them in the
+% current simplified implementation.
 Task_5(imu_path, gnss_path, method);
 % Demonstration: run simplified Kalman filter loop and save ``x_log`` only
 % This mirrors the Python stub ``task5_kf_state_log.py`` and shows how to


### PR DESCRIPTION
## Summary
- allow optional arguments in MATLAB Task_5
- clarify Task_5 invocation in `run_triad_only.m`
- verify with `pytest`

## Testing
- `pip install -e .[tests]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68872f3b7aa48325a688bd3d251632a0