### PR TITLE
Align MATLAB Task 6 via cross-correlation and unify overlay plots

### DIFF
--- a/MATLAB/compute_time_shift.m
+++ b/MATLAB/compute_time_shift.m
@@ -1,0 +1,38 @@
+function [lag, t_shift] = compute_time_shift(est_series, truth_series, dt)
+%COMPUTE_TIME_SHIFT Estimate sample lag between estimate and truth.
+%   [LAG, T_SHIFT] = COMPUTE_TIME_SHIFT(EST_SERIES, TRUTH_SERIES, DT) returns
+%   the integer sample lag LAG that maximises the cross-correlation between
+%   EST_SERIES and TRUTH_SERIES. The corresponding time shift is
+%   T_SHIFT = LAG * DT. Positive LAG means the truth data starts later than
+%   the estimate.
+%
+%   Inputs:
+%     est_series   - estimator samples (Nx1)
+%     truth_series - truth samples    (Mx1)
+%     dt           - sample interval of the estimator [s]
+%
+%   Outputs:
+%     lag      - best integer lag in samples (truth relative to estimate)
+%     t_shift  - corresponding time shift [s]
+%
+%   The series are demeaned before computing the cross-correlation to avoid
+%   bias. This function mirrors the alignment step in the Python
+%   ``assemble_frames`` implementation.
+%
+%   Example:
+%       [lag, t0] = compute_time_shift(est(:,1), truth(:,1), 0.01);
+%
+%   See also XCORR.
+
+    if nargin < 3
+        error('compute_time_shift:NotEnoughInputs', 'Need EST_SERIES, TRUTH_SERIES and DT');
+    end
+    est_series = est_series(:) - mean(est_series);
+    truth_series = truth_series(:) - mean(truth_series);
+
+    corr = xcorr(est_series, truth_series);
+    [~, idx] = max(corr);
+    lag = idx - numel(est_series);
+    t_shift = lag * dt;
+end
+

--- a/MATLAB/save_overlay_state.m
+++ b/MATLAB/save_overlay_state.m
@@ -1,0 +1,53 @@
+function save_overlay_state(t, est_pos, est_vel, truth_pos, truth_vel, frame, run_id, method, out_dir)
+%SAVE_OVERLAY_STATE Plot fused vs. truth position and velocity.
+%   SAVE_OVERLAY_STATE(T, EST_POS, EST_VEL, TRUTH_POS, TRUTH_VEL, FRAME,
+%   RUN_ID, METHOD, OUT_DIR) creates a 2x3 subplot figure mirroring the
+%   Python ``plot_overlay`` used in Task 6. ``FRAME`` is one of 'NED',
+%   'ECEF' or 'Body'.  The figure is saved as
+%   ``<run_id>_task6_overlay_state_<frame>.pdf`` and ``.png`` in OUT_DIR.
+%
+%   This helper ensures parity between MATLAB and Python visualisations.
+%
+%   Example:
+%       save_overlay_state(t, pos, vel, truth_p, truth_v, 'NED', run_id, method, out_dir);
+
+    labels = {'X','Y','Z'};
+    if strcmpi(frame, 'NED')
+        labels = {'N','E','D'};
+    end
+    colors = [0.2157 0.4824 0.7216; 0.8941 0.1020 0.1098; 0.3010 0.6863 0.2902];
+
+    f = figure('Visible','off','Position',[100 100 900 450]);
+    data_est = {est_pos, est_vel};
+    data_truth = {truth_pos, truth_vel};
+    ylabels = {'Position [m]','Velocity [m/s]'};
+
+    for row = 1:2
+        for col = 1:3
+            subplot(2,3,(row-1)*3 + col); hold on; grid on;
+            plot(t, data_est{row}(:,col), 'Color', colors(col,:), ...
+                'DisplayName', ['Fused ' labels{col}]);
+            plot(t, data_truth{row}(:,col), '--', 'Color', colors(col,:), ...
+                'DisplayName', ['Truth ' labels{col}]);
+            if col == 1
+                ylabel(ylabels{row});
+            end
+            xlabel('Time [s]');
+            if row == 1
+                title(labels{col});
+            end
+            if row == 1 && col == 1
+                legend('Location','northeastoutside');
+            end
+            hold off;
+        end
+    end
+    sgtitle(sprintf('%s Task 6 Overlay — %s (%s frame)', run_id, method, frame));
+    pdf_file = fullfile(out_dir, sprintf('%s_task6_overlay_state_%s.pdf', run_id, frame));
+    png_file = strrep(pdf_file, '.pdf', '.png');
+    set(f,'PaperPositionMode','auto');
+    print(f, pdf_file, '-dpdf', '-bestfit');
+    print(f, png_file, '-dpng');
+    close(f);
+end
+


### PR DESCRIPTION
## Summary
- detect missing truth timestamps in Task_6 and align truth/estimate via cross-correlation
- add `compute_time_shift` and use it to shift truth data before plotting
- generate NED/ECEF/Body overlays with `save_overlay_state` using Python-style filenames

## Testing
- `pytest tests/test_task6_rmse_plot.py -q`
- `pytest tests/test_task6_length_handling.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68952b995cf48325956d691f4ce6db50