### PR TITLE
Persist IMU sample timing for Task 7 residual analysis

### DIFF
--- a/MATLAB/Task_5.m
+++ b/MATLAB/Task_5.m
@@ -689,6 +689,9 @@ fclose(fid_sum);
 % Persist IMU and GNSS time vectors for Tasks 6 and 7
 time      = imu_time; %#ok<NASGU>  used by Task_6
 gnss_time = gnss_time; %#ok<NASGU>
+t_est = imu_time; %#ok<NASGU> time vector for downstream tasks
+dt = dt_imu; %#ok<NASGU> IMU sample interval
+imu_rate_hz = 1 / dt_imu; %#ok<NASGU> IMU sampling rate
 
 % Convenience fields matching the Python pipeline
 pos_ned = x_log(1:3,:)';
@@ -705,7 +708,7 @@ save(results_file, 'gnss_pos_ned', 'gnss_vel_ned', 'gnss_accel_ned', ...
     'gnss_pos_ecef', 'gnss_vel_ecef', 'gnss_accel_ecef', ...
     'x_log', 'vel_log', 'accel_from_vel', 'euler_log', 'zupt_log', 'zupt_vel_norm', ...
     'time', 'gnss_time', 'pos_ned', 'vel_ned', 'ref_lat', 'ref_lon', 'ref_r0', ...
-    'states');
+    'states', 't_est', 'dt', 'imu_rate_hz');
 % Provide compatibility with the Python pipeline and downstream tasks
 % by storing the fused position under the generic ``pos`` field as well.
 pos = pos_ned; %#ok<NASGU>
@@ -722,6 +725,11 @@ try
 catch
     warning('Task 5: Failed to verify x_log save in %s', results_file);
 end
+
+% Export estimator time vector for compatibility with Python pipeline
+time_file = fullfile(results_dir, sprintf('%s_task5_time.mat', tag));
+save(time_file, 't_est', 'dt', 'x_log');
+fprintf('Task 5: Saved time vector to %s\n', time_file);
 
     method_struct = struct('gnss_pos_ned', gnss_pos_ned, 'gnss_vel_ned', gnss_vel_ned, ...
         'gnss_accel_ned', gnss_accel_ned, 'gnss_pos_ecef', gnss_pos_ecef, ...

--- a/src/run_triad_only.py
+++ b/src/run_triad_only.py
@@ -182,6 +182,12 @@ def main(argv: Iterable[str] | None = None) -> None:
         time_s = data.get("time_s")
         if time_s is None:
             time_s = data.get("time")
+        if time_s is not None and len(time_s) > 1:
+            imu_dt = float(np.mean(np.diff(time_s)))
+            imu_rate_hz = 1.0 / imu_dt
+        else:
+            imu_dt = None
+            imu_rate_hz = None
 
         pos_ned = data.get("pos_ned_m")
         if pos_ned is None:
@@ -239,6 +245,7 @@ def main(argv: Iterable[str] | None = None) -> None:
 
         mat_out = {
             "time_s": time_s,
+            "t_est": time_s,
             "pos_ned_m": pos_ned,
             "vel_ned_ms": vel_ned,
             "pos_ecef_m": pos_ecef,
@@ -250,6 +257,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             "ref_r0_m": ref_r0,
             "att_quat": quat,
             "method_name": method,
+            "dt": imu_dt,
+            "imu_rate_hz": imu_rate_hz,
             # Consistent fused data for Tasks 5 and 6
             "fused_pos": pos_ned,
             "fused_vel": vel_ned,
@@ -261,8 +270,7 @@ def main(argv: Iterable[str] | None = None) -> None:
         # Export estimator time vector and sampling interval for MATLAB Task 7
         # ------------------------------------------------------------------
         x_log = data.get("x_log")
-        if x_log is not None and time_s is not None:
-            imu_dt = float(np.mean(np.diff(time_s)))
+        if x_log is not None and imu_dt is not None:
             t_est = np.arange(x_log.shape[1]) * imu_dt
             mat_time = {"t_est": t_est, "dt": imu_dt, "x_log": x_log}
             time_path = results_dir / f"{tag}_task5_time.mat"


### PR DESCRIPTION
## Summary
- Record estimator time vector, sample interval, and IMU rate in Task 5 results
- Export Task 5 timing to auxiliary MAT file for compatibility with residual analysis
- Include timing metadata in Python `run_triad_only` outputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68952abe856083259434c4766f27b0f2