### PR TITLE
Add TRIAD basis helper and scale factor check

### DIFF
--- a/MATLAB/Task_5.m
+++ b/MATLAB/Task_5.m
@@ -18,7 +18,7 @@ function result = Task_5(imu_path, gnss_path, method, gnss_pos_ned, varargin)
 %       'gyro_bias_noise'  - gyroscope bias random walk                 [rad/s]  (1e-5)
 %       'vel_q_scale'      - scale for Q(4:6,4:6) velocity process noise [-]      (10.0)
 %       'vel_r'            - R(4:6,4:6) velocity measurement variance   [m^2/s^2] (0.25)
-%       'scale_factor'     - accelerometer scale factor                 [-]      (1.0)
+%       'scale_factor'     - accelerometer scale factor                 [-]      (required)
 
 % add utils folder to path
 addpath(genpath(fullfile(fileparts(mfilename('fullpath')),'utils')));
@@ -177,7 +177,11 @@ addpath(genpath(fullfile(fileparts(mfilename('fullpath')),'utils')));
     end
     % Use accelerometer scale factor from Task 2 when not supplied
     if isempty(scale_factor)
-        scale_factor = accel_scale;
+        if ~isempty(accel_scale) && isfinite(accel_scale)
+            scale_factor = accel_scale;
+        else
+            error('Task 5: accel_scale missing from Task 2/4 output');
+        end
     end
     % Biases are provided by Task 2. Do not override them with
     % dataset-specific constants so that both MATLAB and Python remain

--- a/MATLAB/utils/dcm_to_quat.m
+++ b/MATLAB/utils/dcm_to_quat.m
@@ -1,0 +1,43 @@
+function q = dcm_to_quat(C)
+% DCM_TO_QUAT  Convert rotation matrix to quaternion [qw qx qy qz].
+%   q = DCM_TO_QUAT(C) returns the quaternion corresponding to rotation
+%   matrix C.  The function assumes a passive rotation matrix (body->NED
+%   or similar) but is convention agnostic.
+%
+%   Usage:
+%       q = dcm_to_quat(C)
+
+    assert(all(size(C)==[3 3]), 'dcm_to_quat expects 3x3');
+    tr = trace(C);
+    if tr > 0
+        S = sqrt(tr + 1.0) * 2;
+        qw = 0.25 * S;
+        qx = (C(3,2) - C(2,3)) / S;
+        qy = (C(1,3) - C(3,1)) / S;
+        qz = (C(2,1) - C(1,2)) / S;
+    else
+        [~, i] = max([C(1,1), C(2,2), C(3,3)]);
+        switch i
+            case 1
+                S = sqrt(1.0 + C(1,1) - C(2,2) - C(3,3)) * 2;
+                qw = (C(3,2) - C(2,3)) / S;
+                qx = 0.25 * S;
+                qy = (C(1,2) + C(2,1)) / S;
+                qz = (C(1,3) + C(3,1)) / S;
+            case 2
+                S = sqrt(1.0 + C(2,2) - C(1,1) - C(3,3)) * 2;
+                qw = (C(1,3) - C(3,1)) / S;
+                qx = (C(1,2) + C(2,1)) / S;
+                qy = 0.25 * S;
+                qz = (C(2,3) + C(3,2)) / S;
+            otherwise
+                S = sqrt(1.0 + C(3,3) - C(1,1) - C(2,2)) * 2;
+                qw = (C(2,1) - C(1,2)) / S;
+                qx = (C(1,3) + C(3,1)) / S;
+                qy = (C(2,3) + C(3,2)) / S;
+                qz = 0.25 * S;
+        end
+    end
+    q = [qw qx qy qz];
+end
+

--- a/MATLAB/utils/ecef_ned_rot.m
+++ b/MATLAB/utils/ecef_ned_rot.m
@@ -1,0 +1,19 @@
+function [R_en, R_ne] = ecef_ned_rot(lat_rad, lon_rad)
+%ECEF_NED_ROT  Rotation matrices between ECEF and NED frames.
+%   [R_en, R_ne] = ECEF_NED_ROT(lat_rad, lon_rad) returns the rotation
+%   matrix from ECEF to NED (R_en) and its transpose (NED to ECEF, R_ne).
+%
+%   Usage:
+%       [R_en, R_ne] = ecef_ned_rot(lat_rad, lon_rad)
+%
+%   Inputs are latitude and longitude in radians.
+
+    sL = sin(lat_rad); cL = cos(lat_rad);
+    sLmbd = sin(lon_rad); cLmbd = cos(lon_rad);
+
+    R_en = [ -sL*cLmbd, -sL*sLmbd,  cL;
+             -sLmbd,      cLmbd,    0;
+             -cL*cLmbd, -cL*sLmbd, -sL ];
+    R_ne = R_en.';
+end
+

