### PR TITLE
Refactor MATLAB driver and plot handling

### DIFF
--- a/MATLAB/+cfg/default_cfg.m
+++ b/MATLAB/+cfg/default_cfg.m
@@ -1,0 +1,17 @@
+function s = default_cfg()
+%DEFAULT_CFG  Central place for run-time policy (no hidden defaults in tasks).
+p = project_paths();
+s = struct();
+s.dataset_id = '';        % must be set by caller
+s.method     = '';        % must be set by caller
+s.imu_file   = '';
+s.gnss_file  = '';
+s.truth_file = '';
+
+s.paths = p;
+
+s.plots = struct( ...
+    'popup_figures', true, ...
+    'save_pdf',      true, ...
+    'save_png',      true);
+end

--- a/MATLAB/Task_5.m
+++ b/MATLAB/Task_5.m
@@ -23,6 +23,11 @@ function result = Task_5(imu_path, gnss_path, method, gnss_pos_ned, varargin)
 % add utils folder to path
 addpath(genpath(fullfile(fileparts(mfilename('fullpath')),'utils')));
 addpath(fullfile(fileparts(mfilename('fullpath')),'lib'));
+try
+    cfg = evalin('caller','cfg');
+catch
+    error('cfg not found in caller workspace');
+end
     if nargin < 1 || isempty(imu_path)
         error('IMU path not specified');
     end
@@ -57,13 +62,9 @@ addpath(fullfile(fileparts(mfilename('fullpath')),'lib'));
     vel_r           = p.Results.vel_r;
     scale_factor    = p.Results.scale_factor;
 
-    % Store all outputs under the repository "results" directory
-    here = fileparts(mfilename('fullpath'));
-    root = fileparts(here);
-    results_dir = get_results_dir();
-    if ~exist(results_dir,'dir')
-        mkdir(results_dir);
-    end
+    % Store all outputs under the repository results directory
+    results_dir = cfg.paths.results;
+    ensure_dir(results_dir);
     if ~isfile(gnss_path)
         error('Task_5:GNSSFileNotFound', ...
               'Could not find GNSS data at:\n  %s\nCheck path or filename.', ...
@@ -76,8 +77,7 @@ addpath(fullfile(fileparts(mfilename('fullpath')),'lib'));
     end
     [~, imu_name, ~] = fileparts(imu_path);
     [~, gnss_name, ~] = fileparts(gnss_path);
-    pair_tag = [imu_name '_' gnss_name];
-    tag = [pair_tag '_' method];
+    run_id = sprintf('%s_%s_%s', imu_name, gnss_name, method);
 
     if isempty(method)
         log_tag = '';
@@ -251,14 +251,14 @@ q_b_n = rot_to_quaternion(C_B_N); % Initial attitude quaternion
     % Task 1 results may be saved under two naming schemes. First check the
     % legacy ``Task1_init_*`` file, then fall back to the unified
     % ``*_task1_results`` produced by ``save_task_results``.
-    task1_file = fullfile(results_dir, sprintf('Task1_init_%s.mat', tag));
+    task1_file = fullfile(results_dir, sprintf('Task1_init_%s.mat', run_id));
     if ~isfile(task1_file)
         alt_file = fullfile(results_dir, sprintf('Task1_init_%s.mat', pair_tag));
         if isfile(alt_file)
             task1_file = alt_file;
         else
             % Look for the newer naming convention
-            alt_file = fullfile(results_dir, sprintf('%s_task1_results.mat', tag));
+            alt_file = fullfile(results_dir, sprintf('%s_task1_results.mat', run_id));
             if ~isfile(alt_file)
                 alt_file = fullfile(results_dir, sprintf('%s_task1_results.mat', pair_tag));
             end
@@ -342,7 +342,7 @@ for k = 1:3
 end
 % Compare raw and interpolated GNSS data
 task5_gnss_interp_ned_plot(gnss_time, gnss_pos_ned, gnss_vel_ned, imu_time, ...
-    gnss_pos_interp, gnss_vel_interp, tag, results_dir);
+    gnss_pos_interp, gnss_vel_interp, run_id, results_dir, cfg);
 
 % --- Main Filter Loop ---
 fprintf('-> Starting filter loop over %d IMU samples...\n', num_imu_samples);
