### PR TITLE
Handle comments in truth timeline

### DIFF
--- a/MATLAB/src/utils/read_truth_time.m
+++ b/MATLAB/src/utils/read_truth_time.m
@@ -1,0 +1,35 @@
+function t = read_truth_time(truth_path, notes)
+% READ_TRUTH_TIME Read STATE_* truth file robustly.
+%   T = READ_TRUTH_TIME(TRUTH_PATH, NOTES) reads the truth file at
+%   TRUTH_PATH ignoring lines that start with '#', splits on whitespace,
+%   coerces the first column to numeric, drops NaNs, and returns time
+%   starting at zero. If parsing fails a note is appended to NOTES and
+%   T is returned empty.
+%
+%   Inputs:
+%       truth_path - path to truth file
+%       notes      - cell array of notes (in/out)
+%
+%   Outputs:
+%       t - time vector starting at zero or [] on failure
+
+if nargin < 2
+    notes = {};
+end
+
+if nargin < 1 || isempty(truth_path) || ~isfile(truth_path)
+    t = [];
+    return;
+end
+
+st = readmatrix(truth_path, 'FileType', 'text', 'Delimiter', ' ', 'CommentStyle', '#');
+col = st(:,1);
+col = col(isfinite(col));
+if numel(col) < 2
+    notes{end+1} = 'TRUTH: failed to parse time column; insufficient numeric rows.';
+    t = [];
+    return;
+end
+
+t = col - col(1);
+end

--- a/MATLAB/src/utils/timeline_summary.m
+++ b/MATLAB/src/utils/timeline_summary.m
@@ -47,13 +47,15 @@ fprintf('GNSS  | n=%d     hz=%.6f  dt_med=%.6f  min/max dt=(%.6f,%.6f)  dur=%.3f
 notes = {};
 truth_line = 'TRUTH | (not provided)';
 if ~isempty(truth_path) && isfile(truth_path)
-    St = readmatrix(truth_path);
-    t_truth = St(:,1);
-    t_truth = t_truth - t_truth(1);
-    truth_dt = diff(t_truth);
-    truth_hz = 1/median(truth_dt,'omitnan');
-    fprintf('TRUTH | n=%d    hz=%.6f  dt_med=%.6f  min/max dt=(%.6f,%.6f)  dur=%.3fs  t0=%.6f  t1=%.6f  monotonic=%s\n',...
-        numel(t_truth), truth_hz, median(truth_dt,'omitnan'), min(truth_dt), max(truth_dt), t_truth(end)-t_truth(1), t_truth(1), t_truth(end), string(all(truth_dt>0)));
+    t_truth = read_truth_time(truth_path, notes);
+    if ~isempty(t_truth)
+        truth_dt = diff(t_truth);
+        truth_hz = 1/median(truth_dt,'omitnan');
+        fprintf('TRUTH | n=%d    hz=%.6f  dt_med=%.6f  min/max dt=(%.6f,%.6f)  dur=%.3fs  t0=%.6f  t1=%.6f  monotonic=%s\n',...
+            numel(t_truth), truth_hz, median(truth_dt,'omitnan'), min(truth_dt), max(truth_dt), t_truth(end)-t_truth(1), t_truth(1), t_truth(end), string(all(truth_dt>0)));
+    else
+        fprintf('TRUTH | present but unreadable (see Notes).\n');
+    end
 else
     fprintf('%s\n', truth_line);
 end
@@ -66,9 +68,11 @@ if nargin>=5 && ~isempty(out_txt)
         numel(t_imu), imu_hz, median(imu_dt,'omitnan'), min(imu_dt), max(imu_dt), t_imu(end)-t_imu(1), t_imu(1), t_imu(end), string(all(imu_dt>0)));
     fprintf(fid,'GNSS  | n=%d     hz=%.6f  dt_med=%.6f  min/max dt=(%.6f,%.6f)  dur=%.3fs  t0=%.6f  t1=%.6f  monotonic=%s\n',...
         numel(t_gnss), gnss_hz, median(gnss_dt,'omitnan'), min(gnss_dt), max(gnss_dt), t_gnss(end)-t_gnss(1), t_gnss(1), t_gnss(end), string(all(gnss_dt>0)));
-    if exist('t_truth','var')
+    if exist('t_truth','var') && ~isempty(t_truth)
         fprintf(fid,'TRUTH | n=%d    hz=%.6f  dt_med=%.6f  min/max dt=(%.6f,%.6f)  dur=%.3fs  t0=%.6f  t1=%.6f  monotonic=%s\n',...
             numel(t_truth), truth_hz, median(truth_dt,'omitnan'), min(truth_dt), max(truth_dt), t_truth(end)-t_truth(1), t_truth(1), t_truth(end), string(all(truth_dt>0)));
+    elseif ~isempty(truth_path) && isfile(truth_path)
+        fprintf(fid,'TRUTH | present but unreadable (see Notes).\n');
     else
         fprintf(fid,'%s\n', truth_line);
     end


### PR DESCRIPTION
## Summary
- Read truth timeline files robustly by ignoring '#' comments, coercing the first column to numeric, and dropping invalid rows before normalizing time.
- Replace deprecated `delim_whitespace` usage with regex-based whitespace splitting in timeline utilities.
- Mirror truth timeline parsing in MATLAB with a new `read_truth_time` helper.

## Testing
- `python src/run_triad_only.py` *(partially runs; plots generated)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689626f2cdb08325ab66aa9ca4fdda72