### PR TITLE
Apply Task 4 accelerometer scale factor during fusion

### DIFF
--- a/src/GNSS_IMU_Fusion.py
+++ b/src/GNSS_IMU_Fusion.py
@@ -4,6 +4,10 @@ This script mirrors the MATLAB ``GNSS_IMU_Fusion.m`` workflow and provides
 the same command-line interface.  It performs attitude initialisation and
 extended Kalman filtering given IMU and GNSS logs.
 
+The accelerometer scale factor estimated in Task 4 is applied once when
+correcting raw accelerometer measurements.  If no prior estimate exists a
+neutral factor of ``1.0`` is used.
+
 Usage
 -----
 python src/GNSS_IMU_Fusion.py --imu-file IMU_X001.dat --gnss-file GNSS_X001.csv


### PR DESCRIPTION
## Summary
- load Task 4 accelerometer scale factor when available and default to 1.0 otherwise
- apply scale factor once during accelerometer bias correction
- document scale factor convention in MATLAB Task_5 and Python GNSS_IMU_Fusion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68950214bbf48325aa415e9f5f021df1