### PR TITLE
Improve Task 6 overlay layout

### DIFF
--- a/MATLAB/Task_6.m
+++ b/MATLAB/Task_6.m
@@ -206,6 +206,7 @@ t_ds = t_est(time_idx);
 pos_est_ds = S.x_log(1:3, time_idx);
 vel_est_ds = S.x_log(4:6, time_idx);
 pos_truth_ds = gnss_pos_ned';
+vel_truth_ds = vel_truth_ned_i(time_idx, :)';
 fprintf('Task 6: Downsampled estimates to %d samples (factor: %d)\n', numel(time_idx), downsample_factor);
 if size(pos_truth_ds,2) ~= numel(time_idx)
     error('Task 6: Data length mismatch. Truth: %d, Estimated: %d. Adjust downsampling.', size(pos_truth_ds,2), numel(time_idx));
@@ -261,26 +262,29 @@ plot_overlay('NED', run_id, t_est, pos_ned, vel_ned, acc_ned, ...
 % Display downsampled NED overlay
 fprintf('Task 6: Generating and displaying NED overlay plot...\n');
 fig = figure('Name', 'Task 6 - NED State Overlay', 'Visible', 'on');
-subplot(2,1,1);
-plot(t_ds, pos_est_ds(1,:), 'b', 'DisplayName', 'Est North');
-hold on;
-plot(t_ds, pos_truth_ds(1,:), 'r--', 'DisplayName', 'Truth North');
-plot(t_ds, pos_est_ds(2,:), 'g', 'DisplayName', 'Est East');
-plot(t_ds, pos_truth_ds(2,:), 'm--', 'DisplayName', 'Truth East');
-plot(t_ds, pos_est_ds(3,:), 'k', 'DisplayName', 'Est Down');
-plot(t_ds, pos_truth_ds(3,:), 'c--', 'DisplayName', 'Truth Down');
-title('Position Overlay (NED)');
-xlabel('Time Step'); ylabel('Position (m)');
-legend('Location','best'); grid on; hold off;
+labels = {'North','East','Down'};
+for idx = 1:3
+    subplot(2,3,idx);
+    plot(t_ds, pos_est_ds(idx,:), 'b', 'DisplayName', ['Est ' labels{idx}]);
+    hold on;
+    plot(t_ds, pos_truth_ds(idx,:), 'r--', 'DisplayName', ['Truth ' labels{idx}]);
+    title(['Position ' labels{idx}]);
+    if idx == 1
+        ylabel('Position (m)');
+    end
+    grid on; legend('Location','best'); hold off;
 
-subplot(2,1,2);
-plot(t_ds, vel_est_ds(1,:), 'b', 'DisplayName', 'Est North');
-hold on;
-plot(t_ds, vel_est_ds(2,:), 'g', 'DisplayName', 'Est East');
-plot(t_ds, vel_est_ds(3,:), 'k', 'DisplayName', 'Est Down');
-title('Velocity Overlay (NED)');
-xlabel('Time Step'); ylabel('Velocity (m/s)');
-legend('Location','best'); grid on; hold off;
+    subplot(2,3,idx+3);
+    plot(t_ds, vel_est_ds(idx,:), 'b', 'DisplayName', ['Est ' labels{idx}]);
+    hold on;
+    plot(t_ds, vel_truth_ds(idx,:), 'r--', 'DisplayName', ['Truth ' labels{idx}]);
+    title(['Velocity ' labels{idx}]);
+    xlabel('Time Step');
+    if idx == 1
+        ylabel('Velocity (m/s)');
+    end
+    grid on; legend('Location','best'); hold off;
+end
 
 output_file = fullfile(out_dir, sprintf('%s_task6_overlay_state_NED.pdf', run_id));
 saveas(fig, output_file);

--- a/MATLAB/task6_overlay_plot.m
+++ b/MATLAB/task6_overlay_plot.m
@@ -170,38 +170,36 @@ end
 
 % -------------------------------------------------------------------------
 function pdf_path = plot_overlay(t_est, pos_est, vel_est, acc_est, pos_truth, vel_truth, acc_truth, frame, method, dataset, out_dir)
-%PLOT_OVERLAY Create 3x3 overlay plot of fused vs truth.
+%PLOT_OVERLAY Create 2x3 overlay plot of fused vs truth.
 
 labels = {'X','Y','Z'};
 if strcmpi(frame,'NED')
     labels = {'N','E','D'};
 end
-colors = {[0.2157 0.4824 0.7216], [0.8941 0.1020 0.1098], [0.3010 0.6863 0.2902]};
-ylabels = {'Position [m]','Velocity [m/s]','Acceleration [m/s^2]'};
+    colors = {[0.2157 0.4824 0.7216], [0.8941 0.1020 0.1098], [0.3010 0.6863 0.2902]};
+    ylabels = {'Position [m]','Velocity [m/s]'};
 
-f = figure('Visible','off','Position',[100 100 900 900]);
-data_est  = {pos_est,  vel_est,  acc_est};
-data_truth = {pos_truth, vel_truth, acc_truth};
-for row = 1:3
-    for col = 1:3
-        subplot(3,3,(row-1)*3+col); hold on;
-        plot(t_est, data_est{row}(:,col), 'Color', colors{col}, 'DisplayName', ['Fused ' labels{col}]);
-        plot(t_est, data_truth{row}(:,col), '--', 'Color', colors{col}, 'DisplayName', ['Truth ' labels{col}]);
-        grid on;
-        if row == 1
-            title(labels{col});
-        end
-        if col == 1
-            ylabel(ylabels{row});
-        end
-        if row == 3
+    f = figure('Visible','off','Position',[100 100 900 600]);
+    data_est  = {pos_est,  vel_est};
+    data_truth = {pos_truth, vel_truth};
+    for row = 1:2
+        for col = 1:3
+            subplot(2,3,(row-1)*3+col); hold on;
+            plot(t_est, data_est{row}(:,col), 'Color', colors{col}, 'DisplayName', ['Fused ' labels{col}]);
+            plot(t_est, data_truth{row}(:,col), '--', 'Color', colors{col}, 'DisplayName', ['Truth ' labels{col}]);
+            grid on;
+            if row == 1
+                title(labels{col});
+            end
+            if col == 1
+                ylabel(ylabels{row});
+            end
             xlabel('Time [s]');
-        end
-        if row == 1 && col == 1
-            legend('Location','northeastoutside');
+            if row == 1 && col == 1
+                legend('Location','northeastoutside');
+            end
         end
     end
-end
 sgtitle(sprintf('%s Task 6 Overlay - %s (%s frame)', dataset, method, upper(frame)));
 set(f,'PaperPositionMode','auto');
 run_id = sprintf('%s_%s', dataset, method);

--- a/task6_overlay_plot.py
+++ b/task6_overlay_plot.py
@@ -198,12 +198,11 @@ def plot_overlay(
     labels = ["X", "Y", "Z"] if frame == "ECEF" else ["N", "E", "D"]
     colors = ["#377eb8", "#e41a1c", "#4daf4a"]  # colorblind friendly
 
-    fig, axes = plt.subplots(3, 3, figsize=(12, 9), sharex=True)
+    fig, axes = plt.subplots(2, 3, figsize=(12, 6), sharex=True)
 
     datasets = [
         (pos_est, pos_truth, "Position [m]"),
         (vel_est, vel_truth, "Velocity [m/s]"),
-        (acc_est, acc_truth, "Acceleration [m/s$^2$]"),
     ]
 
     for row, (est, truth, ylab) in enumerate(datasets):
@@ -215,8 +214,7 @@ def plot_overlay(
             ax.grid(True, alpha=0.3)
             if row == 0:
                 ax.set_title(labels[col])
-            if row == 2:
-                ax.set_xlabel("Time [s]")
+            ax.set_xlabel("Time [s]")
 
     axes[0, 0].legend(loc="upper right", ncol=3, fontsize=9, frameon=True)
 


### PR DESCRIPTION
## Summary
- update Task 6 NED overlay figure to show six subplots (3 axes columns x 2 rows)
- generate downsampled velocity truth for overlay
- match Matlab task6_overlay_plot.m to new 2x3 layout
- mirror overlay changes in task6_overlay_plot.py

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887d6a8e5a48325b5bd1ebdc39cbd1b