@@ -509,12 +509,12 @@ p_n_fused = x_log(1:3,:)' ;
 v_n_fused = x_log(4:6,:)' ;
 a_n_fused = accel_from_vel';
 plot_state_grid(imu_time, p_n_fused, v_n_fused, a_n_fused, 'NED', ...
-    sprintf('%s_%s_%s_Task5_FUSED', imu_name, gnss_name, method), results_dir, {'Fused'});
+    sprintf('%s_task5', run_id), results_dir, {'Fused'}, cfg);
 
 % --- Combined Position, Velocity and Acceleration ---
 fig = figure('Name', 'KF Results: P/V/A', 'Position', [100 100 1200 900]);
 labels = {'North', 'East', 'Down'};
-all_file = fullfile(results_dir, sprintf('%s_Task5_AllResults.pdf', tag));
+all_file = fullfile(results_dir, sprintf('%s_Task5_AllResults.pdf', run_id));
 if exist(all_file, 'file'); delete(all_file); end
 for i = 1:3
     % Position
@@ -580,26 +580,26 @@ if ~isempty(zupt_indices)
 end
 
 plot_task5_mixed_frame(imu_time, x_log(1:3,:), x_log(4:6,:), ...
-    acc_log, euler_log, C_ECEF_to_NED, ref_r0, g_NED, tag, method, results_dir, all_file);
+    acc_log, euler_log, C_ECEF_to_NED, ref_r0, g_NED, run_id, method, results_dir, all_file, cfg);
 fprintf('Fused mixed frames plot saved\n');
 
 fprintf('Plotting all data in NED frame.\n');
 plot_task5_ned_frame(imu_time, x_log(1:3,:), x_log(4:6,:), acc_log, ...
-    gnss_time, gnss_pos_ned, gnss_vel_ned, gnss_accel_ned, method);
+    gnss_time, gnss_pos_ned, gnss_vel_ned, gnss_accel_ned, method, run_id, cfg);
 
 fprintf('Plotting all data in ECEF frame.\n');
 plot_task5_ecef_frame(imu_time, x_log(1:3,:), x_log(4:6,:), acc_log, ...
-    gnss_time, gnss_pos_ecef, gnss_vel_ecef, gnss_accel_ecef, C_ECEF_to_NED, ref_r0, method);
+    gnss_time, gnss_pos_ecef, gnss_vel_ecef, gnss_accel_ecef, C_ECEF_to_NED, ref_r0, method, run_id, cfg);
 
 fprintf('Plotting all data in body frame.\n');
 plot_task5_body_frame(imu_time, x_log(1:3,:), x_log(4:6,:), acc_log, euler_log, ...
-    gnss_time, gnss_pos_ned, gnss_vel_ned, gnss_accel_ned, method, g_NED);
+    gnss_time, gnss_pos_ned, gnss_vel_ned, gnss_accel_ned, method, g_NED, run_id, cfg);
 
 state_file = fullfile(fileparts(imu_path), sprintf('STATE_%s.txt', imu_name));
 if exist(state_file, 'file')
     fprintf('Plotting fused ECEF trajectory with truth overlay.\n');
     plot_task5_ecef_truth(imu_time, x_log(1:3,:), x_log(4:6,:), acc_log, ...
-        state_file, C_ECEF_to_NED, ref_r0, method);
+        state_file, C_ECEF_to_NED, ref_r0, method, run_id, cfg);
 end
 
 %% --- End-of-run summary statistics --------------------------------------
@@ -662,7 +662,7 @@ fprintf('%s\n', summary_line);
 fprintf('[SUMMARY] method=%s rmse_pos=%.2f m final_pos=%.2f m ', ...
         method, rmse_pos, final_pos_err);
 fprintf('rmse_vel=%.2f m/s final_vel=%.2f m/s\n', rmse_vel, final_vel);
-fid = fopen(fullfile(results_dir, [tag '_summary.txt']), 'w');
+fid = fopen(fullfile(results_dir, [run_id '_summary.txt']), 'w');
 fprintf(fid, '%s\n', summary_line);
 fclose(fid);
 
@@ -705,7 +705,7 @@ ref_lon = deg2rad(lon_deg); %#ok<NASGU>
 
 % Save using the same naming convention as the Python pipeline
 % <IMU>_<GNSS>_<METHOD>_task5_results.mat
