### PR TITLE
Fix accel_scale variable handling in MATLAB tasks

### DIFF
--- a/MATLAB/Task_2.m
+++ b/MATLAB/Task_2.m
@@ -18,6 +18,7 @@ function body_data = Task_2(imu_path, gnss_path, method, dataset_tag)
 %       gyro_bias     - gyroscope bias estimate (3x1, rad/s)
 %       static_start  - index of first static sample
 %       static_end    - index of last static sample
+%       accel_scale   - accelerometer scale factor applied to raw data
 %   For convenience a struct ``body_data`` containing the same fields is
 %   returned and stored in the workspace variable
 %   ``task2_results`` for interactive use.
@@ -92,6 +93,7 @@ function body_data = Task_2(imu_path, gnss_path, method, dataset_tag)
     static_gyro = mean(gyro_filt(static_start:static_end, :), 1); % 1x3
     g_body_raw = -static_acc';
     scale_factor = constants.GRAVITY / norm(g_body_raw);
+    accel_scale  = scale_factor; % use consistent naming across tasks
     g_body = (g_body_raw / norm(g_body_raw)) * constants.GRAVITY;
     g_body_scaled = g_body; % legacy variable for compatibility with old scripts
     omega_ie_body = static_gyro';
@@ -111,7 +113,7 @@ function body_data = Task_2(imu_path, gnss_path, method, dataset_tag)
     body_data.gyro_bias     = gyro_bias;
     body_data.static_start  = static_start;
     body_data.static_end    = static_end;
-    body_data.accel_scale   = scale_factor;
+    body_data.accel_scale   = accel_scale;
 
     [~, imu_name, ~] = fileparts(imu_path);
     if ~isempty(gnss_path)
@@ -141,14 +143,14 @@ function body_data = Task_2(imu_path, gnss_path, method, dataset_tag)
             accel_bias, accel_mag);
     fprintf('Gyroscope bias     = [% .6e % .6e % .6e] rad/s (|b|=%.6e rad/s)\n', ...
             gyro_bias, gyro_mag);
-    fprintf('Accelerometer scale factor = %.4f\n', scale_factor);
+    fprintf('Accelerometer scale factor = %.4f\n', accel_scale);
     results_dir = get_results_dir();
     if ~exist(results_dir,'dir'); mkdir(results_dir); end
 
     out_file = fullfile(results_dir, sprintf('Task2_%s_%s.mat', dataset_tag, method));
 
     save(out_file, 'g_body', 'g_body_scaled', 'omega_ie_body', ...
-        'accel_bias', 'gyro_bias', 'static_start', 'static_end', 'scale_factor');
+        'accel_bias', 'gyro_bias', 'static_start', 'static_end', 'accel_scale');
 
     assignin('base','task2_results', body_data);
     fprintf('Saved to %s\n', out_file);

--- a/MATLAB/Task_5.m
+++ b/MATLAB/Task_5.m
@@ -48,7 +48,14 @@ if exist(init_file,'file') ~= 2 || exist(body_file,'file') ~= 2 || ...
     error('Task_5:MissingPrereq','Required Task 1--4 outputs not found.');
 end
 load(init_file, 'gravity_ned','lat0_rad','lon0_rad');
-load(body_file, 'accel_bias','gyro_bias','accel_scale');
+load(body_file, 'accel_bias','gyro_bias');
+tmp = load(body_file, 'accel_scale');
+if isfield(tmp, 'accel_scale')
+    accel_scale = tmp.accel_scale;
+else
+    accel_scale = 1;
+    warning('Task_5:MissingField', 'Variable ''accel_scale'' not found. Using scale = 1.');
+end
 load(task3_file, 'task3_results');
 C_b_n = task3_results.(method).R; %#ok<NASGU>
 load(task4_file, 'pos_ned','vel_ned','acc_ned');

--- a/tests/test_validate_and_plot_errors.py
+++ b/tests/test_validate_and_plot_errors.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+import pytest
+import numpy as np
+
+import validate_and_plot
+
+
+def test_validate_and_plot_missing_field(tmp_path, monkeypatch):
+    est_data = {
+        "time": np.array([0.0, 1.0, 2.0]),
+        "quat": np.tile([1.0, 0.0, 0.0, 0.0], (3, 1)),
+    }
+    est_file = tmp_path / "est.npz"
+    np.savez(est_file, **est_data)
+
+    truth_file = Path("tests/data/simple_truth.txt")
+    out_dir = tmp_path / "out"
+
+    args = [
+        "--est-file",
+        str(est_file),
+        "--truth-file",
+        str(truth_file),
+        "--output-dir",
+        str(out_dir),
+    ]
+    monkeypatch.setattr(sys, "argv", ["validate_and_plot.py"] + args)
+    with pytest.raises(KeyError):
+        validate_and_plot.main()

--- a/validate_and_plot.py
+++ b/validate_and_plot.py
@@ -70,10 +70,22 @@ def main() -> None:
     t_truth, pos_truth_ecef, vel_truth_ecef, quat_truth = load_truth(Path(args.truth_file))
 
     est = load_estimate(args.est_file)
-    t_est = np.asarray(est["time"]).squeeze()
-    pos_est = np.asarray(est["pos"])
-    vel_est = np.asarray(est["vel"])
-    quat_est = np.asarray(est.get("quat"))
+    t_est = est.get("time")
+    pos_est = est.get("pos")
+    vel_est = est.get("vel")
+    quat_est = est.get("quat")
+
+    if t_est is None:
+        raise KeyError("time")
+    if pos_est is None:
+        raise KeyError("pos")
+    if vel_est is None:
+        raise KeyError("vel")
+
+    t_est = np.asarray(t_est).squeeze()
+    pos_est = np.asarray(pos_est)
+    vel_est = np.asarray(vel_est)
+    quat_est = np.asarray(quat_est) if quat_est is not None else None
 
     ref_lat = est.get("ref_lat") or est.get("ref_lat_rad") or est.get("lat0")
     ref_lon = est.get("ref_lon") or est.get("ref_lon_rad") or est.get("lon0")


### PR DESCRIPTION
## Summary
- store `accel_scale` in `Task_2` output MAT-file
- load `accel_scale` safely in `Task_5` with fallback

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pytest tests/test_validate_and_plot_errors.py::test_validate_and_plot_missing_field -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_688748b588488325bebd90421e22c4c0