### PR TITLE
Handle IMU clock resets and log sample rates in Python runner

### DIFF
--- a/MATLAB/src/utils/make_monotonic_time.m
+++ b/MATLAB/src/utils/make_monotonic_time.m
@@ -1,0 +1,36 @@
+function [t, meta] = make_monotonic_time(t_like, fallback_len, dt, imu_rate_hint)
+% MAKE_MONOTONIC_TIME Stub matching Python _make_monotonic_time.
+%   Builds a synthetic or unmodified time vector. Currently returns the
+%   input unmodified and records minimal metadata.
+%
+% Usage:
+%   [t, meta] = make_monotonic_time(t_like, fallback_len, dt, imu_rate_hint)
+%
+% Inputs:
+%   t_like        - Time-like vector or empty
+%   fallback_len  - Length used when synthesising time vector
+%   dt            - Sampling interval
+%   imu_rate_hint - IMU sample rate hint
+%
+% Outputs:
+%   t    - Time vector
+%   meta - Struct with metadata fields
+
+if nargin < 2, fallback_len = []; end
+if nargin < 3, dt = []; end
+if nargin < 4, imu_rate_hint = []; end
+
+if isempty(t_like)
+    if isempty(dt)
+        t = [];
+    else
+        n = fallback_len;
+        t = (0:n-1)' * dt;
+    end
+    meta = struct('source', 'synth', 'wraps', 0, 'dt', dt);
+    return;
+end
+
+t = t_like(:);
+meta = struct('source', 'file', 'wraps', 0);
+end

--- a/MATLAB/src/utils/unwrap_clock_1s.m
+++ b/MATLAB/src/utils/unwrap_clock_1s.m
@@ -1,0 +1,24 @@
+function [t_unwrapped, wraps_count] = unwrap_clock_1s(t_raw, wrap, tol)
+% UNWRAP_CLOCK_1S Stub for Python _unwrap_clock_1s.
+%   [t_unwrapped, wraps_count] = unwrap_clock_1s(t_raw, wrap, tol) returns
+%   the input unchanged. TODO: implement 1-second clock unwrapping.
+%
+% Usage:
+%   [t_unwrapped, wraps_count] = unwrap_clock_1s(t_raw, wrap, tol)
+%
+% Inputs:
+%   t_raw  - Raw time vector (seconds)
+%   wrap   - Clock wrap period (seconds, default 1)
+%   tol    - Drop tolerance to detect wrap (seconds, default 0.25)
+%
+% Outputs:
+%   t_unwrapped - Unmodified time vector
+%   wraps_count - Zero; number of wraps detected
+
+if nargin < 2, wrap = 1.0; end
+if nargin < 3, tol = 0.25; end
+
+% TODO: implement unwrapping logic
+wraps_count = 0; %#ok<NASGU>
+t_unwrapped = t_raw;
+end

--- a/MATLAB/src/utils/write_run_meta.m
+++ b/MATLAB/src/utils/write_run_meta.m
@@ -1,0 +1,17 @@
+function write_run_meta(outdir, run_id, meta)
+% WRITE_RUN_META Stub for Python _write_run_meta.
+%   Writes metadata to JSON. Currently this is a placeholder that performs
+%   no action. Implement as needed to mirror Python behaviour.
+%
+% Usage:
+%   write_run_meta(outdir, run_id, meta)
+%
+% Inputs:
+%   outdir - Output directory
+%   run_id - Identifier string
+%   meta   - Struct of metadata to record
+
+% TODO: implement JSON output if required.
+% This stub exists for parity with the Python implementation.
+
+end


### PR DESCRIPTION
## Summary
- Unwrap IMU clocks resetting every second and enforce monotonic timestamps
- Add sample rate hints and write run metadata JSON alongside outputs
- Provide MATLAB stubs for new timebase helper functions

## Testing
- `python - <<'PY'` (import sanity check)
- `python src/run_triad_only.py --no-plots`


------
https://chatgpt.com/codex/tasks/task_e_68960451bcb083259fb6ced712125944