### PR TITLE
Improve Task 6 truth overlay

### DIFF
--- a/MATLAB/task6_overlay_plot.m
+++ b/MATLAB/task6_overlay_plot.m
@@ -170,40 +170,39 @@ end
 
 % -------------------------------------------------------------------------
 function pdf_path = plot_overlay(t_est, pos_est, vel_est, acc_est, pos_truth, vel_truth, acc_truth, frame, method, dataset, out_dir)
-%PLOT_OVERLAY Create overlay plot of fused vs truth.
+%PLOT_OVERLAY Create 3x3 overlay plot of fused vs truth.
 
 labels = {'X','Y','Z'};
 if strcmpi(frame,'NED')
     labels = {'N','E','D'};
 end
 colors = {[0.2157 0.4824 0.7216], [0.8941 0.1020 0.1098], [0.3010 0.6863 0.2902]};
+ylabels = {'Position [m]','Velocity [m/s]','Acceleration [m/s^2]'};
 
-f = figure('Visible','off','Position',[100 100 800 900]);
-for ax = 1:3
-    subplot(3,1,ax);
-    data_est = {pos_est, vel_est, acc_est};
-    data_truth = {pos_truth, vel_truth, acc_truth};
-    plot(t_est, data_est{ax}(:,1), 'Color', colors{1}, 'DisplayName', ['Fused ' labels{1}]); hold on;
-    plot(t_est, data_truth{ax}(:,1), '--', 'Color', colors{1}, 'DisplayName', ['Truth ' labels{1}]);
-    plot(t_est, data_est{ax}(:,2), 'Color', colors{2}, 'DisplayName', ['Fused ' labels{2}]);
-    plot(t_est, data_truth{ax}(:,2), '--', 'Color', colors{2}, 'DisplayName', ['Truth ' labels{2}]);
-    plot(t_est, data_est{ax}(:,3), 'Color', colors{3}, 'DisplayName', ['Fused ' labels{3}]);
-    plot(t_est, data_truth{ax}(:,3), '--', 'Color', colors{3}, 'DisplayName', ['Truth ' labels{3}]);
-    switch ax
-        case 1
-            ylabel('Position [m]');
-            title(sprintf('%s Task 6 Overlay - %s (%s frame)', dataset, method, upper(frame)));
-        case 2
-            ylabel('Velocity [m/s]');
-        otherwise
-            ylabel('Acceleration [m/s^2]');
+f = figure('Visible','off','Position',[100 100 900 900]);
+data_est  = {pos_est,  vel_est,  acc_est};
+data_truth = {pos_truth, vel_truth, acc_truth};
+for row = 1:3
+    for col = 1:3
+        subplot(3,3,(row-1)*3+col); hold on;
+        plot(t_est, data_est{row}(:,col), 'Color', colors{col}, 'DisplayName', ['Fused ' labels{col}]);
+        plot(t_est, data_truth{row}(:,col), '--', 'Color', colors{col}, 'DisplayName', ['Truth ' labels{col}]);
+        grid on;
+        if row == 1
+            title(labels{col});
+        end
+        if col == 1
+            ylabel(ylabels{row});
+        end
+        if row == 3
             xlabel('Time [s]');
-    end
-    grid on;
-    if ax==1
-        legend('Location','northeastoutside');
+        end
+        if row == 1 && col == 1
+            legend('Location','northeastoutside');
+        end
     end
 end
+sgtitle(sprintf('%s Task 6 Overlay - %s (%s frame)', dataset, method, upper(frame)));
 set(f,'PaperPositionMode','auto');
 run_id = sprintf('%s_%s', dataset, method);
 if ~exist(out_dir,'dir'); mkdir(out_dir); end

--- a/docs/MATLAB/Task6_MATLAB.md
+++ b/docs/MATLAB/Task6_MATLAB.md
@@ -9,7 +9,8 @@ legend names described in [PlottingChecklist](../PlottingChecklist.md).
 The script loads `<IMU>_<GNSS>_<METHOD>_kf_output.mat` along with the
 corresponding `STATE_X*.txt` file. All IMU, GNSS and truth samples are
 interpolated to the estimator time vector before being passed to `plot_overlay`
