### PR TITLE
Improve MATLAB Task 7 error plots

### DIFF
--- a/MATLAB/Task_7.m
+++ b/MATLAB/Task_7.m
@@ -1,12 +1,12 @@
 function Task_7()
-%TASK_7 Residual analysis against STATE\_X001.txt in the ECEF frame.
-%   TASK_7() loads the fused state history ``x_log`` saved by Task 5 and
-%   the ground truth trajectory ``STATE_X001.txt``.  The estimator NED
-%   states are converted to the ECEF frame using the reference latitude and
-%   longitude from Task 5.  Residuals in position and velocity are
-%   computed after interpolating the estimator output to the truth time
-%   vector.  Summary statistics are printed and residual plots are shown
-%   interactively.  Results are written to the ``results`` directory.
+%TASK_7 Plot ECEF errors between truth and fused estimate.
+%   TASK_7() loads the fused state history ``x_log`` produced by Task 5 and
+%   the ground truth trajectory ``STATE_X001.txt``. The estimator NED states
+%   are converted to the ECEF frame using the reference latitude and
+%   longitude from Task 5. Position and velocity errors ``truth - estimate``
+%   are computed after interpolating the estimator output to the truth time
+%   vector. A figure with six subplots (position X/Y/Z on the first row,
+%   velocity X/Y/Z on the second) is generated and saved under ``results``.
 
     fprintf('--- Starting Task 7: Residual Analysis with STATE_X001.txt (ECEF) ---\n');
 
