### PR TITLE
Add timeline summaries for Python and MATLAB pipelines

### DIFF
--- a/MATLAB/run_triad_only.m
+++ b/MATLAB/run_triad_only.m
@@ -44,7 +44,9 @@ mustExist(cfg.truth_path, 'Truth file (required for Task 6/7)');
 
 run_id = sprintf('%s_%s_%s', erase(cfg.imu_file,'.dat'), erase(cfg.gnss_file,'.csv'), cfg.method);
 fprintf('%s %s_%s_%s\n', char(9654), erase(cfg.imu_file,'.dat'), erase(cfg.gnss_file,'.csv'), cfg.method);
-fprintf('>> MATLAB results dir: %s\n', mat_results);
+fprintf('MATLAB results dir: %s\n', mat_results);
+summarize_timeline(cfg.imu_path, cfg.gnss_path, cfg.truth_path, cfg.paths.matlab_results, run_id);
+fprintf('[DATA TIMELINE] Saved %s\n', fullfile(cfg.paths.matlab_results, [run_id '_timeline.txt']));
 
 % Expected outputs by task (for assertions)
 t1_mat = fullfile(mat_results, sprintf('Task1_init_%s_%s_%s.mat', ...

--- a/MATLAB/src/utils/summarize_timeline.m
+++ b/MATLAB/src/utils/summarize_timeline.m
@@ -1,0 +1,131 @@
+function out = summarize_timeline(imu_path, gnss_path, truth_path, out_dir, run_id)
+% SUMMARIZE_TIMELINE  Emit simple timing statistics for dataset files.
+% Usage:
+%   out = summarize_timeline(imu_path, gnss_path, truth_path, out_dir, run_id)
+%
+% This helper mirrors the Python ``timeline.py`` utility. It inspects IMU,
+% GNSS and optional truth files to compute nominal sample rates and timing
+% irregularities. A human-readable text report is saved alongside a
+% JSON-like struct in ``out``.
+%
+% Parameters
+% ----------
+% imu_path : char
+%     Path to IMU .dat file.
+% gnss_path : char
+%     Path to GNSS .csv file.
+% truth_path : char
+%     Path to truth file; may be empty.
+% out_dir : char
+%     Output directory for timeline files.
+% run_id : char
+%     Identifier used in filenames.
+%
+% Returns
+% -------
+% out : struct
+%     Structure containing timing summaries.
+%
+if nargin<5, run_id = 'run'; end
+if nargin<4 || isempty(out_dir)
+    out_dir = fullfile(fileparts(mfilename('fullpath')),'..','..','results');
+end
+if ~exist(out_dir,'dir'), mkdir(out_dir); end
+
+out = struct('run_id',run_id,'notes',{{}});
+
+% -- GNSS (CSV)
+Tg = readtable(gnss_path);
+if any(strcmp(Tg.Properties.VariableNames,'Posix_Time'))
+    t_gnss = Tg.Posix_Time;
+else
+    t_gnss = (0:height(Tg)-1)';           % assume 1 Hz if missing
+    out.notes{end+1} = 'GNSS: Posix_Time not found; assumed 1 Hz via row index.';
+end
+out.gnss = rate_from_times(t_gnss);
+
+% -- IMU (DAT)
+Ti = readmatrix(imu_path);
+t_imu = [];
+% Try find a sub-second column [0..1)
+for c = size(Ti,2):-1:max(1,size(Ti,2)-3)
+    v = Ti(:,c);
+    if all(isfinite(v)) && all(v>=0 & v<1)
+        t_imu = unwrap_subsec(v);
+        break;
+    end
+end
+if isempty(t_imu)
+    found=false;
+    for c=1:min(6,size(Ti,2))
+        v = Ti(:,c);
+        if all(isfinite(v))
+            dv = diff(v);
+            if median(abs(dv))>1e-4 && median(abs(dv))<1
+                t_imu = v; found=true; break;
+            end
+        end
+    end
+    if ~found
+        dt = 0.0025;                       % fallback known for X002
+        t_imu = (0:size(Ti,1)-1)'*dt;
+        out.notes{end+1} = 'IMU: no time column; using 400 Hz fallback (dt=0.0025s).';
+    end
+end
+out.imu = rate_from_times(t_imu);
+
+% -- Truth
+if ~isempty(truth_path) && isfile(truth_path)
+    Ts = readmatrix(truth_path);
+    t_truth = Ts(:,2); % second column = time
+    out.truth = rate_from_times(t_truth);
+else
+    out.truth = struct('n',0);
+end
+
+% Save text + json-ish
+txt = fullfile(out_dir, sprintf('%s_timeline.txt', run_id));
+fid = fopen(txt,'w');
+fprintf(fid,'== Timeline summary: %s ==\n', run_id);
+write_line(fid,'IMU',out.imu);
+write_line(fid,'GNSS',out.gnss);
+if isfield(out,'truth') && isfield(out.truth,'n') && out.truth.n>0
+    write_line(fid,'TRUTH',out.truth);
+end
+if ~isempty(out.notes)
+    fprintf(fid,'\nNotes:\n');
+    for i=1:numel(out.notes), fprintf(fid,'- %s\n', out.notes{i}); end
+end
+fclose(fid);
+end
+
+function s = rate_from_times(t)
+t = t(:);
+s.n = numel(t);
+if numel(t)<2
+    s.hz = NaN; s.dt_med=NaN; s.dt_min=NaN; s.dt_max=NaN; s.duration=0; s.t0=NaN; s.t1=NaN; s.monotonic=true; return;
+end
+dt = diff(t);
+s.monotonic = all(dt>=-1e-9);
+s.dt_med = median(dt);
+s.dt_min = min(dt);
+s.dt_max = max(dt);
+if s.dt_med>0, s.hz = 1/s.dt_med; else, s.hz = NaN; end
+s.duration = t(end)-t(1);
+s.t0 = t(1); s.t1 = t(end);
+end
+
+function tw = unwrap_subsec(v)
+tw = zeros(size(v));
+acc=0; tw(1)=v(1);
+for i=2:numel(v)
+    dv = v(i)-v(i-1);
+    if dv < -0.5, acc = acc + 1; end
+    tw(i) = v(i) + acc;
+end
+end
+
+function write_line(fid, tag, s)
+fprintf(fid, '%6s | n=%d  hz=%.6f  dt_med=%.6f  min/max dt=(%.6f,%.6f)  dur=%.3fs  t0=%.6f  t1=%.6f  monotonic=%d\n', ...
+    tag, s.n, s.hz, s.dt_med, s.dt_min, s.dt_max, s.duration, s.t0, s.t1, s.monotonic);
+end

--- a/src/run_triad_only.py
+++ b/src/run_triad_only.py
@@ -39,6 +39,10 @@ from evaluate_filter_results import run_evaluation_npz
 from run_all_methods import run_case, compute_C_NED_to_ECEF
 from utils import save_mat
 
+# Allow importing helper utilities under ``src/utils``.
+sys.path.append(str(Path(__file__).resolve().parent / "utils"))
+from timeline import summarize_files
+
 sys.path.append(str(Path(__file__).resolve().parents[1] / "tools"))
 
 logger = logging.getLogger(__name__)
@@ -171,6 +175,20 @@ def main(argv: Iterable[str] | None = None) -> None:
     print(f"\u25b6 {tag}")
 
     imu_path, gnss_path = check_files(imu_file, gnss_file)
+
+    truth_file = ROOT / "STATE_X001.txt"
+    truth_path = str(truth_file) if truth_file.exists() else None
+    run_id = tag
+    meta, jpath, tpath = summarize_files(
+        str(imu_path),
+        str(gnss_path),
+        truth_path=truth_path,
+        out_dir="results",
+        run_id=run_id,
+    )
+    print(f"[DATA TIMELINE] Saved {tpath} and {jpath}")
+    if not meta["imu"]["monotonic"]:
+        print("[WARN] IMU time not monotonic; unwrapped per-second rollover was applied.")
 
     if logger.isEnabledFor(logging.DEBUG):
         try:

--- a/src/utils/timeline.py
+++ b/src/utils/timeline.py
@@ -1,0 +1,217 @@
+"""Utility functions for dataset timeline summaries.
+
+Usage:
+    from timeline import summarize_files
+
+This module provides helpers to derive sample rates, detect sub-second
+clock resets in IMU logs, and export human-friendly timeline reports.
+A MATLAB counterpart is implemented in ``summarize_timeline.m`` for
+feature parity.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+
+def _rate_from_times(t: np.ndarray) -> dict:
+    """Return timing statistics for a time vector.
+
+    Parameters
+    ----------
+    t : array-like
+        Time stamps in seconds.
+
+    Returns
+    -------
+    dict
+        Mapping with keys ``n``, ``hz``, ``dt_med``, ``dt_min``, ``dt_max``,
+        ``duration``, ``t0``, ``t1`` and ``monotonic``. Values may be ``None``
+        when insufficient samples are available.
+    """
+
+    t = np.asarray(t, dtype=float)
+    if t.size < 2:
+        return {
+            "n": int(t.size),
+            "hz": None,
+            "dt_med": None,
+            "dt_min": None,
+            "dt_max": None,
+            "duration": 0.0,
+            "t0": None,
+            "t1": None,
+            "monotonic": True,
+        }
+    dt = np.diff(t)
+    monotonic = np.all(dt >= -1e-9)
+    if t[-1] >= t[0]:
+        duration = float(t[-1] - t[0])
+    else:
+        duration = float((t[-1] + (t.size - 1) * np.median(dt)) - t[0])
+    dt_med = float(np.median(dt))
+    hz = float(1.0 / dt_med) if dt_med > 0 else None
+    return {
+        "n": int(t.size),
+        "hz": hz,
+        "dt_med": dt_med,
+        "dt_min": float(np.min(dt)),
+        "dt_max": float(np.max(dt)),
+        "duration": duration,
+        "t0": float(t[0]),
+        "t1": float(t[-1]),
+        "monotonic": bool(monotonic),
+    }
+
+
+def _unwrap_imu_seconds(t_subsec: np.ndarray) -> np.ndarray:
+    """Unwrap an IMU clock that resets each second.
+
+    Parameters
+    ----------
+    t_subsec : array-like
+        Sub-second time stamps in the range ``[0, 1)``.
+
+    Returns
+    -------
+    np.ndarray
+        Monotonic time vector with one-second rollover removed.
+    """
+
+    t = np.asarray(t_subsec, dtype=float)
+    if t.size == 0:
+        return t
+    out = np.zeros_like(t)
+    acc = 0.0
+    out[0] = t[0]
+    for i in range(1, len(t)):
+        dt = t[i] - t[i - 1]
+        if dt < -0.5:  # big negative jump => new second started
+            acc += 1.0
+        out[i] = t[i] + acc
+    return out
+
+
+def summarize_files(
+    imu_path: str | os.PathLike,
+    gnss_path: str | os.PathLike,
+    truth_path: str | os.PathLike | None = None,
+    out_dir: str | os.PathLike = "results",
+    run_id: str | None = None,
+):
+    """Summarize IMU, GNSS and optional truth files and save reports.
+
+    Parameters
+    ----------
+    imu_path, gnss_path, truth_path : path-like
+        Input data files. ``truth_path`` may be ``None``.
+    out_dir : str or Path, optional
+        Output directory for ``*_timeline.json`` and ``*_timeline.txt``.
+    run_id : str, optional
+        Identifier used in file names.
+
+    Returns
+    -------
+    tuple
+        ``(summary, json_path, txt_path)`` where ``summary`` is a dictionary
+        containing per-file timing info.
+    """
+
+    os.makedirs(out_dir, exist_ok=True)
+    run_id = run_id or "run"
+
+    summary: dict[str, object] = {"run_id": run_id, "notes": []}
+
+    # ---- GNSS (CSV with Posix_Time if available) ----
+    gnss = pd.read_csv(gnss_path)
+    if "Posix_Time" in gnss.columns:
+        t_gnss = gnss["Posix_Time"].to_numpy()
+    else:
+        t_gnss = np.arange(len(gnss), dtype=float)
+        summary["notes"].append("GNSS: Posix_Time not found; assumed 1 Hz via row index.")
+    summary["gnss"] = {"file": os.path.basename(gnss_path), **_rate_from_times(t_gnss)}
+
+    # ---- IMU (DAT) ----
+    imu = pd.read_csv(imu_path, delim_whitespace=True, header=None, comment="#", engine="python")
+    candidate_time = None
+    for col in range(min(imu.shape[1], 6)):
+        v = imu[col].astype(float).to_numpy()
+        if np.isfinite(v).all() and np.ptp(v) > 0 and np.ptp(v) < 1e6:
+            dv = np.diff(v)
+            if v.size > 10 and np.median(np.abs(dv)) > 1e-4 and np.median(np.abs(dv)) < 1.0:
+                candidate_time = v
+                break
+    if candidate_time is None:
+        subsec = None
+        for col in range(imu.shape[1] - 1, max(-1, imu.shape[1] - 4), -1):
+            v = imu[col].astype(float).to_numpy()
+            if np.all((v >= 0) & (v < 1.0)):
+                subsec = v
+                break
+        if subsec is not None:
+            t_imu = _unwrap_imu_seconds(subsec)
+        else:
+            dt_guess = 0.0025
+            t_imu = np.arange(len(imu), dtype=float) * dt_guess
+            summary["notes"].append("IMU: no time column found; using 400 Hz fallback (dt=0.0025s).")
+    else:
+        if np.all((candidate_time >= 0) & (candidate_time < 1.0)):
+            t_imu = _unwrap_imu_seconds(candidate_time)
+        else:
+            t_imu = candidate_time
+    summary["imu"] = {"file": os.path.basename(imu_path), **_rate_from_times(t_imu)}
+
+    # ---- Truth (STATE_*.txt) ----
+    if truth_path and os.path.isfile(truth_path):
+        truth = pd.read_csv(
+            truth_path,
+            delim_whitespace=True,
+            comment="#",
+            engine="python",
+            names=[
+                "idx",
+                "time",
+                "X",
+                "Y",
+                "Z",
+                "VX",
+                "VY",
+                "VZ",
+                "q0",
+                "q1",
+                "q2",
+                "q3",
+            ],
+        )
+        t_truth = truth["time"].to_numpy()
+        summary["truth"] = {"file": os.path.basename(truth_path), **_rate_from_times(t_truth)}
+    else:
+        summary["truth"] = {"file": None}
+
+    json_path = os.path.join(out_dir, f"{run_id}_timeline.json")
+    txt_path = os.path.join(out_dir, f"{run_id}_timeline.txt")
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+    with open(txt_path, "w", encoding="utf-8") as f:
+        def line(tag: str, s: dict) -> None:
+            f.write(
+                f"{tag:6s} | n={s.get('n')}  hz={s.get('hz'):.6f}  dt_med={s.get('dt_med'):.6f}  "
+                f"min/max dt=({s.get('dt_min'):.6f},{s.get('dt_max'):.6f})  "
+                f"dur={s.get('duration'):.3f}s  t0={s.get('t0')}  t1={s.get('t1')}  "
+                f"monotonic={s.get('monotonic')}\n"
+            )
+
+        f.write(f"== Timeline summary: {run_id} ==\n")
+        line("IMU", summary["imu"])
+        line("GNSS", summary["gnss"])
+        if summary["truth"]["file"]:
+            line("TRUTH", summary["truth"])
+        if summary["notes"]:
+            f.write("\nNotes:\n- " + "\n- ".join(summary["notes"]) + "\n")
+    return summary, json_path, txt_path


### PR DESCRIPTION
## Summary
- add `timeline.py` helper to compute sample rates and generate timeline reports
- call timeline summarizer in `run_triad_only.py` and warn on non-monotonic IMU clocks
- mirror the functionality in MATLAB via `summarize_timeline.m` and integrate into `run_triad_only.m`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896131dbb9c83259e96045305164733