### PR TITLE
Resolve truth path and print timeline summaries

### DIFF
--- a/MATLAB/Task_6.m
+++ b/MATLAB/Task_6.m
@@ -2,15 +2,16 @@ function Task_6(task5_file, imu_path, gnss_path, truth_file)
 %TASK_6 Overlay ground truth on Task 5 results.
 %   TASK_6(TASK5_FILE, IMU_PATH, GNSS_PATH, TRUTH_FILE) loads the
 %   Task 5 results MAT file along with the raw IMU, GNSS and ground truth
-%   trajectories.  All series are interpolated to the estimator time
+%   trajectories. All series are interpolated to the estimator time
 %   vector and ``plot_overlay`` is called for the NED, ECEF and body
-%   frames.  Truth data in the ECEF frame is first converted to the
+%   frames. Truth data in the ECEF frame is first converted to the
 %   estimator's local NED coordinates using ``compute_C_ECEF_to_NED`` so
-%   that residuals are expressed in a consistent frame.  The resulting
+%   that residuals are expressed in a consistent frame. The resulting
 %   ``*_overlay_truth.pdf`` files are written to the directory returned by
-%   ``project_paths()``.  This function expects the initialization output
-%   from Task 1 and the filter output from Task 5 to reside in that same
-%   directory.
+%   ``project_paths()``. If TRUTH_FILE is empty it will be resolved using
+%   ``resolve_truth_path``. This function expects the initialization
+%   output from Task 1 and the filter output from Task 5 to reside in that
+%   same directory.
 %
 % Usage:
 %   Task_6(task5_file, imu_path, gnss_path, truth_file)
@@ -111,7 +112,7 @@ else
 end
 
 if nargin < 4 || isempty(truth_file)
-    truth_file = fullfile(results_dir, 'Task4_results_IMU_X002_GNSS_X002.mat');
+    truth_file = resolve_truth_path();
 end
 
 % Reference coordinates from estimator or defaults

--- a/MATLAB/run_triad_only.m
+++ b/MATLAB/run_triad_only.m
@@ -51,17 +51,17 @@ mustExist(cfg.truth_path,'Truth file');
 
 rid = run_id(cfg.imu_path, cfg.gnss_path, cfg.method);
 results_dir = cfg.paths.matlab_results;
-timeline_matlab(rid, cfg.imu_path, cfg.gnss_path, cfg.truth_path);
 fprintf('%s %s\n', char(0x25B6), rid);
+print_timeline_summary_mat(rid, cfg.imu_path, cfg.gnss_path, cfg.truth_path, results_dir);
 fprintf('MATLAB results dir: %s\n', results_dir);
 
 % Expected outputs by task (for assertions)
 t1_mat = fullfile(mat_results, sprintf('Task1_init_%s.mat', rid));
 t2_mat = fullfile(mat_results, sprintf('Task2_body_%s.mat', rid));
 t3_mat = fullfile(mat_results, sprintf('%s_task3_results.mat', rid));
-results_dir = get_results_dir();
+results_dir = cfg.paths.matlab_results;
 t4_mat = fullfile(results_dir, sprintf('%s_task4_results.mat', rid));
-t5_mat = fullfile(mat_results, sprintf('%s_task5_results.mat', rid));
+t5_mat = fullfile(results_dir, sprintf('%s_task5_results.mat', rid));
 
 % --- Run Tasks 1..5 ------------------------------------------------------
 Task_1(cfg.imu_path, cfg.gnss_path, cfg.method);

--- a/MATLAB/src/Task_4.m
+++ b/MATLAB/src/Task_4.m
@@ -526,24 +526,28 @@ plot_frame_comparison(t, data_sets, labels, 'Mixed', prefix, cfg);
 %% ========================================================================
 % Subtask 4.12b: Load truth ECEF trajectory if available
 % =========================================================================
-state_file = fullfile(fileparts(imu_path), sprintf('STATE_%s.txt', imu_name));
 truth_pos_ecef = [];
 truth_vel_ecef = [];
 truth_time = [];
