### PR TITLE
Add trace capture option to Task 5

### DIFF
--- a/GNSS_IMU_Fusion_Single_script.py
+++ b/GNSS_IMU_Fusion_Single_script.py
@@ -24,8 +24,20 @@ parser.add_argument(
     action="store_true",
     help="Display plots interactively instead of closing them",
 )
+parser.add_argument(
+    "--trace-first-n",
+    type=int,
+    default=0,
+    help="Save first N Kalman filter steps for debugging (stub)",
+)
 args = parser.parse_args()
 INTERACTIVE = args.interactive
+TRACE_FIRST_N = args.trace_first_n
+if TRACE_FIRST_N:
+    logging.info(
+        "Tracing first %d filter steps (Python stub, not yet implemented)",
+        TRACE_FIRST_N,
+    )
 
 from src.constants import EARTH_RATE
 from src.utils import compute_C_ECEF_to_NED, zero_base_time


### PR DESCRIPTION
## Summary
- add optional `trace_first_n` argument to MATLAB `Task_5` for capturing the first N Kalman filter states and covariance
- persist trace data to results and return structure for downstream analysis
- add matching `--trace-first-n` stub option to the Python GNSS/IMU fusion script

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68987d95494c8325b61d54e37ff469cb