-for the NED, ECEF and body frames.
+for the NED, ECEF and body frames.  The resulting 3×3 figures mirror the Task 5
+layout but overlay the truth trajectory instead of the GNSS series.
 
 ```text
 Task 5 output

--- a/docs/Python/Task6_Python.md
+++ b/docs/Python/Task6_Python.md
@@ -9,7 +9,9 @@ The script loads the stored filter results (`*_kf_output.mat` or `.npz`),
 retrieves the corresponding GNSS and IMU logs and aligns them with the ground
 truth file. The helper :func:`plot_overlay` then creates 3×3 figures in the NED,
 ECEF and body frames.  Since NED uses a positive *Down* axis, the script flips
-that component before plotting so altitude increases upward in the figures.
+that component before plotting so altitude increases upward in the figures. The
+layout mirrors the Task 5 plots but replaces the GNSS series with the truth
+trajectory.
 
 ```text
 Task 5 output

--- a/task6_overlay_plot.py
+++ b/task6_overlay_plot.py
@@ -198,25 +198,30 @@ def plot_overlay(
     labels = ["X", "Y", "Z"] if frame == "ECEF" else ["N", "E", "D"]
     colors = ["#377eb8", "#e41a1c", "#4daf4a"]  # colorblind friendly
 
-    fig, axes = plt.subplots(3, 1, figsize=(12, 12), sharex=True)
-    for ax, est, truth, ylab in zip(
-        axes,
-        (pos_est, vel_est, acc_est),
-        (pos_truth, vel_truth, acc_truth),
-        ("Position [m]", "Velocity [m/s]", "Acceleration [m/s$^2$]"),
-    ):
-        for i in range(3):
-            ax.plot(t_est, est[:, i], color=colors[i], label=f"Fused {labels[i]}")
-            ax.plot(t_est, truth[:, i], "--", color=colors[i], label=f"Truth {labels[i]}")
-        ax.set_ylabel(ylab)
-        ax.grid(True, alpha=0.3)
-    axes[-1].set_xlabel("Time [s]")
-    axes[0].set_title(f"{dataset} Task 6 Overlay — {method} ({frame} frame)")
-    axes[0].legend(loc="upper right", ncol=3, fontsize=9, frameon=True)
-    for ax in axes[1:]:
-        ax.legend().set_visible(False)
+    fig, axes = plt.subplots(3, 3, figsize=(12, 9), sharex=True)
 
-    fig.tight_layout()
+    datasets = [
+        (pos_est, pos_truth, "Position [m]"),
+        (vel_est, vel_truth, "Velocity [m/s]"),
+        (acc_est, acc_truth, "Acceleration [m/s$^2$]"),
+    ]
+
+    for row, (est, truth, ylab) in enumerate(datasets):
+        for col in range(3):
+            ax = axes[row, col]
+            ax.plot(t_est, est[:, col], color=colors[col], label=f"Fused {labels[col]}")
+            ax.plot(t_est, truth[:, col], "--", color=colors[col], label=f"Truth {labels[col]}")
+            ax.set_ylabel(ylab if col == 0 else "")
+            ax.grid(True, alpha=0.3)
+            if row == 0:
+                ax.set_title(labels[col])
+            if row == 2:
+                ax.set_xlabel("Time [s]")
+
+    axes[0, 0].legend(loc="upper right", ncol=3, fontsize=9, frameon=True)
+
+    fig.suptitle(f"{dataset} Task 6 Overlay — {method} ({frame} frame)")
+    fig.tight_layout(rect=[0, 0, 1, 0.95])
     run_id = f"{dataset}_{method}"
     out_dir.mkdir(parents=True, exist_ok=True)
     pdf_path = out_dir / f"{run_id}_task6_overlay_state_{frame}.pdf"


### PR DESCRIPTION
## Summary
- refactor Python `task6_overlay_plot` to use a 3×3 layout like Task 5
- mirror the new layout in `MATLAB/task6_overlay_plot.m`
- clarify documentation for Task 6 in MATLAB and Python guides

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887948e85ec8325acacf34db92fae8b