### PR TITLE
refactor: simplify Task 7 truth handling

### DIFF
--- a/MATLAB/Task_7.m
+++ b/MATLAB/Task_7.m
@@ -42,21 +42,26 @@ function Task_7()
     end
 
     if isfield(d, 'truth_pos_ecef') && isfield(d, 'truth_vel_ecef')
+        % Task 4 results already provide truth in ECEF. Construct a matrix
+        % ``truth_data`` so downstream tasks can access the same column
+        % layout as the STATE text file: [index, time, pos(3), vel(3)].
+        idx = (0:size(d.truth_pos_ecef,2)-1)';
         truth_pos_ecef = d.truth_pos_ecef';
         truth_vel_ecef = d.truth_vel_ecef';
-        t_truth = (0:size(truth_pos_ecef,2)-1)';
+        truth_data = [idx, idx, truth_pos_ecef', truth_vel_ecef'];
         fprintf('Task 7: Loaded truth ECEF from %s\n', truth_file);
     else
         fprintf('Task 7: truth_pos_ecef not found in %s. Using STATE_X001.txt\n', truth_file);
         root_dir = fileparts(fileparts(results_dir));
         state_file = fullfile(root_dir, 'STATE_X001.txt');
         raw = read_state_file(state_file);
-        t_truth = raw(:,2); % time column in seconds
-        truth_pos_ecef = raw(:,3:5)';
-        truth_vel_ecef = raw(:,6:8)';
+        truth_data = raw; % retain full dataset for later tasks
     end
-    pos_truth_ecef = truth_pos_ecef;
-    vel_truth_ecef = truth_vel_ecef;
+
+    %% Extract truth position and velocity
+    t_truth = truth_data(:,2);
+    pos_truth_ecef = truth_data(:,3:5)';
+    vel_truth_ecef = truth_data(:,6:8)';
 
     %% Convert estimates from NED to ECEF
     C_n_e = compute_C_ECEF_to_NED(ref_lat, ref_lon)';

--- a/MATLAB/Task_7.m
+++ b/MATLAB/Task_7.m
@@ -44,6 +44,8 @@ function Task_7()
         truth_pos_ecef = d.truth_pos_ecef';
         truth_vel_ecef = d.truth_vel_ecef';
         t_truth = (0:size(truth_pos_ecef,2)-1)';
+        pos_truth_ecef = truth_pos_ecef;
+        vel_truth_ecef = truth_vel_ecef;
         fprintf('Task 7: Loaded truth ECEF from %s\n', truth_file);
     else
         fprintf('Task 7: truth_pos_ecef not found in %s. Using STATE_X001.txt\n', truth_file);
@@ -53,12 +55,9 @@ function Task_7()
         t_truth = raw(:,2); % time column in seconds
         truth_pos_ecef = raw(:,3:5)';
         truth_vel_ecef = raw(:,6:8)';
+        pos_truth_ecef = truth_pos_ecef;
+        vel_truth_ecef = truth_vel_ecef;
     end
-
-    %% Extract truth position and velocity
-    t_truth = truth_data(:,2);
-    pos_truth_ecef = truth_data(:,3:5)';
-    vel_truth_ecef = truth_data(:,6:8)';
 
     %% Convert estimates from NED to ECEF
     C_n_e = compute_C_ECEF_to_NED(ref_lat, ref_lon)';

--- a/MATLAB/Task_7.m
+++ b/MATLAB/Task_7.m
@@ -1,3 +1,4 @@
+
 function Task_7()
 %TASK_7 Plot ECEF residuals between truth and fused estimate.
 %   TASK_7() loads the fused state history ``x_log`` produced by Task 5 and
@@ -44,8 +45,6 @@ function Task_7()
         truth_pos_ecef = d.truth_pos_ecef';
         truth_vel_ecef = d.truth_vel_ecef';
         t_truth = (0:size(truth_pos_ecef,2)-1)';
-        pos_truth_ecef = truth_pos_ecef;
-        vel_truth_ecef = truth_vel_ecef;
         fprintf('Task 7: Loaded truth ECEF from %s\n', truth_file);
     else
         fprintf('Task 7: truth_pos_ecef not found in %s. Using STATE_X001.txt\n', truth_file);
@@ -55,9 +54,9 @@ function Task_7()
         t_truth = raw(:,2); % time column in seconds
         truth_pos_ecef = raw(:,3:5)';
         truth_vel_ecef = raw(:,6:8)';
-        pos_truth_ecef = truth_pos_ecef;
-        vel_truth_ecef = truth_vel_ecef;
     end
+    pos_truth_ecef = truth_pos_ecef;
+    vel_truth_ecef = truth_vel_ecef;
 
     %% Convert estimates from NED to ECEF
     C_n_e = compute_C_ECEF_to_NED(ref_lat, ref_lon)';


### PR DESCRIPTION
## Summary
- remove unused `truth_data` extraction in Task 7 and rely directly on `truth_pos_ecef`/`truth_vel_ecef`
- ensure truth position and velocity arrays are assigned when ground truth is loaded

## Testing
- `octave -qf --eval "addpath('MATLAB'); Task_7"` *(fails: unable to find required `IMU_X002_GNSS_X002_TRIAD_task5_results.mat`)*
- `pytest tests/test_assemble_frames.py`


------
https://chatgpt.com/codex/tasks/task_e_689461c7924c8325addfa17956c370f5