### PR TITLE
Add robust MATLAB utilities and streamline TRIAD runner

### DIFF
--- a/MATLAB/src/Task_4.m
+++ b/MATLAB/src/Task_4.m
@@ -15,7 +15,8 @@ function result = Task_4(imu_path, gnss_path, method)
 
 paths = project_paths();
 results_dir = paths.matlab_results;
-addpath(fullfile(paths.root,'MATLAB','lib'));
+lib_path = fullfile(paths.root,'MATLAB','lib');
+if exist(lib_path,'dir'), addpath(lib_path); end
 
 % pull configuration from caller
 try

--- a/MATLAB/utils/ensure_input_file.m
+++ b/MATLAB/utils/ensure_input_file.m
@@ -1,0 +1,53 @@
+function abs_path = ensure_input_file(kind, fname, paths)
+%ENSURE_INPUT_FILE Locate or copy an input data file to the project root.
+%   abs_path = ENSURE_INPUT_FILE(KIND, FNAME, PATHS) returns the absolute
+%   path to FNAME. If the file does not exist under PATHS.root, common
+%   locations are searched and the file is copied to the root for future
+%   runs.
+%
+%   KIND is only used for printed diagnostics (e.g. 'IMU', 'GNSS').
+%
+%   Usage:
+%       imu_path = ensure_input_file('IMU', 'IMU_X002.dat', paths);
+
+if nargin < 3
+    error('ensure_input_file:MissingInput', 'paths struct required');
+end
+
+target = fullfile(paths.root, fname);
+if isfile(target)
+    abs_path = target; return;
+end
+
+search = {
+    fullfile(paths.root, fname)
+    fullfile(paths.matlab, fname)
+    fullfile(paths.root, 'MATLAB', 'src', fname)
+    fullfile(paths.root, 'src', fname)
+    fullfile(paths.root, '..', fname)
+    fullfile(paths.root, 'MATLAB', fname)
+};
+
+src_found = '';
+for i = 1:numel(search)
+    if isfile(search{i})
+        src_found = search{i};
+        break;
+    end
+end
+
+if ~isempty(src_found)
+    try
+        copyfile(src_found, target);
+        fprintf('Copied %s from %s -> %s\n', kind, src_found, target);
+    catch ME
+        warning('Could not copy %s from %s -> %s (%s). Using source in place.', kind, src_found, target, ME.message);
+        abs_path = src_found; return;
+    end
+    abs_path = target;
+    return;
+end
+
+error('%s file not found. Looked for %s and in: %s', kind, target, strjoin(search, ', '));
+end
+