-results_file = fullfile(results_dir, sprintf('%s_task5_results.mat', tag));
+results_file = fullfile(results_dir, sprintf('%s_task5_results.mat', run_id));
 save(results_file, 'gnss_pos_ned', 'gnss_vel_ned', 'gnss_accel_ned', ...
     'gnss_pos_ecef', 'gnss_vel_ecef', 'gnss_accel_ecef', ...
     'x_log', 'vel_log', 'accel_from_vel', 'euler_log', 'zupt_log', 'zupt_vel_norm', ...
@@ -729,7 +729,7 @@ catch
 end
 
 % Export estimator time vector for compatibility with Python pipeline
-time_file = fullfile(results_dir, sprintf('%s_task5_time.mat', tag));
+time_file = fullfile(results_dir, sprintf('%s_task5_time.mat', run_id));
 save(time_file, 't_est', 'dt', 'x_log');
 fprintf('Task 5: Saved time vector to %s\n', time_file);
 
@@ -895,9 +895,9 @@ end % End of main function
              -sp,   cp*sr,            cp*cr];
     end
 
-    function plot_task5_mixed_frame(t, pos_ned, vel_ned, acc_ned, eul_log, C_E_N, r0, g_N, tag, method, results_dir, all_file)
+    function plot_task5_mixed_frame(t, pos_ned, vel_ned, acc_ned, eul_log, C_E_N, r0, g_N, run_id, method, results_dir, all_file, cfg)
         %PLOT_TASK5_MIXED_FRAME Plot ECEF position/velocity and body accel.
