### PR TITLE
Harden MATLAB task pipeline and utilities

### DIFF
--- a/MATLAB/src/utils/print_timeline_matlab.m
+++ b/MATLAB/src/utils/print_timeline_matlab.m
@@ -1,0 +1,63 @@
+function timeline_txt = print_timeline_matlab(run_id_str, imu_path, gnss_path, truth_path, out_dir)
+%PRINT_TIMELINE_MATLAB Print and save concise dataset timeline summary.
+%   TIMELINE_TXT = PRINT_TIMELINE_MATLAB(RUN_ID, IMU_PATH, GNSS_PATH,
+%   TRUTH_PATH, OUT_DIR) prints summary statistics for IMU, GNSS and truth
+%   files. The summary is also written to ``OUT_DIR`` with filename
+%   ``<run_id>_timeline.txt``. The returned value is the path to the saved
+%   text file.
+
+    if ~exist(out_dir, 'dir'); mkdir(out_dir); end
+
+    % --- IMU: assume column 2 contains fractional seconds at 400 Hz ---
+    imu = readmatrix(imu_path);
+    t_i = imu(:,2);
+    dt_i = diff(t_i);
+    dt_i = dt_i(isfinite(dt_i));
+    hz_i = 1/median(dt_i);
+    imu_line = sprintf(['IMU   | n=%d   hz=%.6f  dt_med=%.6f  min/max dt=(%.6f,%.6f)  ' ...
+        'dur=%.3fs  t0=%.6f  t1=%.6f  monotonic=%s'], ...
+        numel(t_i), hz_i, median(dt_i), min(dt_i), max(dt_i), t_i(end)-t_i(1), t_i(1), t_i(end), string(all(dt_i>0)).lower());
+
+    % --- GNSS: use Posix_Time column ---
+    T = readtable(gnss_path);
+    if any(strcmpi(T.Properties.VariableNames, 'Posix_Time'))
+        t_g = T.Posix_Time;
+    else
+        t_g = (0:height(T)-1)';
+    end
+    dt_g = diff(t_g);
+    dt_g = dt_g(isfinite(dt_g));
+    hz_g = 1/median(dt_g);
+    gnss_line = sprintf(['GNSS  | n=%d     hz=%.6f  dt_med=%.6f  min/max dt=(%.6f,%.6f)  ' ...
+        'dur=%.3fs  t0=%.6f  t1=%.6f  monotonic=%s'], ...
+        numel(t_g), hz_g, median(dt_g), min(dt_g), max(dt_g), t_g(end)-t_g(1), t_g(1), t_g(end), string(all(dt_g>0)).lower());
+
+    % --- TRUTH: ignore lines starting with '#'
+    if ~isempty(truth_path) && isfile(truth_path)
+        fid = fopen(truth_path,'r');
+        C = textscan(fid,'%f%f%f%f%f%f%f%f%f%f','CommentStyle','#');
+        fclose(fid);
+        t_t = C{1};
+        if isempty(t_t) || ~isfinite(t_t(1))
+            truth_line = 'TRUTH | present but unreadable (see Notes).';
+        else
+            dt_t = diff(t_t); dt_t = dt_t(isfinite(dt_t));
+            hz_t = 1/median(dt_t);
+            truth_line = sprintf(['TRUTH | n=%d    hz=%.6f  dt_med=%.6f  min/max dt=(%.6f,%.6f)  ' ...
+                'dur=%.3fs  t0=%.6f  t1=%.6f  monotonic=%s'], ...
+                numel(t_t), hz_t, median(dt_t), min(dt_t), max(dt_t), t_t(end)-t_t(1), t_t(1), t_t(end), string(all(dt_t>0)).lower());
+        end
+    else
+        truth_line = 'TRUTH | present but unreadable (see Notes).';
+    end
+
+    header = sprintf('== Timeline summary: %s ==\n', run_id_str);
+    lines = strjoin({header, imu_line, gnss_line, truth_line}, newline);
+    disp(lines);
+
+    fp = fullfile(out_dir, sprintf('%s_timeline.txt', run_id_str));
+    fid = fopen(fp,'w'); fprintf(fid,'%s\n',lines); fclose(fid);
+    fprintf('[DATA TIMELINE] Saved %s\n', fp);
+    timeline_txt = fp;
+end
+

--- a/MATLAB/src/utils/resolve_truth.m
+++ b/MATLAB/src/utils/resolve_truth.m
@@ -1,0 +1,36 @@
+function truth_path = resolve_truth(preferred_path)
+%RESOLVE_TRUTH Locate or create the canonical truth file.
+%   TRUTH_PATH = RESOLVE_TRUTH(PREFERRED_PATH) ensures that the truth file
+%   used by MATLAB tasks is located at the canonical path
+%   ``/Users/vimalchawda/Desktop/IMU/STATE_IMU_X001.txt``. If the file is
+%   missing but ``STATE_X001.txt`` exists, it is copied into place. The
+%   function returns the path to the truth file or an empty string if the
+%   file could not be found or created.
+
+    if nargin==0 || isempty(preferred_path)
+        preferred_path = '/Users/vimalchawda/Desktop/IMU/STATE_IMU_X001.txt';
+    end
+    fallback = '/Users/vimalchawda/Desktop/IMU/STATE_X001.txt';
+
+    if isfile(preferred_path)
+        fprintf('Using TRUTH: %s\n', preferred_path);
+        truth_path = preferred_path;
+        return;
+    end
+
+    if isfile(fallback)
+        try
+            fprintf('Truth missing at preferred path; copying %s -> %s\n', fallback, preferred_path);
+            copyfile(fallback, preferred_path);
+            truth_path = preferred_path;
+            fprintf('Using TRUTH: %s\n', truth_path);
+            return;
+        catch ME
+            warning('Failed to copy truth file: %s', ME.message);
+        end
+    end
+
+    warning('Truth file not found at preferred or fallback paths.');
+    truth_path = '';
+end
+

