### PR TITLE
Add MATLAB frame comparison helper and expose utils path

### DIFF
--- a/MATLAB/Task_4.m
+++ b/MATLAB/Task_4.m
@@ -14,6 +14,9 @@ function result = Task_4(imu_path, gnss_path, method)
 % Usage:
 %   Task_4(imu_path, gnss_path, method)
 
+% add utils folder to path
+addpath(fullfile(fileparts(fileparts(mfilename('fullpath'))),'src','utils'));
+
 if nargin < 1 || isempty(imu_path)
     error('IMU file not specified');
 end

--- a/MATLAB/Task_6.m
+++ b/MATLAB/Task_6.m
@@ -15,6 +15,9 @@ function Task_6(task5_file, imu_path, gnss_path, truth_file)
 % Usage:
 %   Task_6(task5_file, imu_path, gnss_path, truth_file)
 
+% add utils folder to path
+addpath(fullfile(fileparts(fileparts(mfilename('fullpath'))),'src','utils'));
+
 if nargin < 4
     error('Task_6:BadArgs', 'Expected TASK5_FILE, IMU_PATH, GNSS_PATH, TRUTH_FILE');
 end

--- a/MATLAB/run_triad_only.m
+++ b/MATLAB/run_triad_only.m
@@ -20,6 +20,8 @@ else
     script_dir = fileparts(mfilename('fullpath'));
 end
 addpath(script_dir);
+% add utils folder to path
+addpath(fullfile(fileparts(script_dir),'src','utils'));
 
 imu_file  = 'IMU_X002.dat';
 gnss_file = 'GNSS_X002.csv';

--- a/MATLAB/task5_plot_comparison.m
+++ b/MATLAB/task5_plot_comparison.m
@@ -13,6 +13,9 @@ function task5_plot_comparison(run_id)
 %
 %   See also: plot_frame_comparison, Task_5
 
+% add utils folder to path
+addpath(fullfile(fileparts(fileparts(mfilename('fullpath'))),'src','utils'));
+
     if nargin < 1 || isempty(run_id)
         error('task5_plot_comparison:MissingRunID', 'RUN_ID is required');
     end


### PR DESCRIPTION
## Summary
- add `plot_frame_comparison.m` helper for plotting three-axis data in multiple frames and saving PDF/PNG
- ensure MATLAB tasks and run script include `src/utils` on the path

## Testing
- `octave --no-gui --silent --eval "clear; run_triad_only"` *(fails: command not found: octave)*

------
https://chatgpt.com/codex/tasks/task_e_689522058bd0832583ba0c50e714d3cd