-if isfile(state_file)
+
+truth_path = '';
+if exist('cfg','var') && isfield(cfg,'truth_path')
+    truth_path = cfg.truth_path;
+end
+
+if ~isempty(truth_path) && isfile(truth_path)
     try
-        truth_data = read_state_file(state_file);
+        truth_data = read_state_file(truth_path);
         % Preserve time as a column vector for downstream tasks
-        truth_time = truth_data(:,2);
-        truth_time = truth_time(:);
+        truth_time = truth_data(:,2); truth_time = truth_time(:);
         truth_pos_ecef = truth_data(:,3:5);
         truth_vel_ecef = truth_data(:,6:8);
-        fprintf('Loaded truth ECEF trajectory from %s\n', state_file);
+        fprintf('Loaded truth ECEF trajectory from %s\n', truth_path);
     catch ME
         warning('Failed to load truth state file: %s', ME.message);
     end
 else
-    fprintf('Truth state file not found: %s\n', state_file);
+    fprintf('Truth state file not found: %s\n', truth_path);
 end
 
 

--- a/MATLAB/src/utils/print_timeline_summary_mat.m
+++ b/MATLAB/src/utils/print_timeline_summary_mat.m
@@ -1,0 +1,97 @@
+function out_txt = print_timeline_summary_mat(rid, imu_path, gnss_path, truth_path, out_dir)
+%PRINT_TIMELINE_SUMMARY_MAT Print concise timing summary for datasets.
+%   OUT_TXT = PRINT_TIMELINE_SUMMARY_MAT(RID, IMU_PATH, GNSS_PATH, TRUTH_PATH,
+%   OUT_DIR) writes a text summary named "<RID>_timeline.txt" to OUT_DIR and
+%   prints a 3-line summary block to the console. This mirrors the Python
+%   ``timeline.print_timeline_summary`` function.
+%
+%   Usage:
+%       print_timeline_summary_mat(rid, imu_path, gnss_path, truth_path, out_dir)
+%
+%   rid        - identifier string used in header and filename
+%   imu_path   - path to IMU ``.dat`` file
+%   gnss_path  - path to GNSS ``.csv`` file
+%   truth_path - path to truth state file (optional)
+%   out_dir    - directory to write ``<rid>_timeline.txt``
+%
+%   The function attempts to detect IMU and GNSS sampling rates and whether
+%   their time vectors are strictly monotonic. If ``truth_path`` is provided
+%   and readable, its timing information is summarized as well.
+
+    if ~exist(out_dir,'dir'), mkdir(out_dir); end
+    lines = {};
+
+    % ---------- IMU ----------
+    imu = readmatrix(imu_path);
+    n_imu = size(imu,1);
+    % try to find a [0,1) resetting clock; else synthesize @ 400 Hz
+    t_imu = [];
+    for c = 1:min(4,size(imu,2))
+        col = imu(:,c);
+        if all(isfinite(col)) && min(col) >= 0 && max(col) <= 1.0000001
+            t_imu = unwrap_clock01(col, 0.0025);  % unwrap seconds
+            break;
+        end
+    end
+    if isempty(t_imu)
+        t_imu = (0:n_imu-1)' * 0.0025; % fallback 400 Hz
+    end
+    dt_imu = diff(t_imu);
+    hz_imu = 1/median(dt_imu);
+    imu_line = sprintf('IMU   | n=%d   hz=%.6f  dt_med=%.6f  min/max dt=(%.6f,%.6f)  dur=%.3fs  t0=%.6f  t1=%.6f  monotonic=%s',...
+        n_imu, hz_imu, median(dt_imu), min(dt_imu), max(dt_imu), t_imu(end)-t_imu(1), t_imu(1), t_imu(end), tf(all(dt_imu>0)));
+
+    % ---------- GNSS ----------
+    T = readtable(gnss_path);
+    if any(strcmp(T.Properties.VariableNames,'Posix_Time'))
+        tg = T.Posix_Time;
+    else
+        tg = datetime(T.UTC_yyyy, T.UTC_MM, T.UTC_dd, T.UTC_HH, T.UTC_mm, T.UTC_ss);
+        tg = seconds(tg - tg(1));
+    end
+    tg = tg(:);
+    dtg = diff(tg);
+    gnss_line = sprintf('GNSS  | n=%d   hz=%.6f  dt_med=%.6f  min/max dt=(%.6f,%.6f)  dur=%.3fs  t0=%.6f  t1=%.6f  monotonic=%s',...
+        numel(tg), 1/median(dtg), median(dtg), min(dtg), max(dtg), tg(end)-tg(1), tg(1), tg(end), tf(all(dtg>0)));
+
+    % ---------- TRUTH ----------
+    truth_line = 'TRUTH | present but unreadable (see Notes).';
+    if ~isempty(truth_path) && isfile(truth_path)
+        try
+            opts = detectImportOptions(truth_path,'FileType','text','CommentStyle','#');
+            S = readmatrix(truth_path, opts);
+            tt = S(:,1); tt = tt(:);
+            if numel(tt) > 1 && all(isfinite(tt))
+                dtt = diff(tt);
+                truth_line = sprintf('TRUTH | n=%d   hz=%.6f  dt_med=%.6f  min/max dt=(%.6f,%.6f)  dur=%.3fs  t0=%.6f  t1=%.6f  monotonic=%s',...
+                    numel(tt), 1/median(dtt), median(dtt), min(dtt), max(dtt), tt(end)-tt(1), tt(1), tt(end), tf(all(dtt>0)));
+            end
+        catch
+            % keep default line
+        end
+    else
+        truth_line = 'TRUTH | (not provided)';
+    end
+
+    head = sprintf('== Timeline summary: %s ==', rid);
+    disp(head); disp(imu_line); disp(gnss_line); disp(truth_line);
+    out_txt = fullfile(out_dir, sprintf('%s_timeline.txt', rid));
+    fid = fopen(out_txt,'w');
+    fprintf(fid, '%s\n%s\n%s\n%s\n', head, imu_line, gnss_line, truth_line);
+    fclose(fid);
+    fprintf('[DATA TIMELINE] Saved %s\n', out_txt);
+end
+
+function s = tf(x), if x, s='true'; else, s='false'; end, end
+
+function t = unwrap_clock01(x, dt)
+% unwrap a [0,1) repeating clock into continuous seconds
+    wrap = [false; diff(x) < -0.5];
+    k = cumsum(wrap);
+    t = x + k;
+    t = t - t(1);
+    if abs(median(diff(t)) - dt) > 1e-4
+        t = (0:numel(x)-1)' * dt;
+    end
+end
+

--- a/src/run_triad_only.py
+++ b/src/run_triad_only.py
@@ -42,6 +42,7 @@ from utils import save_mat
 # Allow importing helper utilities under ``src/utils``.
 sys.path.append(str(Path(__file__).resolve().parent / "utils"))
 from timeline import print_timeline
+from resolve_truth_path import resolve_truth_path
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "tools"))
 
@@ -176,8 +177,7 @@ def main(argv: Iterable[str] | None = None) -> None:
 
     imu_path, gnss_path = check_files(imu_file, gnss_file)
 
-    truth_file = ROOT / "STATE_X001.txt"
-    truth_path = str(truth_file) if truth_file.exists() else None
+    truth_path = resolve_truth_path()
     run_id = tag
 
     print("Note: Python saves to results/ ; MATLAB saves to MATLAB/results/ (independent).")


### PR DESCRIPTION
## Summary
- Unify truth file handling via `resolve_truth_path` across MATLAB and Python
- Print and save dataset timing summaries at run start
- Remove dataset-specific truth defaults in MATLAB tasks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68964fbf51508325bedc3ac3f46449a4