### PR TITLE
Implement fused frame plots for Task 5

### DIFF
--- a/MATLAB/ned2ecef_series.m
+++ b/MATLAB/ned2ecef_series.m
@@ -1,0 +1,15 @@
+function [pos_ecef, vel_ecef] = ned2ecef_series(pos_ned, vel_ned, lat_rad, lon_rad, r0_ecef)
+%NED2ECEF_SERIES Convert NED position/velocity arrays to ECEF.
+%   [POS_ECEF, VEL_ECEF] = NED2ECEF_SERIES(POS_NED, VEL_NED, LAT_RAD, LON_RAD,
+%   R0_ECEF) converts the Nx3 matrices POS_NED and VEL_NED from North-East-Down
+%   coordinates to Earth-Centered Earth-Fixed. LAT_RAD and LON_RAD specify the
+%   reference latitude and longitude in radians. R0_ECEF is the 3-element ECEF
+%   reference position vector.
+%
+%   This mirrors the helper used in the Python pipeline.
+
+C_e_n = compute_C_ECEF_to_NED(lat_rad, lon_rad);
+C_n_e = C_e_n';
+pos_ecef = (C_n_e * pos_ned')' + r0_ecef(:)';
+vel_ecef = (C_n_e * vel_ned')';
+end

--- a/MATLAB/ned2ecef_vector.m
+++ b/MATLAB/ned2ecef_vector.m
@@ -1,0 +1,9 @@
+function vec_ecef = ned2ecef_vector(vec_ned, lat_rad, lon_rad)
+%NED2ECEF_VECTOR Rotate NED vectors to ECEF.
+%   VEC_ECEF = NED2ECEF_VECTOR(VEC_NED, LAT_RAD, LON_RAD) rotates the Nx3 matrix
+%   VEC_NED from North-East-Down to Earth-Centered Earth-Fixed using the
+%   reference latitude and longitude in radians.
+
+C_e_n = compute_C_ECEF_to_NED(lat_rad, lon_rad);
+vec_ecef = (C_e_n' * vec_ned')';
+end

--- a/MATLAB/plot_xyz_timeseries.m
+++ b/MATLAB/plot_xyz_timeseries.m
@@ -1,0 +1,36 @@
+function plot_xyz_timeseries(t, pos, vel, acc, title_str, file_base, labels)
+%PLOT_XYZ_TIMESERIES  Plot position/velocity/acceleration timeseries.
+%   PLOT_XYZ_TIMESERIES(T, POS, VEL, ACC, TITLE_STR, FILE_BASE) creates a 3x3
+%   subplot figure with rows [position, velocity, acceleration] and columns
+%   representing the X/Y/Z axes.  The figure is saved to FILE_BASE.pdf and
+%   FILE_BASE.png.  LABELS is an optional cell array of axis labels.
+
+if nargin < 7 || isempty(labels)
+    labels = {'X','Y','Z'};
+end
+
+fig = figure('Visible','off','Position',[100 100 1200 900]);
+for k = 1:3
+    subplot(3,3,k);
+    plot(t, pos(:,k), 'b-', 'LineWidth', 1.5);
+    grid on; ylabel('[m]'); title(sprintf('Position %s', labels{k}));
+
+    subplot(3,3,3+k);
+    plot(t, vel(:,k), 'b-', 'LineWidth', 1.5);
+    grid on; ylabel('[m/s]'); title(sprintf('Velocity %s', labels{k}));
+
+    subplot(3,3,6+k);
+    plot(t, acc(:,k), 'b-', 'LineWidth', 1.5);
+    grid on; ylabel('[m/s^2]'); title(sprintf('Acceleration %s', labels{k}));
+end
+xlabel('Time (s)');
+sgtitle(title_str);
+
+pdf_file = [file_base '.pdf'];
+png_file = [file_base '.png'];
+set(fig,'PaperPositionMode','auto');
+print(fig, pdf_file, '-dpdf', '-bestfit');
+print(fig, png_file, '-dpng');
+close(fig);
+fprintf('Saved plot: %s\n', pdf_file);
+end


### PR DESCRIPTION
## Summary
- add helpers `ned2ecef_series` and `ned2ecef_vector`
- add generic `plot_xyz_timeseries` plotting function
- compute fused trajectories in Task_5 and plot them in NED/ECEF/Body
- store fused outputs to a single MAT-file

## Testing
- `pytest tests/test_ecef_to_geodetic.py::test_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_688780031778832590d983eeee5b66bf