### PR TITLE
Save truth ECEF trajectory in Task4 results

### DIFF
--- a/MATLAB/Task_4.m
+++ b/MATLAB/Task_4.m
@@ -350,6 +350,28 @@ fprintf('-> IMU-derived position, velocity, and acceleration computed for all me
 
 
 %% ========================================================================
+% Subtask 4.12b: Load truth ECEF trajectory if available
+% =========================================================================
+state_file = fullfile(fileparts(imu_path), sprintf('STATE_%s.txt', imu_name));
+truth_pos_ecef = [];
+truth_vel_ecef = [];
+truth_time = [];
+if isfile(state_file)
+    try
+        truth_data = read_state_file(state_file);
+        truth_time = truth_data(:,2);
+        truth_pos_ecef = truth_data(:,3:5);
+        truth_vel_ecef = truth_data(:,6:8);
+        fprintf('Loaded truth ECEF trajectory from %s\n', state_file);
+    catch ME
+        warning('Failed to load truth state file: %s', ME.message);
+    end
+else
+    fprintf('Truth state file not found: %s\n', state_file);
+end
+
+
+%% ========================================================================
 % Subtask 4.13: Validate and Plot Data
 % =========================================================================
 fprintf('\nSubtask 4.13: Validating and plotting data.\n');
@@ -367,21 +389,27 @@ fprintf('-> All data plots saved for all methods.\n');
 % Save GNSS positions for use by Task 5
 task4_file = fullfile(results_dir, sprintf('Task4_results_%s.mat', pair_tag));
 if isfile(task4_file)
-    save(task4_file, 'gnss_pos_ned', 'acc_biases', 'gyro_biases', 'scale_factors', '-append');
+    save(task4_file, 'gnss_pos_ned', 'acc_biases', 'gyro_biases', 'scale_factors', ...
+        'truth_pos_ecef', 'truth_vel_ecef', 'truth_time', '-append');
 else
-    save(task4_file, 'gnss_pos_ned', 'acc_biases', 'gyro_biases', 'scale_factors');
+    save(task4_file, 'gnss_pos_ned', 'acc_biases', 'gyro_biases', 'scale_factors', ...
+        'truth_pos_ecef', 'truth_vel_ecef', 'truth_time');
 end
 fprintf('GNSS NED positions saved to %s\n', task4_file);
 
 % Save method-specific results using helper
 result_struct = struct('gnss_pos_ned', gnss_pos_ned, 'acc_biases', acc_biases, ...
-                'gyro_biases', gyro_biases, 'scale_factors', scale_factors);
+                'gyro_biases', gyro_biases, 'scale_factors', scale_factors, ...
+                'truth_pos_ecef', truth_pos_ecef, 'truth_vel_ecef', truth_vel_ecef, ...
+                'truth_time', truth_time);
 save_task_results(result_struct, imu_name, gnss_name, method_tag, 4);
 % Task 5 loads these positions when initialising the Kalman filter
 
 % Return results structure and store in base workspace
 result = struct('gnss_pos_ned', gnss_pos_ned, 'acc_biases', acc_biases, ...
-                'gyro_biases', gyro_biases, 'scale_factors', scale_factors);
+                'gyro_biases', gyro_biases, 'scale_factors', scale_factors, ...
+                'truth_pos_ecef', truth_pos_ecef, 'truth_vel_ecef', truth_vel_ecef, ...
+                'truth_time', truth_time);
 assignin('base', 'task4_results', result);
 
 end % End of main function: run_task4

--- a/MATLAB/Task_7.m
+++ b/MATLAB/Task_7.m
@@ -40,10 +40,10 @@ function Task_7()
         d = struct();
     end
 
-    if isfield(d, 'truth_pos_ecef') && isfield(d, 'truth_vel_ecef')
+    if isfield(d, 'truth_pos_ecef') && isfield(d, 'truth_vel_ecef') && isfield(d, 'truth_time')
         truth_pos_ecef = d.truth_pos_ecef';
         truth_vel_ecef = d.truth_vel_ecef';
-        t_truth = (0:size(truth_pos_ecef,2)-1)';
+        t_truth = d.truth_time(:);
         fprintf('Task 7: Loaded truth ECEF from %s\n', truth_file);
     else
         fprintf('Task 7: truth_pos_ecef not found in %s. Using STATE_X001.txt\n', truth_file);