@@ -53,62 +53,64 @@ function Task_7()
     vel_est_i = interp1(t_est, vel_est_ecef', t_truth, 'linear', 'extrap')';
     fprintf('Task 7: Interpolated estimates to %d truth samples\n', numel(t_truth));
 
-    %% Compute residuals
-    fprintf('Task 7: Computing residuals...\n');
-    pos_residuals = pos_est_i - pos_truth_ecef;
-    vel_residuals = vel_est_i - vel_truth_ecef;
+    %% Compute errors (truth - estimate)
+    fprintf('Task 7: Computing errors...\n');
+    pos_error = pos_truth_ecef - pos_est_i;
+    vel_error = vel_truth_ecef - vel_est_i;
 
-    %% Residual statistics
-    pos_res_mean = mean(pos_residuals, 2);
-    pos_res_std  = std(pos_residuals, 0, 2);
-    vel_res_mean = mean(vel_residuals, 2);
-    vel_res_std  = std(vel_residuals, 0, 2);
-    fprintf('Position residual mean [m]: [%.8f %.8f %.8f]\n', pos_res_mean(1), pos_res_mean(2), pos_res_mean(3));
-    fprintf('Position residual std  [m]: [%.8f %.8f %.8f]\n', pos_res_std(1), pos_res_std(2), pos_res_std(3));
-    fprintf('Velocity residual mean [m/s]: [%.8f %.8f %.8f]\n', vel_res_mean(1), vel_res_mean(2), vel_res_mean(3));
-    fprintf('Velocity residual std  [m/s]: [%.8f %.8f %.8f]\n', vel_res_std(1), vel_res_std(2), vel_res_std(3));
+    %% Error statistics
+    pos_err_mean = mean(pos_error, 2);
+    pos_err_std  = std(pos_error, 0, 2);
+    vel_err_mean = mean(vel_error, 2);
+    vel_err_std  = std(vel_error, 0, 2);
+    fprintf('Position error mean [m]: [%.8f %.8f %.8f]\n', pos_err_mean(1), pos_err_mean(2), pos_err_mean(3));
+    fprintf('Position error std  [m]: [%.8f %.8f %.8f]\n', pos_err_std(1), pos_err_std(2), pos_err_std(3));
+    fprintf('Velocity error mean [m/s]: [%.8f %.8f %.8f]\n', vel_err_mean(1), vel_err_mean(2), vel_err_mean(3));
+    fprintf('Velocity error std  [m/s]: [%.8f %.8f %.8f]\n', vel_err_std(1), vel_err_std(2), vel_err_std(3));
 
     fprintf('Final fused_vel_ecef: [%.8f %.8f %.8f]\n', vel_est_i(1,end), vel_est_i(2,end), vel_est_i(3,end));
     fprintf('Final truth_vel_ecef: [%.8f %.8f %.8f]\n', vel_truth_ecef(1,end), vel_truth_ecef(2,end), vel_truth_ecef(3,end));
 
-    %% Plot residuals
-    fprintf('Task 7: Generating and displaying ECEF residual plots...\n');
-    fig = figure('Name', 'Task 7 - ECEF Residuals', 'Visible', 'on');
-    subplot(2,1,1);
-    plot(t_truth, pos_residuals(1,:), 'b', 'DisplayName','X'); hold on;
-    plot(t_truth, pos_residuals(2,:), 'g', 'DisplayName','Y');
-    plot(t_truth, pos_residuals(3,:), 'k', 'DisplayName','Z');
-    title('Position Residuals (ECEF)'); xlabel('Time [s]'); ylabel('Residual (m)');
-    legend('Location','best'); grid on; hold off;
-
-    subplot(2,1,2);
-    plot(t_truth, vel_residuals(1,:), 'b', 'DisplayName','VX'); hold on;
-    plot(t_truth, vel_residuals(2,:), 'g', 'DisplayName','VY');
-    plot(t_truth, vel_residuals(3,:), 'k', 'DisplayName','VZ');
-    title('Velocity Residuals (ECEF)'); xlabel('Time [s]'); ylabel('Residual (m/s)');
-    legend('Location','best'); grid on; hold off;
-
+    %% Plot errors
+    fprintf('Task 7: Generating ECEF error plots...\n');
+    fig = figure('Name', 'Task 7 - ECEF Errors', 'Visible', 'on', 'Position',[100 100 900 450]);
+    labels = {'X','Y','Z'};
+    for j = 1:3
+        subplot(2,3,j);
+        plot(t_truth, pos_error(j,:), 'k');
+        title(labels{j});
+        ylabel('Position Error [m]');
+        grid on;
+    end
+    for j = 1:3
+        subplot(2,3,3+j);
+        plot(t_truth, vel_error(j,:), 'k');
+        ylabel('Velocity Error [m/s]');
+        xlabel('Time [s]');
+        grid on;
+    end
+    sgtitle('Truth - Estimate Errors (ECEF)');
     out_pdf = fullfile(results_dir, 'IMU_X002_GNSS_X002_TRIAD_task7_3_residuals_position_velocity_ecef.pdf');
     saveas(fig, out_pdf);
-    fprintf('Task 7: Saved residual plot: %s\n', out_pdf);
+    fprintf('Task 7: Saved error plot: %s\n', out_pdf);
 
     %% Difference ranges
     fprintf('Task 7: Computing difference ranges...\n');
     directions = {'X','Y','Z'};
-    for i=1:3
-        pos_range = [min(pos_residuals(i,:)) max(pos_residuals(i,:))];
-        vel_range = [min(vel_residuals(i,:)) max(vel_residuals(i,:))];
-        pos_exceed = sum(abs(pos_residuals(i,:)) > 1);
-        vel_exceed = sum(abs(vel_residuals(i,:)) > 1);
-        fprintf('ECEF %s position diff range: %.2f m to %.2f m. %d samples exceed 1.0 m\n', ...
+    for i = 1:3
+        pos_range = [min(pos_error(i,:)) max(pos_error(i,:))];
+        vel_range = [min(vel_error(i,:)) max(vel_error(i,:))];
+        pos_exceed = sum(abs(pos_error(i,:)) > 1);
+        vel_exceed = sum(abs(vel_error(i,:)) > 1);
+        fprintf('ECEF %s position error range: %.2f m to %.2f m. %d samples exceed 1.0 m\n', ...
             directions{i}, pos_range(1), pos_range(2), pos_exceed);
-        fprintf('ECEF %s velocity diff range: %.2f m/s to %.2f m/s. %d samples exceed 1.0 m/s\n', ...
+        fprintf('ECEF %s velocity error range: %.2f m/s to %.2f m/s. %d samples exceed 1.0 m/s\n', ...
             directions{i}, vel_range(1), vel_range(2), vel_exceed);
     end
 
     %% Save results
     results_out = fullfile(results_dir, 'IMU_X002_GNSS_X002_TRIAD_task7_results.mat');
-    save(results_out, 'pos_residuals', 'vel_residuals', 'pos_est_i', 'vel_est_i');
+    save(results_out, 'pos_error', 'vel_error', 'pos_est_i', 'vel_est_i');
     fprintf('Task 7: Results saved to %s\n', results_out);
     fprintf('Task 7: Completed successfully\n');
 end


### PR DESCRIPTION
## Summary
- compute truth minus estimate errors in `Task_7.m`
- plot position and velocity errors using six subplots
- save updated statistics and figures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887dbf47a7083258ae9eaa3b7054e3f