### PR TITLE
Standardize Task 6 overlay legend style

### DIFF
--- a/MATLAB/task6_overlay_plot.m
+++ b/MATLAB/task6_overlay_plot.m
@@ -171,12 +171,13 @@ end
 % -------------------------------------------------------------------------
 function pdf_path = plot_overlay(t_est, pos_est, vel_est, acc_est, pos_truth, vel_truth, acc_truth, frame, method, dataset, out_dir)
 %PLOT_OVERLAY Create 2x3 overlay plot of fused vs truth.
+%   The fused estimate is drawn in a red solid line with 'x' markers, while
+%   the ground truth uses a black dotted line with '*' markers for clarity.
 
 labels = {'X','Y','Z'};
 if strcmpi(frame,'NED')
     labels = {'N','E','D'};
 end
-    colors = {[0.2157 0.4824 0.7216], [0.8941 0.1020 0.1098], [0.3010 0.6863 0.2902]};
     ylabels = {'Position [m]','Velocity [m/s]'};
 
     f = figure('Visible','off','Position',[100 100 900 600]);
@@ -185,8 +186,18 @@ end
     for row = 1:2
         for col = 1:3
             subplot(2,3,(row-1)*3+col); hold on;
-            plot(t_est, data_est{row}(:,col), 'Color', colors{col}, 'DisplayName', ['Fused ' labels{col}]);
-            plot(t_est, data_truth{row}(:,col), '--', 'Color', colors{col}, 'DisplayName', ['Truth ' labels{col}]);
+            % Fused estimate in red with 'x' marker
+            if row == 1 && col == 1
+                plot(t_est, data_est{row}(:,col), 'r-', 'LineWidth',2, ...
+                    'Marker','x', 'Markersize',4, 'DisplayName','Fused');
+                plot(t_est, data_truth{row}(:,col), 'k:', ...
+                    'Marker','*', 'Markersize',4, 'DisplayName','Truth');
+            else
+                plot(t_est, data_est{row}(:,col), 'r-', 'LineWidth',2, ...
+                    'Marker','x', 'Markersize',4, 'HandleVisibility','off');
+                plot(t_est, data_truth{row}(:,col), 'k:', ...
+                    'Marker','*', 'Markersize',4, 'HandleVisibility','off');
+            end
             grid on;
             if row == 1
                 title(labels{col});
@@ -196,7 +207,7 @@ end
             end
             xlabel('Time [s]');
             if row == 1 && col == 1
-                legend('Location','northeastoutside');
+                legend('Location','northeast', 'Box','on', 'FontSize',10);
             end
         end
     end

--- a/task6_overlay_plot.py
+++ b/task6_overlay_plot.py
@@ -194,9 +194,13 @@ def plot_overlay(
     dataset: str,
     out_dir: Path,
 ) -> Path:
-    """Create the overlay plot and save it to ``out_dir``."""
+    """Create the overlay plot and save it to ``out_dir``.
+
+    The figure uses a consistent legend scheme: the fused estimate is shown
+    in a red solid line with ``"x"`` markers, and the ground truth is shown
+    in a black dotted line with ``"*"`` markers.
+    """
     labels = ["X", "Y", "Z"] if frame == "ECEF" else ["N", "E", "D"]
-    colors = ["#377eb8", "#e41a1c", "#4daf4a"]  # colorblind friendly
 
     fig, axes = plt.subplots(2, 3, figsize=(12, 6), sharex=True)
 
@@ -208,15 +212,34 @@ def plot_overlay(
     for row, (est, truth, ylab) in enumerate(datasets):
         for col in range(3):
             ax = axes[row, col]
-            ax.plot(t_est, est[:, col], color=colors[col], label=f"Fused {labels[col]}")
-            ax.plot(t_est, truth[:, col], "--", color=colors[col], label=f"Truth {labels[col]}")
+            # plot fused estimate in red with 'x' marker
+            label_fused = "Fused" if (row == 0 and col == 0) else "_nolegend_"
+            ax.plot(
+                t_est,
+                est[:, col],
+                "r-",
+                linewidth=2,
+                marker="x",
+                markersize=3,
+                label=label_fused,
+            )
+            # plot truth in black dotted with '*' marker
+            label_truth = "Truth" if (row == 0 and col == 0) else "_nolegend_"
+            ax.plot(
+                t_est,
+                truth[:, col],
+                "k:",
+                marker="*",
+                markersize=3,
+                label=label_truth,
+            )
             ax.set_ylabel(ylab if col == 0 else "")
             ax.grid(True, alpha=0.3)
             if row == 0:
                 ax.set_title(labels[col])
             ax.set_xlabel("Time [s]")
 
-    axes[0, 0].legend(loc="upper right", ncol=3, fontsize=9, frameon=True)
+    axes[0, 0].legend(loc="upper right", fontsize=9, frameon=True)
 
     fig.suptitle(f"{dataset} Task 6 Overlay — {method} ({frame} frame)")
     fig.tight_layout(rect=[0, 0, 1, 0.95])


### PR DESCRIPTION
## Summary
- Harmonize Task 6 overlay plotting style in Python and MATLAB
- Fused estimates now plot red lines with `x` markers; truth uses black dotted lines with `*` markers
- Ensure legends are boxed and shown once per figure for clarity

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68986c0ee5748325b3a8849f9111a316