### PR TITLE
Resolve MATLAB truth path and run ID issues

### DIFF
--- a/MATLAB/src/utils/resolve_truth_path.m
+++ b/MATLAB/src/utils/resolve_truth_path.m
@@ -1,0 +1,34 @@
+function truth_path = resolve_truth_path()
+%RESOLVE_TRUTH_PATH Canonicalize the truth file path.
+%   Picks a preferred path; if missing but an alternate exists, copies the
+%   alternate into the preferred location so future runs are stable.
+%
+%   truth_path = resolve_truth_path()
+%       Returns the path string to the truth file if found or copied, or an
+%       empty char if neither exists.
+
+    preferred = '/Users/vimalchawda/Desktop/IMU/STATE_IMU_X001.txt';
+    alternate = '/Users/vimalchawda/Desktop/IMU/STATE_X001.txt';
+
+    if isfile(preferred)
+        truth_path = preferred;
+        fprintf('Using TRUTH: %s\n', truth_path);
+        return;
+    end
+
+    if isfile(alternate)
+        try
+            fprintf('Truth missing at preferred path; copying %s -> %s\n', alternate, preferred);
+            copyfile(alternate, preferred, 'f');   % force overwrite
+            truth_path = preferred;
+            fprintf('Using TRUTH: %s\n', truth_path);
+            return;
+        catch ME
+            warning('Copy to preferred failed (%s). Falling back to alternate.', ME.message);
+            truth_path = alternate;
+            return;
+        end
+    end
+
+    truth_path = '';
+end

--- a/MATLAB/src/utils/run_id.m
+++ b/MATLAB/src/utils/run_id.m
@@ -1,13 +1,15 @@
 function rid = run_id(imu_path, gnss_path, method)
-%RUN_ID Construct a standardized run identifier.
-%   RID = RUN_ID(IMU_PATH, GNSS_PATH, METHOD) returns a string of the form
-%   '<IMU>_<GNSS>_<METHOD>' using the base file names without extensions.
-%   METHOD is uppercased.
+%RUN_ID Make a consistent run id like "IMU_X002_GNSS_X002_TRIAD"
+%   RID = RUN_ID(IMU_PATH, GNSS_PATH, METHOD) returns a run identifier
+%   composed of the IMU base name, GNSS base name, and METHOD in uppercase.
+%   METHOD must be provided.
 
-[~, imu_name, ~]  = fileparts(imu_path);
-[~, gnss_name, ~] = fileparts(gnss_path);
-if nargin < 3 || isempty(method)
-    method = '';
+    if nargin < 3
+        error('run_id needs imu_path, gnss_path, method');
+    end
+    [~, imu_name, ~]  = fileparts(imu_path);   % e.g., IMU_X002
+    [~, gnss_name, ~] = fileparts(gnss_path);  % e.g., GNSS_X002
+    rid = sprintf('%s_%s_%s', imu_name, gnss_name, upper(string(method)));
+    rid = char(rid);
 end
-rid = sprintf('%s_%s_%s', imu_name, gnss_name, upper(method));
-end
+

--- a/src/utils/resolve_truth_path.py
+++ b/src/utils/resolve_truth_path.py
@@ -1,0 +1,39 @@
+"""Utilities for locating the canonical truth file.
+
+This mirrors ``MATLAB/src/utils/resolve_truth_path.m``. It selects a
+preferred path for the truth file and, if missing but an alternate exists,
+copies the alternate to the preferred location. The function returns the
+path to the truth file if one is found or copied, otherwise ``None``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+
+
+def resolve_truth_path() -> str | None:
+    """Resolve the path to the truth file.
+
+    Returns the canonical truth file path, copying from an alternate if
+    necessary. If neither file exists, ``None`` is returned.
+    """
+
+    preferred = Path("/Users/vimalchawda/Desktop/IMU/STATE_IMU_X001.txt")
+    alternate = Path("/Users/vimalchawda/Desktop/IMU/STATE_X001.txt")
+
+    if preferred.is_file():
+        print(f"Using TRUTH: {preferred}")
+        return str(preferred)
+
+    if alternate.is_file():
+        try:
+            print(f"Truth missing at preferred path; copying {alternate} -> {preferred}")
+            shutil.copy2(alternate, preferred)
+            print(f"Using TRUTH: {preferred}")
+            return str(preferred)
+        except Exception as exc:  # pragma: no cover - best effort
+            print(f"Copy to preferred failed ({exc}). Falling back to alternate.")
+            return str(alternate)
+
+    return None


### PR DESCRIPTION
## Summary
- Guard MATLAB run_id helper and return consistent string identifiers
- Resolve truth file path at runtime and ensure Tasks 6/7 have required data
- Add MATLAB and Python utilities for truth path resolution

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68964d95c4e48325ba7ea7b22a5c037f