--- a/MATLAB/utils/print_timeline_matlab.m
+++ b/MATLAB/utils/print_timeline_matlab.m
@@ -1,0 +1,94 @@
+function print_timeline_matlab(rid, imu_path, gnss_path, truth_path, out_dir)
+%PRINT_TIMELINE_MATLAB Summarise time vectors for IMU/GNSS/Truth datasets.
+%   PRINT_TIMELINE_MATLAB(RID, IMU_PATH, GNSS_PATH, TRUTH_PATH, OUT_DIR)
+%   prints a summary to the console and saves it to <RID>_timeline.txt under
+%   OUT_DIR. The implementation is robust to missing columns and ignores
+%   comments in the truth file.
+%
+%   Usage:
+%       print_timeline_matlab('run_id', 'IMU.dat', 'GNSS.csv', 'STATE.txt', 'results');
+
+lines = {};
+
+% ---------- IMU ----------
+imu = readmatrix(imu_path,'FileType','text');
+nI = size(imu,1);
+% detect time-like column (prefer strictly increasing, else assume 400 Hz)
+col = [];
+for c = 1:min(3,size(imu,2))  % try first 3 cols
+    t = imu(:,c);
+    if all(isfinite(t)) && (numel(unique(diff(t)))==1) && all(diff(t) > 0)
+        col = c; break;
+    end
+end
+if isempty(col)
+    % assume synthetic time at 400 Hz
+    tI = (0:nI-1)'/400;
+    noteI = 'IMU: constructed time @400Hz';
+else
+    tI = imu(:,col);
+    noteI = sprintf('IMU: used time-like column %d (median dt=%.6f)', col, median(diff(tI)));
+end
+lines = [lines; format_line('IMU', tI, nI)];
+
+% ---------- GNSS ----------
+opts = detectImportOptions(gnss_path,'Delimiter',',');
+Tg = readtable(gnss_path, opts);
+nG = height(Tg);
+
+if any(strcmpi(Tg.Properties.VariableNames,'Posix_Time'))
+    tg = Tg.Posix_Time;
+    noteG = 'GNSS: used Posix_Time';
+else
+    % fall back: build from UTC parts if present
+    need = {'UTC_yyyy','UTC_MM','UTC_dd','UTC_HH','UTC_mm','UTC_ss'};
+    if all(ismember(need, Tg.Properties.VariableNames))
+        utc = datetime(Tg.UTC_yyyy, Tg.UTC_MM, Tg.UTC_dd, Tg.UTC_HH, Tg.UTC_mm, Tg.UTC_ss, 'TimeZone','UTC');
+        t0 = utc(1);
+        tg = seconds(utc - t0);
+        noteG = 'GNSS: built from UTC_* columns';
+    else
+        % last fallback: uniform @1Hz
+        tg = (0:nG-1)';
+        noteG = 'GNSS: fallback uniform @1Hz';
+    end
+end
+lines = [lines; format_line('GNSS', tg, nG)];
+
+% ---------- TRUTH ----------
+if ~isempty(truth_path) && isfile(truth_path)
+    % ignore comments (#)
+    opts = detectImportOptions(truth_path, 'Delimiter',' ', 'CommentStyle','#', 'ConsecutiveDelimitersRule','join');
+    Ts = readtable(truth_path, opts);
+    ts = Ts{:,1};
+    nS = numel(ts);
+    lines = [lines; format_line('TRUTH', ts, nS)];
+else
+    lines = [lines; "TRUTH | present but unreadable (see Notes)."];
+end
+
+% ---------- Notes ----------
+notes = {noteI; noteG};
+if exist('noteS','var'), notes{end+1} = noteS; end
+
+% print + save
+txt = strjoin(["== Timeline summary: " + rid + " =="; ""; lines; ""; "Notes:"; "- " + string(notes)], newline);
+disp(txt);
+
+if ~exist(out_dir,'dir'), mkdir(out_dir), end
+out_path = fullfile(out_dir, sprintf('%s_timeline.txt', rid));
+fid = fopen(out_path,'w'); fprintf(fid,'%s\n',txt); fclose(fid);
+fprintf('[DATA TIMELINE] Saved %s\n', out_path);
+
+end
+
+function s = format_line(tag, t, n)
+t = t(:);
+dt  = diff(t);
+hz  = 1/median(dt);
+dur = t(end)-t(1);
+mono = all(dt > 0);
+s = sprintf('%-5s | n=%-7d hz=%-10.6f dt_med=%.6f  min/max dt=(%.6f,%.6f)  dur=%.3fs  t0=%.6f  t1=%.6f  monotonic=%s',...
+    tag, n, hz, median(dt), min(dt), max(dt), dur, t(1), t(end), lower(string(mono)));
+end
+

--- a/MATLAB/utils/project_paths.m
+++ b/MATLAB/utils/project_paths.m
@@ -1,0 +1,41 @@
+function paths = project_paths()
+%PROJECT_PATHS Robust paths for the MATLAB pipeline (independent from Python).
+%   paths = PROJECT_PATHS() returns a struct with paths.root, paths.matlab,
+%   and paths.matlab_results. The function also adds nearby utils directories
+%   to the MATLAB path so that helper functions are found reliably.
+%
+%   Usage:
+%       p = project_paths();
+%
+%   The results directory (MATLAB/results) is created if it does not exist.
+
+here = fileparts(mfilename('fullpath'));  % .../IMU/MATLAB
+paths.matlab = here;
+paths.root   = fileparts(here);           % .../IMU (project root)
+
+% results dir (MATLAB-only)
+paths.matlab_results = fullfile(paths.matlab,'results');
+if ~exist(paths.matlab_results,'dir'), mkdir(paths.matlab_results), end
+
+% candidate utils dirs (add only if they exist)
+utils_candidates = {
+    fullfile(paths.matlab,'utils')
+    fullfile(paths.matlab,'src','utils')
+    fullfile(paths.root,'MATLAB','utils')
+    fullfile(paths.root,'MATLAB','src','utils')
+    fullfile(paths.root,'src','utils')
+};
+
+found_any = false;
+for i = 1:numel(utils_candidates)
+    p = utils_candidates{i};
+    if exist(p,'dir')
+        addpath(p);
+        found_any = true;
+    end
+end
+if ~found_any
+    warning('utils folder not found near %s', fullfile(paths.matlab,'src','utils'));
+end
+end
+

--- a/MATLAB/utils/run_id.m
+++ b/MATLAB/utils/run_id.m
@@ -1,0 +1,19 @@
+function rid = run_id(imu_path, gnss_path, method)
+%RUN_ID Construct a consistent run identifier.
+%   rid = RUN_ID(IMU_PATH, GNSS_PATH, METHOD) returns a string identifier
+%   of the form ``IMU_X002_GNSS_X002_TRIAD``. Only the base names of the
+%   input files are used and METHOD is upper-cased.
+%
+%   Usage:
+%       rid = run_id('IMU_X002.dat', 'GNSS_X002.csv', 'triad');
+
+[~, imu_base, ~]  = fileparts(imu_path);
+[~, gnss_base, ~] = fileparts(gnss_path);
+
+% Normalize names
+imu_tag  = regexprep(imu_base,  '^IMU_','IMU_');
+gnss_tag = regexprep(gnss_base, '^GNSS_','GNSS_');
+
+rid = sprintf('%s_%s_%s', imu_tag, gnss_tag, upper(method));
+end
+

--- a/src/utils/ensure_input_file.py
+++ b/src/utils/ensure_input_file.py
@@ -1,0 +1,40 @@
+"""Locate or copy a data file to the project root.
+
+This stub mirrors the MATLAB ``ensure_input_file`` utility.  The Python
+implementation is pending.  When implemented it should search common
+locations for a given file and copy it to the project root so subsequent
+runs operate on a stable set of inputs.
+
+Usage
+-----
+    ensure_input_file('IMU', 'IMU_X002.dat', paths)
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+
+def ensure_input_file(kind: str, fname: str, paths: Dict[str, Path]) -> Path:
+    """Return absolute path to *fname* ensuring it exists.
+
+    Parameters
+    ----------
+    kind : str
+        Label for diagnostic messages (e.g. "IMU" or "GNSS").
+    fname : str
+        Name of the file to locate.
+    paths : dict
+        Mapping containing at least ``root`` and ``matlab`` entries.
+
+    Returns
+    -------
+    Path
+        Absolute path to the resolved file.
+
+    Notes
+    -----
+    Placeholder implementation; real logic will mirror the MATLAB version.
+    """
+    raise NotImplementedError("ensure_input_file is not yet implemented")
+


### PR DESCRIPTION
## Summary
- Add standalone `project_paths`, `run_id`, `ensure_input_file`, and `print_timeline_matlab` utilities under `MATLAB/utils`
- Refactor `run_triad_only.m` to use new helpers and resolve input files reliably
- Guard library path addition in `Task_4.m` and add Python stub for `ensure_input_file`

## Testing
- `pytest tests/test_utils.py::test_rotation_matrix_orthonormal -q`


------
https://chatgpt.com/codex/tasks/task_e_68965f5e8048832583585b0afd68382e