### PR TITLE
Improve MATLAB Task_4 robustness

### DIFF
--- a/MATLAB/Task_4.m
+++ b/MATLAB/Task_4.m
@@ -1,12 +1,20 @@
-function Task_4( imu_path, gnss_path, method )
-%TASK_4 Integrate GNSS and IMU data in NED, ECEF and body frames.
-%   Task_4(IMU_PATH, GNSS_PATH, METHOD) loads the previous task results,
-%   integrates the IMU specific force using the rotation matrix from Task 3
-%   and compares it with the GNSS trajectory. Results and comparison plots
-%   are saved under the ``results`` directory returned by GET_RESULTS_DIR.
+function Task_4(imu_file, gnss_file, method, output_tag)
+%TASK_4 GNSS/IMU integration with robust file handling.
+%   TASK_4(IMU_FILE, GNSS_FILE, METHOD, OUTPUT_TAG) loads the MAT files
+%   produced by Tasks 1--3, applies the attitude matrix from Task 3 and
+%   integrates the IMU specific force.  Plots are produced in NED, ECEF and
+%   body frames and saved under ``results/`` for reuse by later tasks.
 %
-%   This implementation mirrors the Python pipeline ``run_triad_only.py``
-%   for cross-language parity.
+%   IMU_FILE   - path to the raw IMU dataset (``IMU_X002.dat`` for example)
+%   GNSS_FILE  - path to the GNSS CSV file
+%   METHOD     - Wahba solution method used in Task 3 (e.g. ``'TRIAD'``)
+%   OUTPUT_TAG - base name for all saved results.  If empty, a tag of the
+%                form ``IMU_X002_GNSS_X002_TRIAD`` is generated from the
+%                input filenames.
+%
+%   Example:
+%       Task_4('data/IMU_X002.dat', 'data/GNSS_X002.csv', 'TRIAD', ...
+%              'IMU_X002_GNSS_X002_TRIAD');
 %
 %   See also GET_RESULTS_DIR.
 
@@ -15,11 +23,15 @@ if nargin < 3
 end
 
 results_dir = get_results_dir();
-if ~exist(results_dir,'dir'); mkdir(results_dir); end
+if ~exist(results_dir, 'dir'); mkdir(results_dir); end
 
-[~, imu_name, ~]  = fileparts(imu_path);
-[~, gnss_name, ~] = fileparts(gnss_path);
-tag = sprintf('%s_%s_%s', imu_name, gnss_name, method);
+[~, imu_name, ~]  = fileparts(imu_file);
+[~, gnss_name, ~] = fileparts(gnss_file);
+if nargin < 4 || isempty(output_tag)
+    tag = sprintf('%s_%s_%s', imu_name, gnss_name, method);
+else
+    tag = output_tag;
+end
 
 % ------------------------------------------------------------------
 % Subtask 4.1: Load outputs from previous tasks
@@ -29,24 +41,88 @@ task1_file = fullfile(results_dir, sprintf('Task1_init_%s.mat', tag));
 task2_file = fullfile(results_dir, sprintf('Task2_body_%s.mat', tag));
 task3_file = fullfile(results_dir, sprintf('Task3_results_%s.mat', tag));
 out_mat    = fullfile(results_dir, sprintf('Task4_results_%s.mat', tag));
-out_mat2   = fullfile(results_dir, sprintf('%s_task4_results.mat', tag));
 
