### PR TITLE
Fix ECEF conversion call in Task_5

### DIFF
--- a/MATLAB/Task_5.m
+++ b/MATLAB/Task_5.m
@@ -129,8 +129,8 @@ acc_fused_ned = zeros(size(vel_est_ned));
 acc_fused_ned(:,2:end) = diff(vel_est_ned,1,2) / dt;
 
 % Convert estimates to the ECEF frame using the fixed reference attitude
-[pos_est_ecef, vel_est_ecef] = ned2ecef_series(pos_est_ned, vel_est_ned, ...
-    lat0_rad, lon0_rad);
+[pos_est_ecef, vel_est_ecef] = ned2ecef_series( ...
+    pos_est_ned, vel_est_ned, [], lat0_rad, lon0_rad);
 
 % Save using Python-style variable names for cross-language parity
 save(out_mat, 'x_log','pos_est_ned','vel_est_ned','pos_est_ecef', ...


### PR DESCRIPTION
## Summary
- pass an empty argument when converting fused NED data to ECEF in `Task_5.m`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68876c11972c8325af9a5c8da762af2b