--- a/MATLAB/src/utils/run_id.m
+++ b/MATLAB/src/utils/run_id.m
@@ -1,15 +1,27 @@
 function rid = run_id(imu_path, gnss_path, method)
-%RUN_ID Make a consistent run id like "IMU_X002_GNSS_X002_TRIAD"
+%RUN_ID standardised run identifier IMU_<id>_GNSS_<id>_<METHOD>
 %   RID = RUN_ID(IMU_PATH, GNSS_PATH, METHOD) returns a run identifier
-%   composed of the IMU base name, GNSS base name, and METHOD in uppercase.
-%   METHOD must be provided.
+%   composed of the IMU base name, GNSS base name and METHOD in uppercase.
+%   If the dataset names do not already start with ``IMU_`` or ``GNSS_``,
+%   the prefixes are added automatically.
 
-    if nargin < 3
-        error('run_id needs imu_path, gnss_path, method');
+    [~, imu_name, imu_ext]   = fileparts(imu_path);
+    [~, gnss_name, gnss_ext] = fileparts(gnss_path);
+    imu_name  = erase(imu_name,  imu_ext);
+    gnss_name = erase(gnss_name, gnss_ext);
+
+    if startsWith(lower(imu_name), 'imu_')
+        imu_name = imu_name;
+    else
+        imu_name = ['IMU_' imu_name];
     end
-    [~, imu_name, ~]  = fileparts(imu_path);   % e.g., IMU_X002
-    [~, gnss_name, ~] = fileparts(gnss_path);  % e.g., GNSS_X002
+
+    if startsWith(lower(gnss_name), 'gnss_')
+        gnss_name = gnss_name;
+    else
+        gnss_name = ['GNSS_' gnss_name];
+    end
+
     rid = sprintf('%s_%s_%s', imu_name, gnss_name, upper(string(method)));
-    rid = char(rid);
 end
 

--- a/src/utils/print_timeline_matlab.py
+++ b/src/utils/print_timeline_matlab.py
@@ -1,0 +1,15 @@
+"""Stub mirroring ``MATLAB/src/utils/print_timeline_matlab.m``."""
+
+from __future__ import annotations
+
+from .timeline import print_timeline_summary
+
+
+def print_timeline_matlab(run_id_str: str, imu_path: str, gnss_path: str, truth_path: str, out_dir: str):
+    """Delegate to :func:`print_timeline_summary` for cross-language parity."""
+
+    return print_timeline_summary(run_id_str, imu_path, gnss_path, truth_path, out_dir)
+
+
+__all__ = ["print_timeline_matlab"]
+

--- a/src/utils/resolve_truth.py
+++ b/src/utils/resolve_truth.py
@@ -1,0 +1,35 @@
+"""Python analogue of ``MATLAB/src/utils/resolve_truth.m``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+
+
+def resolve_truth(preferred_path: str | None = None) -> str:
+    """Return path to canonical truth file, copying from fallback if needed."""
+
+    if not preferred_path:
+        preferred_path = "/Users/vimalchawda/Desktop/IMU/STATE_IMU_X001.txt"
+    preferred = Path(preferred_path)
+    fallback = Path("/Users/vimalchawda/Desktop/IMU/STATE_X001.txt")
+
+    if preferred.is_file():
+        print(f"Using TRUTH: {preferred}")
+        return str(preferred)
+
+    if fallback.is_file():
+        try:
+            print(f"Truth missing at preferred path; copying {fallback} -> {preferred}")
+            shutil.copy2(fallback, preferred)
+            print(f"Using TRUTH: {preferred}")
+            return str(preferred)
+        except Exception as exc:  # pragma: no cover
+            print(f"Failed to copy truth file: {exc}")
+
+    print("Truth file not found at preferred or fallback paths.")
+    return ""
+
+
+__all__ = ["resolve_truth"]
+

--- a/src/utils/run_id.py
+++ b/src/utils/run_id.py
@@ -1,0 +1,21 @@
+"""Python counterpart to ``MATLAB/src/utils/run_id.m``."""
+
+from pathlib import Path
+
+
+def run_id(imu_path: str, gnss_path: str, method: str) -> str:
+    """Return a standardised run identifier ``IMU_<id>_GNSS_<id>_<METHOD>``."""
+
+    imu_name = Path(imu_path).stem
+    gnss_name = Path(gnss_path).stem
+
+    if not imu_name.lower().startswith("imu_"):
+        imu_name = f"IMU_{imu_name}"
+    if not gnss_name.lower().startswith("gnss_"):
+        gnss_name = f"GNSS_{gnss_name}"
+
+    return f"{imu_name}_{gnss_name}_{method.upper()}"
+
+
+__all__ = ["run_id"]
+


### PR DESCRIPTION
## Summary
- add robust run_id, truth resolver, and timeline utilities
- run MATLAB TRIAD pipeline with mandatory tasks and timeline logging
- fix Task 4 interpolation/saving to avoid duplicate time failures

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689652fdeb288325adb14a6858571b10