@@ -54,11 +54,6 @@ function Task_7()
         truth_pos_ecef = raw(:,3:5)';
         truth_vel_ecef = raw(:,6:8)';
     end
-
-    %% Extract truth position and velocity
-    t_truth = truth_data(:,2);
-    pos_truth_ecef = truth_data(:,3:5)';
-    vel_truth_ecef = truth_data(:,6:8)';
 
     %% Convert estimates from NED to ECEF
     C_n_e = compute_C_ECEF_to_NED(ref_lat, ref_lon)';
@@ -75,9 +70,9 @@ function Task_7()
 
     %% Compute errors (truth - estimate)
     fprintf('Task 7: Computing errors...\n');
-    pos_error = pos_truth_ecef - pos_est_i;
-    vel_error = vel_truth_ecef - vel_est_i;
-    pos_residual = pos_est_i - pos_truth_ecef;
+    pos_error = truth_pos_ecef - pos_est_i;
+    vel_error = truth_vel_ecef - vel_est_i;
+    pos_residual = pos_est_i - truth_pos_ecef;
     assert(max(abs(pos_residual), [], 'all') < 100, ...
         'Task-7: Position residual blew up - transform error?');
 
@@ -95,7 +90,7 @@ function Task_7()
     fprintf('Velocity error std  [m/s]: [%.8f %.8f %.8f]\n', vel_err_std(1), vel_err_std(2), vel_err_std(3));
 
     fprintf('Final fused_vel_ecef: [%.8f %.8f %.8f]\n', vel_est_i(1,end), vel_est_i(2,end), vel_est_i(3,end));
-    fprintf('Final truth_vel_ecef: [%.8f %.8f %.8f]\n', vel_truth_ecef(1,end), vel_truth_ecef(2,end), vel_truth_ecef(3,end));
+    fprintf('Final truth_vel_ecef: [%.8f %.8f %.8f]\n', truth_vel_ecef(1,end), truth_vel_ecef(2,end), truth_vel_ecef(3,end));
     fprintf('[SUMMARY] method=KF rmse_pos=%.2f m final_pos=%.2f m ', ...
             sqrt(mean(sum(pos_error.^2,2))), final_pos);
     fprintf('rmse_vel=%.2f m/s final_vel=%.2f m/s\n', ...

--- a/src/GNSS_IMU_Fusion.py
+++ b/src/GNSS_IMU_Fusion.py
@@ -919,6 +919,7 @@ def main():
     t_rel_gnss = gnss_time - t0
     truth_pos_ecef_i = truth_vel_ecef_i = None
     truth_pos_ned_i = truth_vel_ned_i = None
+    t_truth = pos_truth_ecef = vel_truth_ecef = None
     if truth_file:
         try:
             truth = np.loadtxt(truth_file, comments="#")
@@ -1938,6 +1939,9 @@ def main():
         fused_vel=fused_vel[method],
         pos_ecef=pos_ecef,
         vel_ecef=vel_ecef,
+        truth_pos_ecef=pos_truth_ecef if pos_truth_ecef is not None else np.array([]),
+        truth_vel_ecef=vel_truth_ecef if vel_truth_ecef is not None else np.array([]),
+        truth_time=t_truth if t_truth is not None else np.array([]),
         pos_body=pos_body,
         vel_body=vel_body,
         innov_pos=innov_pos_all[method],
@@ -1973,6 +1977,9 @@ def main():
             "fused_vel": fused_vel[method],
             "pos_ecef": pos_ecef,
             "vel_ecef": vel_ecef,
+            "truth_pos_ecef": pos_truth_ecef if pos_truth_ecef is not None else np.empty((0, 3)),
+            "truth_vel_ecef": vel_truth_ecef if vel_truth_ecef is not None else np.empty((0, 3)),
+            "truth_time": t_truth if t_truth is not None else np.empty(0),
             "pos_body": pos_body,
             "vel_body": vel_body,
             "innov_pos": innov_pos_all[method],


### PR DESCRIPTION
## Summary
- Capture available STATE_X truth data in Task_4 and store `truth_pos_ecef`, `truth_vel_ecef`, and `truth_time` alongside existing GNSS bias outputs.
- Load these truth fields in Task_7 when available, avoiding a second parse of STATE_X logs.
- Extend the Python GNSS/IMU fusion pipeline to save the same truth arrays in its NPZ/MAT result files for parity.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689461c78d108325933eeeb60591a724