--- a/MATLAB/utils/triad_matrix.m
+++ b/MATLAB/utils/triad_matrix.m
@@ -1,0 +1,48 @@
+function T = triad_matrix(v1, v2)
+% TRIAD_MATRIX  Build 3x3 orthonormal basis given two non-collinear 3x1 vectors.
+%   T = TRIAD_MATRIX(v1, v2) returns a matrix whose columns are an
+%   orthonormal basis built from primary vector v1 and secondary vector v2.
+%   v1 and v2 must be 3-element vectors.
+%
+%   Usage:
+%       T = triad_matrix(v1, v2)
+%
+%   The basis vectors are:
+%       t1 = v1 / norm(v1)
+%       t2 = normalized component of v2 orthogonal to t1
+%       t3 = t1 x t2 (right-handed)
+%
+%   Errors if inputs are near zero or collinear.
+
+    arguments
+        v1 (1,3) double
+        v2 (1,3) double
+    end
+
+    v1 = v1(:); v2 = v2(:);
+    assert(numel(v1)==3 && numel(v2)==3, 'triad_matrix: inputs must be 3-vectors');
+
+    n1 = norm(v1);
+    n2 = norm(v2);
+    if n1 < 1e-12
+        error('triad_matrix: primary vector near zero');
+    end
+    if n2 < 1e-12
+        error('triad_matrix: secondary vector near zero');
+    end
+
+    t1 = v1 / n1;
+    v2p = v2 - (t1.' * v2) * t1;
+    n2p = norm(v2p);
+    if n2p < 1e-12
+        error('triad_matrix: vectors are collinear; cannot build basis');
+    end
+    t2 = v2p / n2p;
+    t3 = cross(t1, t2);
+    t3 = t3 / norm(t3);
+    if abs(det([t1 t2 t3])) < 1e-6
+        error('triad_matrix: degenerate basis (det ~ 0)');
+    end
+    T = [t1 t2 t3];
+end
+

--- a/src/utils/frames.py
+++ b/src/utils/frames.py
@@ -1,0 +1,36 @@
+"""Frame rotation helpers.
+
+Provides tested ECEF↔NED rotation matrices, matching MATLAB's
+``ecef_ned_rot`` utility.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+
+def ecef_to_ned(lat_rad: float, lon_rad: float) -> tuple[np.ndarray, np.ndarray]:
+    """Return rotation matrices between ECEF and NED frames.
+
+    Parameters
+    ----------
+    lat_rad, lon_rad : float
+        Geodetic latitude and longitude in radians.
+
+    Returns
+    -------
+    R_en, R_ne : ndarray
+        ``R_en`` maps ECEF vectors to NED; ``R_ne`` is its transpose.
+    """
+
+    sL = np.sin(lat_rad)
+    cL = np.cos(lat_rad)
+    sLam = np.sin(lon_rad)
+    cLam = np.cos(lon_rad)
+
+    R_en = np.array([
+        [-sL * cLam, -sL * sLam, cL],
+        [-sLam, cLam, 0.0],
+        [-cL * cLam, -cL * sLam, -sL],
+    ])
+    return R_en, R_en.T
+

--- a/src/utils/triad.py
+++ b/src/utils/triad.py
@@ -1,0 +1,50 @@
+"""TRIAD basis construction utilities.
+
+This module mirrors :func:`triad_matrix` in the MATLAB utilities.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+
+def triad_matrix(v1: np.ndarray, v2: np.ndarray) -> np.ndarray:
+    """Return a 3x3 orthonormal basis from two 3-vectors.
+
+    Parameters
+    ----------
+    v1, v2 : ndarray, shape (3,)
+        Primary and secondary direction vectors.
+
+    Returns
+    -------
+    ndarray, shape (3, 3)
+        Columns ``[t1, t2, t3]`` forming a right-handed basis.
+
+    Raises
+    ------
+    ValueError
+        If vectors are near zero or collinear.
+    """
+
+    v1 = np.asarray(v1).reshape(3)
+    v2 = np.asarray(v2).reshape(3)
+    n1 = np.linalg.norm(v1)
+    n2 = np.linalg.norm(v2)
+    if n1 < 1e-12:
+        raise ValueError("triad_matrix: primary vector near zero")
+    if n2 < 1e-12:
+        raise ValueError("triad_matrix: secondary vector near zero")
+
+    t1 = v1 / n1
+    v2p = v2 - t1 * np.dot(t1, v2)
+    n2p = np.linalg.norm(v2p)
+    if n2p < 1e-12:
+        raise ValueError("triad_matrix: vectors are collinear; cannot build basis")
+    t2 = v2p / n2p
+    t3 = np.cross(t1, t2)
+    t3 /= np.linalg.norm(t3)
+    T = np.column_stack((t1, t2, t3))
+    if abs(np.linalg.det(T)) < 1e-6:
+        raise ValueError("triad_matrix: degenerate basis (det ~ 0)")
+    return T
+


### PR DESCRIPTION
## Summary
- add triad_matrix, ecef_ned_rot, and dcm_to_quat helpers for MATLAB and matching Python utilities
- use triad_matrix in Task 3, save quaternion/rotation outputs for later tasks
- estimate accelerometer scale in Task 4 with dynamic check and require scale in Task 5

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895e119ffd48325822dd94312987853