### PR TITLE
Fix timeline unwrapping and plotting utilities

### DIFF
--- a/MATLAB/src/utils/unwrap_seconds.m
+++ b/MATLAB/src/utils/unwrap_seconds.m
@@ -1,0 +1,35 @@
+function t = unwrap_seconds(subsec, dt_hint)
+%UNWRAP_SECONDS Reconstruct a monotonic time vector from fractional seconds.
+%   t = UNWRAP_SECONDS(subsec, dt_hint) returns a timeline where the
+%   fractional-second counter SUBSEC is unwrapped and optionally snapped to a
+%   uniform grid using DT_HINT. SUBSEC is assumed to reset to ~0 every second.
+%
+%   Usage:
+%       t = unwrap_seconds(subsec)
+%       t = unwrap_seconds(subsec, dt_hint)
+%
+%   This helper mirrors ``_unwrap_seconds`` in ``src/utils/timeline.py``.
+%
+%   Inputs:
+%       subsec  - fractional seconds that reset to ~0 every second
+%       dt_hint - optional expected sample interval (e.g., 0.0025)
+%
+%   Output:
+%       t       - unwrapped time vector starting at zero
+
+if nargin < 2 || isempty(dt_hint)
+    dt_hint = median(diff(subsec(subsec>0)));
+end
+
+d = diff(subsec(:));
+wrap = d < -0.5;              % detect negative jumps (wraps)
+step = [0; cumsum(wrap)];
+t = double(subsec(:)) + step; % add whole seconds per wrap
+
+t = t - t(1);                 % start at zero
+
+if isfinite(dt_hint) && dt_hint > 0
+    n = numel(t);
+    t = (0:n-1)' * dt_hint;   % lock to uniform timeline
+end
+end

--- a/src/run_triad_only.py
+++ b/src/run_triad_only.py
@@ -41,7 +41,7 @@ from utils import save_mat
 
 # Allow importing helper utilities under ``src/utils``.
 sys.path.append(str(Path(__file__).resolve().parent / "utils"))
-from timeline import print_timeline_summary
+from timeline import print_timeline
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "tools"))
 
@@ -180,13 +180,8 @@ def main(argv: Iterable[str] | None = None) -> None:
     truth_path = str(truth_file) if truth_file.exists() else None
     run_id = tag
 
-    print(
-        "Note: Python saves to results/ ; MATLAB saves to MATLAB/results/ (independent)."
-    )
-    timeline_txt = print_timeline_summary(
-        run_id, str(imu_path), str(gnss_path), truth_path, str(results_dir)
-    )
-    print(f"[DATA TIMELINE] Saved {timeline_txt}")
+    print("Note: Python saves to results/ ; MATLAB saves to MATLAB/results/ (independent).")
+    print_timeline(run_id, str(imu_path), str(gnss_path), truth_path, out_dir=str(results_dir))
 
     if logger.isEnabledFor(logging.DEBUG):
         try:

--- a/src/utils/plot_state_grid.py
+++ b/src/utils/plot_state_grid.py
@@ -1,18 +1,33 @@
 """Stub for MATLAB ``plot_state_grid`` equivalent."""
 from __future__ import annotations
+
 import numpy as np
 import matplotlib.pyplot as plt
 
 def plot_state_grid(t: np.ndarray, pos: np.ndarray, vel: np.ndarray, acc: np.ndarray,
-                    frame: str, tag: str, outdir: str | None = None,
-                    legend_entries: list[str] | None = None) -> None:
+                    frame: str, *, visible: str = "off", save_dir: str | None = None,
+                    run_id: str = "") -> None:
     """Placeholder plotting helper.
 
-    The full implementation is pending. This stub ensures API parity with the
-    MATLAB function so code can import it without failure.
+    Mirrors the MATLAB ``plot_state_grid`` function. The full implementation is
+    pending; this stub accepts the same arguments so code can import it without
+    failure.
+
+    Parameters
+    ----------
+    t : ndarray
+        Time vector [s].
+    pos, vel, acc : ndarray
+        N×3 arrays of position, velocity and acceleration in the specified frame.
+    frame : str
+        Coordinate frame label (e.g. ``"NED"``).
+    visible : {'on','off'}, optional
+        Show figure windows (default ``'off'``).
+    save_dir : str, optional
+        Directory to save plots.
+    run_id : str, optional
+        Identifier used in filenames.
     """
+    _ = (t, pos, vel, acc, frame, visible, save_dir, run_id)
     # TODO: implement plotting similar to MATLAB version
-    if legend_entries is None:
-        legend_entries = []
-    _ = (t, pos, vel, acc, frame, tag, outdir, legend_entries)
     pass


### PR DESCRIPTION
## Summary
- add `unwrap_seconds` and `timeline_summary` in MATLAB to produce monotonic IMU timelines and dataset timing reports
- simplify plotting helpers and update Task 4 to align IMU/GNSS rates with clamped accelerometer scale
- mirror timeline printing and plot helper stubs in Python and invoke timeline summary in `run_triad_only.py`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68961ec6d61c83259f9d16c0fcc9eb39