### PR TITLE
Fix MATLAB project path resolution and add MATLAB path for Python pipeline

### DIFF
--- a/src/compare_python_matlab.py
+++ b/src/compare_python_matlab.py
@@ -35,7 +35,11 @@ def run_matlab_pipeline(imu_file: str, gnss_file: str, method: str) -> Path:
     matlab = shutil.which("matlab") or shutil.which("octave")
     if not matlab:
         raise RuntimeError("MATLAB/Octave not found")
+    # Add MATLAB directory to path before invoking main so Octave/MATLAB
+    # can resolve scripts within the project.
+    matlab_dir = Path(__file__).resolve().parents[1] / "MATLAB"
     cmd = (
+        f"addpath('{matlab_dir}'); "
         f"main('{imu_file}', '{gnss_file}', '{method}');"
     )
     if "octave" in Path(matlab).name:


### PR DESCRIPTION
## Summary
- Robustly compute project root and add utils directories in `project_paths.m`
- Ensure Python's MATLAB pipeline prepends the MATLAB folder to the path before calling `main`

## Testing
- `pytest -q` *(52 passed, 8 skipped, 4 warnings; interrupted after completion)*

------
https://chatgpt.com/codex/tasks/task_e_689666b196e08325a0f3e36dfab25698