-        %   Saves a multi-panel figure using the given METHOD and TAG.
+        %   Saves a multi-panel figure using the given METHOD and RUN_ID.
         pos_ecef = (C_E_N' * pos_ned) + r0;
         vel_ecef = C_E_N' * vel_ned;
         N = size(acc_ned,2);
@@ -906,7 +906,8 @@ end % End of main function
             C_B_N = euler_to_rot(eul_log(:,k));
             acc_body(:,k) = C_B_N' * (acc_ned(:,k) - g_N);
         end
-        fig = figure('Name','Task5 Mixed Frame','Position',[100 100 1200 900]);
+        fig = figure('Name','Task5 Mixed Frame','Position',[100 100 1200 900], ...
+            'Visible', ternary(cfg.plots.popup_figures,'on','off'));
         dims_e = {'X','Y','Z'}; dims_b = {'X','Y','Z'};
         for i = 1:3
             subplot(3,3,i);   plot(t, pos_ecef(i,:), 'b-'); grid on;
@@ -919,18 +920,21 @@ end % End of main function
             title(['Acc ' dims_b{i} ' Body']); ylabel('m/s^2'); xlabel('Time [s]');
         end
         sgtitle([method ' Mixed Frame Data']);
-        % fname = fullfile(results_dir, sprintf('%s_Task5_MixedFrame.pdf', tag));
-        % set(fig,'PaperPositionMode','auto');
-        % print(fig, fname, '-dpdf', '-bestfit');
-        % exportgraphics(fig, all_file, 'Append', true);
-        % fprintf('Saved plot: %s\n', fname);
-        % close(fig);
+        fname = fullfile(results_dir, sprintf('%s_task5_Mixed_state', run_id));
+        if cfg.plots.save_pdf
+            print(fig, [fname '.pdf'], '-dpdf', '-bestfit');
+        end
+        if cfg.plots.save_png
+            print(fig, [fname '.png'], '-dpng');
+        end
+        close(fig);
     end
 
-    function plot_task5_ned_frame(t, pos_ned, vel_ned, acc_ned, t_gnss, pos_gnss, vel_gnss, acc_gnss, method)
+    function plot_task5_ned_frame(t, pos_ned, vel_ned, acc_ned, t_gnss, pos_gnss, vel_gnss, acc_gnss, method, run_id, cfg)
         %PLOT_TASK5_NED_FRAME Plot fused vs GNSS data in the NED frame.
         labels = {'North','East','Down'};
-        figure('Name','Task5 NED Frame','Position',[100 100 1200 900]);
+        figure('Name','Task5 NED Frame','Position',[100 100 1200 900], ...
+            'Visible', ternary(cfg.plots.popup_figures,'on','off'));
         for k = 1:3
             subplot(3,3,k); hold on;
             plot(t_gnss, pos_gnss(:,k),'k:','DisplayName','GNSS');
@@ -948,15 +952,24 @@ end % End of main function
             hold off; grid on; ylabel('[m/s^2]'); title(['Acceleration ' labels{k}]); legend;
         end
         sgtitle([method ' - All data in NED frame']);
+        fname = fullfile(cfg.paths.results, sprintf('%s_task5_NED_state', run_id));
+        if cfg.plots.save_pdf
+            print(gcf, [fname '.pdf'], '-dpdf', '-bestfit');
+        end
+        if cfg.plots.save_png
+            print(gcf, [fname '.png'], '-dpng');
+        end
+        close(gcf);
     end
 
-    function plot_task5_ecef_frame(t, pos_ned, vel_ned, acc_ned, t_gnss, pos_ecef, vel_ecef, acc_ecef, C_E_N, r0, method)
+    function plot_task5_ecef_frame(t, pos_ned, vel_ned, acc_ned, t_gnss, pos_ecef, vel_ecef, acc_ecef, C_E_N, r0, method, run_id, cfg)
         %PLOT_TASK5_ECEF_FRAME Plot fused vs GNSS data in the ECEF frame.
         labels = {'X','Y','Z'};
         pos_fused = (C_E_N' * pos_ned) + r0;
         vel_fused = C_E_N' * vel_ned;
         acc_fused = C_E_N' * acc_ned;
-        figure('Name','Task5 ECEF Frame','Position',[100 100 1200 900]);
+        figure('Name','Task5 ECEF Frame','Position',[100 100 1200 900], ...
+            'Visible', ternary(cfg.plots.popup_figures,'on','off'));
         for k = 1:3
             subplot(3,3,k); hold on;
             plot(t_gnss, pos_ecef(:,k),'k:','DisplayName','GNSS');
@@ -974,9 +987,17 @@ end % End of main function
             hold off; grid on; ylabel('[m/s^2]'); title(['Acceleration ' labels{k}]); legend;
         end
         sgtitle([method ' - All data in ECEF frame']);
+        fname = fullfile(cfg.paths.results, sprintf('%s_task5_ECEF_state', run_id));
+        if cfg.plots.save_pdf
+            print(gcf, [fname '.pdf'], '-dpdf', '-bestfit');
+        end
+        if cfg.plots.save_png
+            print(gcf, [fname '.png'], '-dpng');
+        end
+        close(gcf);
     end
 
-    function plot_task5_body_frame(t, pos_ned, vel_ned, acc_ned, eul_log, t_gnss, pos_gnss_ned, vel_gnss_ned, acc_gnss_ned, method, g_N)
+    function plot_task5_body_frame(t, pos_ned, vel_ned, acc_ned, eul_log, t_gnss, pos_gnss_ned, vel_gnss_ned, acc_gnss_ned, method, g_N, run_id, cfg)
         %PLOT_TASK5_BODY_FRAME Plot fused results in body frame coordinates.
         labels = {'X','Y','Z'};
         N = size(pos_ned,2);
@@ -996,7 +1017,8 @@ end % End of main function
             vel_gnss_body(:,k) = C_B_N' * vel_gnss_ned(k,:)';
             acc_gnss_body(:,k) = C_B_N' * (acc_gnss_ned(k,:)' - g_N);
         end
-        figure('Name','Task5 Body Frame','Position',[100 100 1200 900]);
+        figure('Name','Task5 Body Frame','Position',[100 100 1200 900], ...
+            'Visible', ternary(cfg.plots.popup_figures,'on','off'));
         for j = 1:3
             subplot(3,3,j); hold on;
             plot(t_gnss, pos_gnss_body(j,:),'k:','DisplayName','GNSS');
@@ -1014,9 +1036,17 @@ end % End of main function
             hold off; grid on; ylabel('[m/s^2]'); title(['Acceleration ' labels{j}']); legend;
         end
         sgtitle([method ' - All data in body frame']);
+        fname = fullfile(cfg.paths.results, sprintf('%s_task5_BODY_state', run_id));
+        if cfg.plots.save_pdf
+            print(gcf, [fname '.pdf'], '-dpdf', '-bestfit');
+        end
+        if cfg.plots.save_png
+            print(gcf, [fname '.png'], '-dpng');
+        end
+        close(gcf);
     end
 
-    function plot_task5_ecef_truth(t, pos_ned, vel_ned, acc_ned, state_file, C_E_N, r0, method)
+    function plot_task5_ecef_truth(t, pos_ned, vel_ned, acc_ned, state_file, C_E_N, r0, method, run_id, cfg)
         %PLOT_TASK5_ECEF_TRUTH Overlay fused output with provided truth data.
         if ~exist(state_file,'file'); return; end
         truth = readmatrix(state_file);
@@ -1030,7 +1060,8 @@ end % End of main function
         vel_fused = C_E_N' * vel_ned;
         acc_fused = C_E_N' * acc_ned;
 
-        figure('Name','Task5 ECEF with Truth','Position',[100 100 1200 900]);
+        figure('Name','Task5 ECEF with Truth','Position',[100 100 1200 900], ...
+            'Visible', ternary(cfg.plots.popup_figures,'on','off'));
         labels = {'X','Y','Z'};
         for k = 1:3
             subplot(3,3,k); hold on;
@@ -1049,4 +1080,12 @@ end % End of main function
             hold off; grid on; ylabel('[m/s^2]'); title(['Acceleration ' labels{k}]); legend;
         end
         sgtitle([method ' - ECEF frame with Truth']);
+        fname = fullfile(cfg.paths.results, sprintf('%s_task5_ECEF_truth', run_id));
+        if cfg.plots.save_pdf
+            print(gcf, [fname '.pdf'], '-dpdf', '-bestfit');
+        end
+        if cfg.plots.save_png
+            print(gcf, [fname '.png'], '-dpng');
+        end
+        close(gcf);
     end

--- a/MATLAB/project_paths.m
+++ b/MATLAB/project_paths.m
@@ -1,0 +1,26 @@
+function P = project_paths()
+%PROJECT_PATHS  Discover project root reliably and standardize folders.
+
+% Find the folder of the caller (works both from editor and command line)
+st = dbstack('-completenames');
+if isempty(st)
+    here = fileparts(mfilename('fullpath'));
+else
+    here = fileparts(st(1).file);
+end
+
+% Assume this file lives in MATLAB/ ; project root is its parent
+root = fileparts(here);
+
+% Standard locations
+P = struct();
+P.root          = root;
+P.results       = fullfile(root, 'results');
+P.src_utils     = fullfile(root, 'src', 'utils');     % Python-shared math
+P.matlab_utils  = fullfile(root, 'MATLAB', 'utils');  % MATLAB helpers
+
+% Add to path once
+if exist(P.src_utils,'dir');    addpath(P.src_utils);   end
+if exist(P.matlab_utils,'dir'); addpath(P.matlab_utils);end
+if exist(P.results,'dir')==0;   mkdir(P.results);       end
+end

--- a/MATLAB/run_triad.m
+++ b/MATLAB/run_triad.m
@@ -1,0 +1,71 @@
+function S = run_triad(cfg)
+%RUN_TRIAD  Structured runner that executes Tasks 1..7 with timing & checks.
+
+arguments
+    cfg struct
+end
+
+% --- Paths & deps
+addpath(cfg.paths.src_utils);      % src/utils (shared constants, frames, etc.)
+addpath(cfg.paths.matlab_utils);   % MATLAB/utils (triad_matrix, etc.)
+ensure_dir(cfg.paths.results);
+
+% --- Inputs must exist (zero hidden defaults)
+require_files({cfg.imu_path, cfg.gnss_path});
+
+% --- Deterministic plots & RNG
+rng(0);
+set(0,'DefaultFigureVisible', ternary(cfg.plots.popup_figures,'on','off'));
+
+% --- Run ID + standard filenames
+[~,imu_name,~]  = fileparts(cfg.imu_path);
+[~,gnss_name,~] = fileparts(cfg.gnss_path);
+run_id = sprintf('%s_%s_%s', imu_name, gnss_name, cfg.method);
+S = struct('run_id',run_id, 't',struct());
+
+% --- Task list (function handles keep code DRY)
+tasks = { ...
+    @( ) Task_1(cfg.imu_path, cfg.gnss_path, cfg.method), ...
+    @( ) Task_2(cfg.imu_path, cfg.gnss_path, cfg.method), ...
+    @( ) Task_3(cfg.imu_path, cfg.gnss_path, cfg.method), ...
+    @( ) Task_4(cfg.imu_path, cfg.gnss_path, cfg.method), ...
+    @( ) Task_5(cfg.imu_path, cfg.gnss_path, cfg.method)  ...
+};
+
+fprintf('\u25b6 %s\n', run_id);
+for k = 1:numel(tasks)
+    t0 = tic;
+    try
+        tasks{k}();
+    catch ME
+        fprintf(2,'[ERROR] Task %d failed: %s\n', k, ME.message);
+        rethrow(ME);
+    end
+    S.t.(sprintf('Task%d',k)) = toc(t0);
+end
+
+% --- Tasks 6 & 7 only if we have both: Task 5 results + truth
+task5_file = fullfile(cfg.paths.results, sprintf('%s_task5_results.mat', run_id));
+has_truth  = ~isempty(cfg.truth_path) && isfile(cfg.truth_path);
+if isfile(task5_file) && has_truth
+    fprintf('--- Running Task 6: Truth Overlay/Validation ---\n');
+    t0 = tic;
+    Task_6(task5_file, cfg.imu_path, cfg.gnss_path, cfg.truth_path);
+    S.t.Task6 = toc(t0);
+
+    fprintf('--- Running Task 7: Residuals & Summary ---\n');
+    t0 = tic;
+    Task_7();              % uses saved Task 5 artifacts by design
+    S.t.Task7 = toc(t0);
+
+    out_dir = fullfile(cfg.paths.results, run_id);
+    fprintf('Task 6/7 plots saved under: %s\n', out_dir);
+else
+    warning('Task 6/7 skipped: missing Task 5 results or truth file.');
+end
+
+% --- Save a compact run summary
+S.cfg = cfg; %#ok<STRNU>
+save(fullfile(cfg.paths.results, [run_id '_driver_summary.mat']), 'S');
+
+end

--- a/MATLAB/task5_gnss_interp_ned_plot.m
+++ b/MATLAB/task5_gnss_interp_ned_plot.m
@@ -1,23 +1,26 @@
-function task5_gnss_interp_ned_plot(gnss_time, gnss_pos_ned, gnss_vel_ned, imu_time, pos_interp, vel_interp, tag, results_dir)
+function task5_gnss_interp_ned_plot(gnss_time, gnss_pos_ned, gnss_vel_ned, imu_time, pos_interp, vel_interp, run_id, results_dir, cfg)
 %TASK5_GNSS_INTERP_NED_PLOT  Compare raw and interpolated GNSS trajectories.
 %   TASK5_GNSS_INTERP_NED_PLOT(GNSS_TIME, GNSS_POS_NED, GNSS_VEL_NED,
-%   IMU_TIME, POS_INTERP, VEL_INTERP, TAG, RESULTS_DIR) creates position and
-%   velocity plots in the NED frame showing raw GNSS samples and the
-%   interpolated trajectories at IMU timestamps.  Plots are saved in the
-%   provided results directory with filenames based on TAG.
-%
-%   Usage:
-%       task5_gnss_interp_ned_plot(t_gnss, pos_gnss, vel_gnss, t_imu,
-%                                  pos_interp, vel_interp, tag, out_dir)
+%   IMU_TIME, POS_INTERP, VEL_INTERP, RUN_ID, RESULTS_DIR, CFG) creates
+%   position and velocity plots in the NED frame showing raw GNSS samples
+%   and the interpolated trajectories at IMU timestamps.  Plots are saved in
+%   the provided results directory with filenames based on RUN_ID. CFG
+%   controls plot visibility and saving policy.
 
-if nargin < 8
-    results_dir = get_results_dir();
+if nargin < 8 || isempty(results_dir)
+    results_dir = 'results';
+end
+if nargin < 9 || isempty(cfg)
+    cfg.plots.popup_figures = true;
+    cfg.plots.save_pdf = true;
+    cfg.plots.save_png = true;
 end
 
 comp_labels = { 'North (m)', 'East (m)', 'Down (m)' };
 
 % Position comparison ---------------------------------------------------
-fig = figure('Name', 'GNSS Position Interpolation', 'Position', [100 100 1200 600]);
+fig = figure('Name', 'GNSS Position Interpolation', 'Position', [100 100 1200 600], ...
+    'Visible', ternary(cfg.plots.popup_figures,'on','off'));
 for i = 1:3
     subplot(2,3,i); hold on; grid on; box on;
     plot(gnss_time, gnss_pos_ned(:,i), 'o', 'DisplayName', 'GNSS raw');
@@ -37,8 +40,12 @@ for i = 1:3
     legend('Location','best');
 end
 
-fname = fullfile(results_dir, sprintf('%s_task5_gnss_interp_ned', tag));
-saveas(fig, [fname '.png']);
-saveas(fig, [fname '.pdf']);
+fname = fullfile(results_dir, sprintf('%s_task5_gnss_interp_ned', run_id));
+if cfg.plots.save_png
+    saveas(fig, [fname '.png']);
+end
+if cfg.plots.save_pdf
+    saveas(fig, [fname '.pdf']);
+end
 close(fig);
 end

--- a/MATLAB/utils/ensure_dir.m
+++ b/MATLAB/utils/ensure_dir.m
@@ -1,0 +1,3 @@
+function ensure_dir(d)
+if exist(d,'dir')==0, mkdir(d); end
+end

--- a/MATLAB/utils/plot_state_grid.m
+++ b/MATLAB/utils/plot_state_grid.m
@@ -1,11 +1,12 @@
-function plot_state_grid(t, pos, vel, acc, frame, tag, outdir, legendEntries)
+function plot_state_grid(t, pos, vel, acc, frame, tag, outdir, legendEntries, cfg)
 %PLOT_STATE_GRID 3x3 pop-up of Position/Velocity/Acceleration for N/E/D.
-%   PLOT_STATE_GRID(T, POS, VEL, ACC, FRAME, TAG, OUTDIR, LEGENDENTRIES)
+%   PLOT_STATE_GRID(T, POS, VEL, ACC, FRAME, TAG, OUTDIR, LEGENDENTRIES, CFG)
 %   displays a 3×3 grid of plots showing position, velocity and
 %   acceleration components over time. FRAME is a string identifying the
-%   coordinate frame (e.g. 'NED'), TAG is used for the figure name and file
-%   prefix. OUTDIR is where plots are saved. LEGENDENTRIES is optional and
-%   allows custom legend labels when multiple series are provided.
+%   coordinate frame (e.g. 'NED'), TAG is used for the file prefix. OUTDIR
+%   is where plots are saved. LEGENDENTRIES is optional and allows custom
+%   legend labels when multiple series are provided. CFG controls plotting
+%   policy (popup_figures, save_pdf, save_png).
 %
 %   POS, VEL and ACC may be either N×3 arrays or cell arrays of such arrays
 %   to overlay multiple series. Each array must have the same number of rows
@@ -14,8 +15,14 @@ function plot_state_grid(t, pos, vel, acc, frame, tag, outdir, legendEntries)
 if nargin < 8
     legendEntries = {};
 end
+if nargin < 9 || isempty(cfg)
+    cfg.plots.popup_figures = true;
+    cfg.plots.save_pdf = true;
+    cfg.plots.save_png = true;
+end
 
-figure('Name', sprintf('%s %s', frame, tag), 'NumberTitle','off', 'Visible','on');
+figure('Name', sprintf('%s %s', frame, tag), 'NumberTitle','off', ...
+       'Visible', ternary(cfg.plots.popup_figures,'on','off'));
 tiledlayout(3,3,'TileSpacing','compact','Padding','compact');
 rows = {'Position [m]','Velocity [m/s]','Acceleration [m/s^2]'};
 cols = {'North','East','Down'};
@@ -62,8 +69,12 @@ if nargin >= 7 && ~isempty(outdir)
     if ~exist(outdir,'dir')
         mkdir(outdir);
     end
-    base = sprintf('%s_%s_state_%s', tag, frame, datestr(now,'yyyymmdd_HHMMSS'));
-    exportgraphics(gcf, fullfile(outdir, [base '.pdf']), 'ContentType','vector');
-    saveas(gcf, fullfile(outdir, [base '.png']));
+    base = sprintf('%s_%s_state', tag, frame);
+    if cfg.plots.save_pdf
+        exportgraphics(gcf, fullfile(outdir, [base '.pdf']), 'ContentType','vector');
+    end
+    if cfg.plots.save_png
+        saveas(gcf, fullfile(outdir, [base '.png']));
+    end
 end
 end

--- a/MATLAB/utils/require_files.m
+++ b/MATLAB/utils/require_files.m
@@ -1,0 +1,8 @@
+function require_files(paths)
+%REQUIRE_FILES  Assert that all given paths exist.
+for i=1:numel(paths)
+    if ~isfile(paths{i})
+        error('Required file not found: %s', paths{i});
+    end
+end
+end

--- a/MATLAB/utils/ternary.m
+++ b/MATLAB/utils/ternary.m
@@ -1,0 +1,3 @@
+function out = ternary(cond,a,b)
+if cond, out=a; else, out=b; end
+end

--- a/src/cfg/__init__.py
+++ b/src/cfg/__init__.py
@@ -1,0 +1,4 @@
+"""Configuration helpers (Python counterparts to MATLAB cfg package)."""
+from .default_cfg import default_cfg
+
+__all__ = ["default_cfg"]

--- a/src/cfg/default_cfg.py
+++ b/src/cfg/default_cfg.py
@@ -1,0 +1,22 @@
+"""Default configuration stub mirroring MATLAB ``cfg.default_cfg``."""
+from __future__ import annotations
+
+from .. import project_paths  # type: ignore
+
+
+def default_cfg() -> dict:
+    """Return default configuration dictionary."""
+    paths = project_paths.project_paths() if hasattr(project_paths, "project_paths") else {}
+    return {
+        "dataset_id": "",
+        "method": "",
+        "imu_file": "",
+        "gnss_file": "",
+        "truth_file": "",
+        "paths": paths,
+        "plots": {
+            "popup_figures": True,
+            "save_pdf": True,
+            "save_png": True,
+        },
+    }

--- a/src/project_paths.py
+++ b/src/project_paths.py
@@ -1,0 +1,20 @@
+"""Utility to discover repository paths (stub for MATLAB project_paths)."""
+from __future__ import annotations
+
+import pathlib
+
+
+def project_paths() -> dict:
+    """Return a dictionary with standard project paths.
+
+    This is a lightweight Python counterpart to the MATLAB ``project_paths``
+    helper.  Paths are resolved relative to this file.
+    """
+    here = pathlib.Path(__file__).resolve().parent
+    root = here.parent
+    return {
+        "root": str(root),
+        "results": str(root / "results"),
+        "src_utils": str(root / "src" / "utils"),
+        "matlab_utils": str(root / "MATLAB" / "utils"),
+    }

--- a/src/utils/ensure_dir.py
+++ b/src/utils/ensure_dir.py
@@ -1,0 +1,9 @@
+"""Stub for MATLAB ``ensure_dir``."""
+from __future__ import annotations
+
+import pathlib
+
+
+def ensure_dir(path: str) -> None:
+    """Create *path* if it does not exist."""
+    pathlib.Path(path).mkdir(parents=True, exist_ok=True)

--- a/src/utils/plot_frame_comparison.m
+++ b/src/utils/plot_frame_comparison.m
@@ -1,13 +1,20 @@
-function plot_frame_comparison(t, data_sets, labels, frame_name, out_prefix)
+function plot_frame_comparison(t, data_sets, labels, frame_name, out_prefix, cfg)
 %PLOT_FRAME_COMPARISON Plot 3-axis data in either 3-subplot or 1-panel mixed form.
 %   t           : time vector (Nx1)
 %   data_sets   : cell array of M×N or N×3 datasets (each dataset rows are axes)
 %   labels      : cell array of legend strings
 %   frame_name  : 'NED','ECEF','BODY','Mixed'
 %   out_prefix  : full path prefix, e.g. results/.../RUNID_taskX
+%   cfg         : struct with plotting policy
+
+if nargin < 6 || isempty(cfg)
+    cfg.plots.popup_figures = true;
+    cfg.plots.save_pdf = true;
+    cfg.plots.save_png = true;
+end
 
 % Create figure
-figure('Visible','off');
+figure('Visible', ternary(cfg.plots.popup_figures,'on','off'));
 if strcmpi(frame_name,'Mixed')
     % single axes
     hold on; grid on;
@@ -36,7 +43,12 @@ else
     end
 end
 % Save PDF & PNG
-saveas(gcf, [out_prefix '_' frame_name '_comparison.pdf'], 'pdf');
-saveas(gcf, [out_prefix '_' frame_name '_comparison.png'], 'png');
+fname = [out_prefix '_' frame_name '_comparison'];
+if cfg.plots.save_pdf
+    saveas(gcf, [fname '.pdf'], 'pdf');
+end
+if cfg.plots.save_png
+    saveas(gcf, [fname '.png'], 'png');
+end
 close;
 end

--- a/src/utils/require_files.py
+++ b/src/utils/require_files.py
@@ -1,0 +1,12 @@
+"""Stub for MATLAB ``require_files``."""
+from __future__ import annotations
+
+import pathlib
+from typing import Iterable
+
+
+def require_files(paths: Iterable[str]) -> None:
+    """Assert that all *paths* exist as files."""
+    for p in paths:
+        if not pathlib.Path(p).is_file():
+            raise FileNotFoundError(f"Required file not found: {p}")

--- a/src/utils/ternary.py
+++ b/src/utils/ternary.py
@@ -1,0 +1,7 @@
+"""Simple ternary helper mirroring MATLAB ``ternary``."""
+from __future__ import annotations
+
+
+def ternary(cond: bool, a, b):
+    """Return *a* if *cond* else *b*."""
+    return a if cond else b


### PR DESCRIPTION
## Summary
- Add structured MATLAB driver `run_triad` and thin `run_triad_only` wrapper
- Centralize configuration and project paths with `default_cfg` and `project_paths`
- Make Task 4 and Task 5 plotting deterministic via `cfg.plots` and standardized filenames
- Provide Python stubs mirroring new MATLAB helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895e80ed1b083259030fe5d631fd633