### PR TITLE
Align Task 7 truth variable naming

### DIFF
--- a/MATLAB/Task_7.m
+++ b/MATLAB/Task_7.m
@@ -55,6 +55,9 @@ function Task_7()
         truth_vel_ecef = raw(:,6:8)';
     end
 
+    pos_truth_ecef = truth_pos_ecef;
+    vel_truth_ecef = truth_vel_ecef;
+
     %% Convert estimates from NED to ECEF
     C_n_e = compute_C_ECEF_to_NED(ref_lat, ref_lon)';
     fprintf('Task 7: Extracting and converting estimates to ECEF...\n');
@@ -73,7 +76,7 @@ function Task_7()
     pos_error = truth_pos_ecef - pos_est_i;
     vel_error = truth_vel_ecef - vel_est_i;
     pos_residual = pos_est_i - truth_pos_ecef;
-    assert(max(abs(pos_residual), [], 'all') < 100, ...
+    assert(max(abs(pos_residual(:))) < 100, ...
         'Task-7: Position residual blew up - transform error?');
 
     final_pos = norm(pos_error(:,end));


### PR DESCRIPTION
## Summary
- expose `pos_truth_ecef` and `vel_truth_ecef` directly after loading truth data in Task 7
- simplify residual check to avoid Octave/MATLAB incompatibilities

## Testing
- `octave -qf --path MATLAB --eval "Task_7"`
- `PYTHONPATH=src python task7_ecef_residuals_plot.py --est-file fused_estimate.npz --imu-file IMU_X002_small.dat --gnss-file GNSS_X002_small.csv --truth-file STATE_X001.txt --dataset IMU_X002_small.dat --gnss GNSS_X002_small.csv --method TRIAD --output-dir python_results`


------
https://chatgpt.com/codex/tasks/task_e_6894841751148325a4f1316191681cc5