-load(task1_file,'lat0_rad','lon0_rad','gravity_ned');
-load(task2_file,'accel_bias','gyro_bias','accel_scale','static_start','static_end');
-load(task3_file,'task3_results');
-C_b_n = task3_results.TRIAD.R;
-fprintf('Subtask 4.1: Accessing rotation matrices from Task 3.\n');
-fprintf(' -> Loaded C_b_n for method %s\n', method);
+fprintf('Task 4: loading previous task outputs:\n');
+fprintf('  Task 1 -> %s\n', task1_file);
+fprintf('  Task 2 -> %s\n', task2_file);
+fprintf('  Task 3 -> %s\n', task3_file);
+
+% ---- Task 1 ----
+if isfile(task1_file)
+    S1 = load(task1_file);
+else
+    error('Task_4:MissingTask1', 'Task 1 result file not found: %s', task1_file);
+end
+if isfield(S1,'lat0_rad');      lat0_rad = S1.lat0_rad;
+elseif isfield(S1,'lat');        lat0_rad = deg2rad(S1.lat);
+else
+    error('Task_4:MissingField','Latitude field missing from %s', task1_file);
+end
+if isfield(S1,'lon0_rad');      lon0_rad = S1.lon0_rad;
+elseif isfield(S1,'lon');        lon0_rad = deg2rad(S1.lon);
+else
+    error('Task_4:MissingField','Longitude field missing from %s', task1_file);
+end
+if isfield(S1,'gravity_ned');   gravity_ned = S1.gravity_ned(:);
+elseif isfield(S1,'g_NED');      gravity_ned = S1.g_NED(:);
+else
+    error('Task_4:MissingField','Gravity vector missing from %s', task1_file);
+end
+if isfield(S1,'ref_r0'); r0_init = S1.ref_r0(:); else; r0_init = []; end
+
+% ---- Task 2 ----
+if isfile(task2_file)
+    S2 = load(task2_file);
+else
+    error('Task_4:MissingTask2', 'Task 2 result file not found: %s', task2_file);
+end
+if isfield(S2,'accel_bias'); accel_bias = S2.accel_bias(:)';
+elseif isfield(S2,'acc_bias');  accel_bias = S2.acc_bias(:)';
+else
+    error('Task_4:MissingField','Accelerometer bias missing from %s', task2_file);
+end
+if isfield(S2,'gyro_bias');  gyro_bias = S2.gyro_bias(:)';
+else
+    error('Task_4:MissingField','Gyroscope bias missing from %s', task2_file);
+end
+if isfield(S2,'accel_scale'); accel_scale = S2.accel_scale; else; accel_scale = 1; end
+if isfield(S2,'static_start'); static_start = S2.static_start; else; static_start = 1; end
+if isfield(S2,'static_end');   static_end   = S2.static_end;   else; static_end   = 1; end
+
+% ---- Task 3 ----
+if isfile(task3_file)
+    S3 = load(task3_file);
+else
+    error('Task_4:MissingTask3', 'Task 3 result file not found: %s', task3_file);
+end
+if ~isfield(S3,'task3_results')
+    error('Task_4:MissingField','task3_results missing from %s', task3_file);
+end
+task3_results = S3.task3_results;
+if isfield(task3_results, method)
+    if isfield(task3_results.(method), 'R')
+        C_b_n = task3_results.(method).R;
+    else
+        error('Task_4:MissingField','Rotation matrix R missing for %s in %s', method, task3_file);
+    end
+else
+    error('Task_4:MissingField','Method %s not found in %s', method, task3_file);
+end
+fprintf('Loaded rotation matrix for %s.\n', method);
 
 % ------------------------------------------------------------------
 % Subtask 4.3: Load GNSS data
 % ------------------------------------------------------------------
 fprintf('Subtask 4.3: Loading GNSS data.\n');
 
-gnss = readtable(gnss_path);
-fprintf('Subtask 4.4: GNSS data shape: %d x %d\n', size(gnss,1), 3);
+gnss = readtable(gnss_file);
+fprintf('Subtask 4.4: GNSS data shape: %d x %d\n', size(gnss,1), width(gnss));
 
-r0 = [gnss.X_ECEF_m(1); gnss.Y_ECEF_m(1); gnss.Z_ECEF_m(1)];
+if ~isempty(r0_init)
+    r0 = r0_init;
+else
+    r0 = [gnss.X_ECEF_m(1); gnss.Y_ECEF_m(1); gnss.Z_ECEF_m(1)];
+end
 C_e_n = compute_C_ECEF_to_NED(lat0_rad, lon0_rad);
 fprintf('Subtask 4.5: Reference point (ECEF) = [%.1f, %.1f, %.1f]\n', r0);
 
@@ -57,7 +133,8 @@ vel_ned  = C_e_n*vel_ecef;
 fprintf('Subtask 4.7: Converted GNSS to NED: first=[%.2f,%.2f,%.2f], last=[%.2f,%.2f,%.2f]\n', ...
     pos_ned(1,1),pos_ned(2,1),pos_ned(3,1),pos_ned(1,end),pos_ned(2,end),pos_ned(3,end));
 
-dt_gnss = mean(diff(gnss.Posix_Time));
+gnss_time = gnss.Posix_Time;
+dt_gnss = mean(diff(gnss_time));
 acc_ned = diff(vel_ned,1,2) / dt_gnss;
 fprintf('Subtask 4.8: GNSS accel RMS = %.4f m/s^2\n', rms(acc_ned(:)) );
 
