### PR TITLE
Enable interactive Task 7.5 plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,9 @@ python src/run_all_methods.py --task 7
   `python task7_ecef_residuals_plot.py --est-file <fused.npz> --imu-file <IMU.dat> \
   --gnss-file <GNSS.csv> --dataset <tag>`
 * Subtask 7.5 generates `<tag>_task7_5_diff_truth_fused_over_time_<frame>.pdf` for
-  NED, ECEF and Body frames with the component-wise difference between truth and fused trajectories.
+  NED, ECEF and Body frames with the component-wise difference between truth and
+  fused trajectories. Pass `--show` to `evaluate_filter_results.py` to display
+  these plots interactively.
 
 ### Notes
 

--- a/docs/Python/Task7_Python.md
+++ b/docs/Python/Task7_Python.md
@@ -28,6 +28,8 @@ Residual position and velocity are compared with the GNSS data. When a truth tra
 - If the reference trajectory is provided, plot component-wise differences.
 - Figures are saved as `<tag>_task7_5_diff_truth_fused_over_time_<frame>.pdf` for
   all frames (NED, ECEF and Body).
+- Use the `--show` flag with `evaluate_filter_results.py` to display the plots
+  interactively in addition to saving them.
 
 ## Result
 

--- a/src/evaluate_filter_results.py
+++ b/src/evaluate_filter_results.py
@@ -165,7 +165,13 @@ def run_evaluation(
     plt.close(fig)
 
 
-def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) -> None:
+def run_evaluation_npz(
+    npz_file: str,
+    save_path: str,
+    tag: str | None = None,
+    *,
+    show: bool = False,
+) -> None:
     """Evaluate residuals stored in a ``*_kf_output.npz`` file.
 
     Parameters
@@ -176,6 +182,9 @@ def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) ->
         Directory where the evaluation plots will be written.
     tag
         Optional dataset tag used to prefix the filenames.
+    show
+        If ``True`` display the Task 7.5 figures interactively in addition to
+        saving them.
     """
     start_time = time.time()
     out_dir = Path(save_path)
@@ -323,6 +332,7 @@ def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) ->
             ref_lon,
             run_id,
             out_dir,
+            show=show,
         )
     else:
         print("Subtask 7.5 skipped: missing fused or truth data")
@@ -360,8 +370,16 @@ def subtask7_5_diff_plot(
     ref_lon: float | None,
     run_id: str,
     out_dir: str,
+    *,
+    show: bool = False,
 ) -> None:
-    """Plot ``truth - fused`` differences in NED, ECEF and Body frames."""
+    """Plot ``truth - fused`` differences in NED, ECEF and Body frames.
+
+    Parameters
+    ----------
+    show
+        When ``True`` display each figure interactively via :func:`matplotlib.pyplot.show`.
+    """
 
     # Use relative time for direct comparison with Task 6 plots
     time = time - time[0]
@@ -394,6 +412,8 @@ def subtask7_5_diff_plot(
         print(f"Saved {pdf}")
         fig.savefig(png)
         print(f"Saved {png}")
+        if show:
+            plt.show()
         plt.close(fig)
 
         pos_thr = 1.0
@@ -456,9 +476,14 @@ if __name__ == "__main__":
     # Task 7 plots now default to the top-level ``results`` directory
     ap.add_argument("--output", default="results")
     ap.add_argument("--tag", help="Dataset tag used as filename prefix")
+    ap.add_argument(
+        "--show",
+        action="store_true",
+        help="Display Task 7.5 plots interactively",
+    )
     args = ap.parse_args()
     if args.npz:
-        run_evaluation_npz(args.npz, args.output, args.tag)
+        run_evaluation_npz(args.npz, args.output, args.tag, show=args.show)
     else:
         if not (args.prediction and args.gnss and args.attitude):
             ap.error(


### PR DESCRIPTION
## Summary
- add `show` option to `evaluate_filter_results.py` for interactive Task 7.5 plots
- document `--show` flag in README and Task7 Python notes

## Testing
- `pytest tests/test_evaluate_filter_results.py::test_run_evaluation_npz_diff_plot -q`

------
https://chatgpt.com/codex/tasks/task_e_6887434729f88325a3975ea7af4c14c2