### PR TITLE
Export KF time vector for MATLAB Task 7

### DIFF
--- a/MATLAB/Task_7.m
+++ b/MATLAB/Task_7.m
@@ -27,12 +27,27 @@ function Task_7()
     if isfield(S5, 't_est') && isfield(S5, 'dt')
         t_est = S5.t_est(:);
         dt    = S5.dt;
-    elseif isfield(S5, 'x_log') && isfield(S5, 'imu_rate_hz')
-        N      = size(S5.x_log, 2);
-        dt     = 1 / S5.imu_rate_hz;
-        t_est  = (0:N-1)' * dt;
     else
-        error('Task_7: estimator time vector missing and dt not provided.');
+        time_file = fullfile(results_dir, sprintf('%s_task5_time.mat', run_id));
+        if isfile(time_file)
+            Stime = load(time_file, 't_est', 'dt', 'x_log');
+            if isfield(Stime, 't_est') && isfield(Stime, 'dt')
+                t_est = Stime.t_est(:);
+                dt    = Stime.dt;
+                if ~exist('x_log', 'var') || isempty(x_log)
+                    if isfield(Stime, 'x_log'); x_log = Stime.x_log; end
+                end
+            end
+        end
+        if ~(exist('t_est','var') && exist('dt','var'))
+            if isfield(S5, 'x_log') && isfield(S5, 'imu_rate_hz')
+                N     = size(S5.x_log, 2);
+                dt    = 1 / S5.imu_rate_hz;
+                t_est = (0:N-1)' * dt;
+            else
+                error('Task_7: estimator time vector missing and dt not provided.');
+            end
+        end
     end
     ref_lat = S5.ref_lat;
     ref_lon = S5.ref_lon;

--- a/src/run_triad_only.py
+++ b/src/run_triad_only.py
@@ -29,6 +29,7 @@ from typing import Iterable, List, Dict
 import numpy as np
 import pandas as pd
 from scipy.spatial.transform import Rotation as R
+import scipy.io as sio
 from tabulate import tabulate
 
 from evaluate_filter_results import run_evaluation_npz
@@ -255,6 +256,18 @@ def main(argv: Iterable[str] | None = None) -> None:
             "quat_log": quat,
         }
         save_mat(npz_path.with_suffix(".mat"), mat_out)
+
+        # ------------------------------------------------------------------
+        # Export estimator time vector and sampling interval for MATLAB Task 7
+        # ------------------------------------------------------------------
+        x_log = data.get("x_log")
+        if x_log is not None and time_s is not None:
+            imu_dt = float(np.mean(np.diff(time_s)))
+            t_est = np.arange(x_log.shape[1]) * imu_dt
+            mat_time = {"t_est": t_est, "dt": imu_dt, "x_log": x_log}
+            time_path = results_dir / f"{tag}_task5_time.mat"
+            sio.savemat(str(time_path), mat_time)
+            logger.info("Saved Task 5 time data to %s", time_path)
 
         logger.info(
             "Subtask 6.8.2: Plotted %s position North: First = %.4f, Last = %.4f",


### PR DESCRIPTION
## Summary
- Save estimator time vector and sampling interval from run_triad_only
- Load new Task 5 time export in MATLAB Task_7 to avoid missing t_est/dt

## Testing
- `pytest -q`
- `python src/run_triad_only.py --no-plots`
- `ls results/IMU_X002_GNSS_X002_TRIAD*task5_time.mat`
- Attempted `apt-get install -y octave` (failed: ca-certificates-java post-installation error)


------
https://chatgpt.com/codex/tasks/task_e_68951a99613c832589b3141aa7772b8d