@@ -65,7 +142,7 @@ fprintf('Subtask 4.8: GNSS accel RMS = %.4f m/s^2\n', rms(acc_ned(:)) );
 % Subtask 4.9: Load IMU data and correct
 % ------------------------------------------------------------------
 fprintf('Subtask 4.9: Loading IMU data.\n');
-imu_raw = readmatrix(imu_path);
+imu_raw = readmatrix(imu_file);
 dt = mean(diff(imu_raw(1:100,2)));
 accel_raw = imu_raw(:,6:8) / dt;
 gyro_raw  = imu_raw(:,3:5) / dt;
@@ -96,35 +173,49 @@ fprintf('Subtask 4.12: Integrated IMU data using %s method.\n', method);
 % Subtask 4.13: Plot comparison
 % ------------------------------------------------------------------
 fprintf('Subtask 4.13: Plotting GNSS vs IMU in NED frame.\n');
-fig = figure('Visible','off');
+fig = figure();
 plot_ned_comparison(pos_ned, pos_imu, vel_ned, vel_imu, acc_ned, acc_imu);
-file_ned = fullfile(results_dir, sprintf('%s_task4_NED.pdf', tag));
+file_ned = fullfile(results_dir, sprintf('%s_task4_results_NED.pdf', tag));
 saveas(fig, file_ned);
+saveas(fig, strrep(file_ned,'.pdf','.png'));
 close(fig);
 fprintf('Saved plot: %s\n', file_ned);
 
 % -- ECEF frame --
-fig = figure('Visible','off');
+fig = figure();
 C_n_e = C_e_n';
 pos_imu_ecef = C_n_e*pos_imu + r0;
 vel_imu_ecef = C_n_e*vel_imu;
 pos_gnss_ecef = pos_ecef;
 vel_gnss_ecef = vel_ecef;
 plot_ned_comparison(pos_gnss_ecef,pos_imu_ecef,vel_gnss_ecef,vel_imu_ecef,acc_ned,acc_imu);
-file_ecef = fullfile(results_dir, sprintf('%s_task4_ECEF.pdf', tag));
-saveas(fig,file_ecef); close(fig);
+file_ecef = fullfile(results_dir, sprintf('%s_task4_results_ECEF.pdf', tag));
+saveas(fig, file_ecef);
+saveas(fig, strrep(file_ecef,'.pdf','.png')); close(fig);
 fprintf('Saved plot: %s\n', file_ecef);
 
 % -- Body frame --
-fig = figure('Visible','off');
+fig = figure();
 plot_body_frame(accel, gyro);
-file_body = fullfile(results_dir, sprintf('%s_task4_BODY.pdf', tag));
-saveas(fig,file_body); close(fig);
+file_body = fullfile(results_dir, sprintf('%s_task4_results_Body.pdf', tag));
+saveas(fig, file_body);
+saveas(fig, strrep(file_body,'.pdf','.png'));
+close(fig);
 fprintf('Saved plot: %s\n', file_body);
 
-save(out_mat, 'pos_ned','vel_ned','acc_ned','pos_imu','vel_imu','acc_imu');
-movefile(out_mat,out_mat2,'f');
-fprintf('Saved Task 4 results to %s\n', out_mat2);
+% ------------------------------------------------------------------
+% Save key outputs for downstream use
+% ------------------------------------------------------------------
+pos_est_ned   = pos_imu;
+vel_est_ned   = vel_imu;
+acc_est_ned   = acc_imu;
+pos_est_ecef  = pos_imu_ecef;
+vel_est_ecef  = vel_imu_ecef;
+save_vars = {'pos_est_ned','vel_est_ned','acc_est_ned','pos_est_ecef', ...
+    'vel_est_ecef','lat0_rad','lon0_rad','gravity_ned','accel_scale','C_b_n','C_e_n','r0'};
+save(out_mat, save_vars{:});
+fprintf('Saved Task 4 results to %s\n', out_mat);
+fprintf('Task 4 completed: All frame plots saved, variables ready for Task 5.\n');
 end
 
 % ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- handle missing Task 1–3 files and variables in `Task_4` with explicit errors
- add optional output tag argument and detailed logging
- plot figures visibly and save PDF/PNG copies with new naming
- save integrated results in `Task4_results_<tag>.mat`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68873a690a0c8325b39e919ed238489c