### PR TITLE
Update MATLAB logging for Tasks 2–3

### DIFF
--- a/MATLAB/Task_3.m
+++ b/MATLAB/Task_3.m
@@ -140,7 +140,7 @@ R_tri = M_ned_1 * M_body';
 [U,~,V] = svd(R_tri);
 R_tri = U*V';
 fprintf('Rotation matrix (TRIAD method, Case 1):\n');
-disp(R_tri);
+fprintf('[% .8e % .8e % .8e;\n % .8e % .8e % .8e;\n % .8e % .8e % .8e]\n', R_tri');
 fig_tri = figure; plot(R_tri(:)); title('TRIAD Rotation Matrix'); xlabel('Element'); ylabel('Value'); grid on;
 save_plot(fig_tri, imu_name, gnss_name, method, 3);
 expected_C_b_n = [0.23364698, -0.04540352, 0.971260835; ...
@@ -159,7 +159,7 @@ R_tri_doc = M_ned_2 * M_body';
 [U,~,V] = svd(R_tri_doc);
 R_tri_doc = U*V';
 fprintf('Rotation matrix (TRIAD method, Case 2):\n');
-disp(R_tri_doc);
+fprintf('[% .8e % .8e % .8e;\n % .8e % .8e % .8e;\n % .8e % .8e % .8e]\n', R_tri_doc');
 
 
 %% ========================================================================
@@ -169,13 +169,13 @@ fprintf('\nSubtask 3.3: Computing rotation matrix using Davenport’s Q-Method.\
 % Case 1
 [R_dav, q_dav] = davenport_q_method(v1_B, v2_B, v1_N, v2_N);
 fprintf('Rotation matrix (Davenport’s Q-Method, Case 1):\n');
-disp(R_dav);
+fprintf('[% .8e % .8e % .8e;\n % .8e % .8e % .8e;\n % .8e % .8e % .8e]\n', R_dav');
 fprintf('Davenport quaternion (Case 1): [%.6f, %.6f, %.6f, %.6f]\n', q_dav(1), q_dav(2), q_dav(3), q_dav(4));
 
 % Case 2
 [R_dav_doc, q_dav_doc] = davenport_q_method(v1_B, v2_B, v1_N, v2_N_doc);
 fprintf('Rotation matrix (Davenport’s Q-Method, Case 2):\n');
-disp(R_dav_doc);
+fprintf('[% .8e % .8e % .8e;\n % .8e % .8e % .8e;\n % .8e % .8e % .8e]\n', R_dav_doc');
 fprintf('Davenport quaternion (Case 2): [%.6f, %.6f, %.6f, %.6f]\n', q_dav_doc(1), q_dav_doc(2), q_dav_doc(3), q_dav_doc(4));
 
 
@@ -186,7 +186,7 @@ fprintf('\nSubtask 3.4: Computing rotation matrix using SVD method.\n');
 R_svd = svd_alignment({g_body, omega_ie_body}, {g_NED, omega_ie_NED});
 R_svd_doc = R_svd; % In the python script, SVD method is not re-run for Case 2
 fprintf('Rotation matrix (SVD method):\n');
-disp(R_svd);
+fprintf('[% .8e % .8e % .8e;\n % .8e % .8e % .8e;\n % .8e % .8e % .8e]\n', R_svd');
 
 
 %% ========================================================================
@@ -241,7 +241,7 @@ if diff_err < tol
     warning('All Earth-rate errors are very close; differences are within %.1e\xB0', tol);
 end
 
-fprintf('\n==== Method Comparison for Case 1 ====\n');
+fprintf('\n==== Method Comparison for %s ====\n', dataset_tag);
 fprintf('%-10s  %-18s  %-22s\n', 'Method', 'Gravity Err (deg)', 'Earth-Rate Err (deg)');
 for i = 1:length(methods)
     fprintf('%-10s  %18.4f  %22.4f\n', methods{i}, grav_errors(i), omega_errors(i));
@@ -309,7 +309,7 @@ if exist(task3_file, 'file')
     if isfield(data, 'task3_results') && isfield(data.task3_results, 'TRIAD')
         C_B_N = data.task3_results.TRIAD.R;
         fprintf('\nRotation matrix C_{B}^{N}:\n');
-        disp(C_B_N);
+        fprintf('[% .8e % .8e % .8e;\n % .8e % .8e % .8e;\n % .8e % .8e % .8e]\n', C_B_N');
     end
 end
 fprintf('Results saved to %s\n', results_dir);


### PR DESCRIPTION
## Summary
- improve Task 2 logs: 0-based index print, bias magnitudes, scale factor, full precision vectors
- expand Task 2 save log with variable summary
- print rotation matrices in scientific notation for Task 3
- show dataset tag in method comparison table

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `matlab -batch "run('MATLAB/run_triad_only.m');"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887423615308325be5cd661b06bfc8e