### PR TITLE
Fix Task4 orthonormal check + enforce Tasks 6/7 + Task3 filenames

### DIFF
--- a/MATLAB/src/Task_3.m
+++ b/MATLAB/src/Task_3.m
@@ -63,18 +63,18 @@ end
 % ---- pack canonical struct that Task_4 expects ----
 task3_results = struct();
 task3_results.methods = {'TRIAD','Davenport','SVD'};
-task3_results.Rbn = struct('TRIAD', R_tri, 'Davenport', R_dav, 'SVD', R_svd);
-task3_results.q   = struct('TRIAD', q_tri, 'Davenport', q_dav, 'SVD', q_svd);
-task3_results.meta = struct('imu_id', imu_id, 'gnss_id', gnss_id, 'method', method);
+task3_results.Rbn.TRIAD     = R_tri;
+task3_results.Rbn.Davenport = R_dav;
+task3_results.Rbn.SVD       = R_svd;
+task3_results.q.TRIAD       = q_tri;
+task3_results.q.Davenport   = q_dav;
+task3_results.q.SVD         = q_svd;
+task3_results.meta = struct('imu_id',imu_id,'gnss_id',gnss_id,'method',method);
 
-% ---- save under BOTH filenames (generic + method-specific) ----
-out_generic = fullfile(results_dir, ...
-    sprintf('Task3_results_IMU_%s_GNSS_%s.mat', imu_id, gnss_id));
-out_method  = fullfile(results_dir, ...
-    sprintf('IMU_%s_GNSS_%s_%s_task3_results.mat', imu_id, gnss_id, method));
+out_generic = fullfile(results_dir, sprintf('Task3_results_%s_%s.mat', imu_id, gnss_id));
+out_method  = fullfile(results_dir, sprintf('%s_%s_%s_task3_results.mat', imu_id, gnss_id, method));
 
 save(out_generic, 'task3_results', '-v7');
 save(out_method,  'task3_results', '-v7');
-
 fprintf('Task 3: saved task3_results to:\n  %s\n  %s\n', out_generic, out_method);
 end


### PR DESCRIPTION
## Summary
- fix Task 4 ECEF↔NED rotation calculation and orthonormality check
- standardize Task 3 result filenames and struct layout
- make MATLAB run_triad_only always run Tasks 6 and 7 with mandatory truth file

## Testing
- `pytest -q`
- `pytest tests/test_naming.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6895fb3af94883258ce5ab657ab93970