### PR TITLE
Set global map limits and save Task 1 plot as PNG

### DIFF
--- a/MATLAB/src/Task_1.m
+++ b/MATLAB/src/Task_1.m
@@ -156,28 +156,31 @@ fprintf('\nSubtask 1.5: Plotting location on Earth map.\n');
 
 % Create a geographic plot if Mapping Toolbox is available
 if exist('geoplot', 'file') == 2 && license('test', 'map_toolbox')
-    figure('Name', 'Initial Location on Earth Map', 'Position', [100, 100, 1000, 500]);
+    figure('Name', 'Initial Location on Earth Map', ...
+           'Position', [100, 100, 1000, 500], 'Visible', 'on');
     geobasemap satellite; % Use satellite imagery as the basemap
 
-    % Set map limits to focus on the location
-    geolimits([lat_deg - 2, lat_deg + 2], [lon_deg - 2, lon_deg + 2]);
+    % Set global map limits
+    geolimits([-90 90], [-180 180]);
 
     % Plot the initial location with a red marker
     hold on;
     geoplot(lat_deg, lon_deg, 'ro', 'MarkerSize', 10, 'MarkerFaceColor', 'r');
 
-    % Add a text label
-    text_str = sprintf('Lat: %.4f°, Lon: %.4f°', lat_deg, lon_deg);
-    text(lon_deg + 0.1, lat_deg, text_str, 'Color', 'white', 'FontSize', 12, 'FontWeight', 'bold');
+    % Add a text label with dataset and coordinates
+    text_str = sprintf('%s\nLat: %.4f°, Lon: %.4f°', tag, lat_deg, lon_deg);
+    text(lon_deg + 0.1, lat_deg, text_str, 'Color', 'white', ...
+         'FontSize', 12, 'FontWeight', 'bold');
     hold off;
 
     % Set plot title
     title('Initial Location on Earth Map');
 
-    % Save the plot as both PDF and PNG using a reasonable page size
+    % Save the plot as PNG using a reasonable page size
     set(gcf, 'PaperPositionMode', 'auto');
     base_fig = figure(gcf);
     save_plot(base_fig, imu_name, gnss_name, method, 1);
+    set(base_fig, 'Visible', 'on');
 else
     warning('Mapping Toolbox not found. Skipping geographic plot.');
 end

--- a/MATLAB/src/save_plot.m
+++ b/MATLAB/src/save_plot.m
@@ -1,24 +1,21 @@
 function save_plot(fig, imu_name, gnss_name, method, task)
-%SAVE_PLOT Save figure as PDF and PNG in the results directory.
+%SAVE_PLOT Save figure as PNG in the results directory.
 %   SAVE_PLOT(FIG, IMU_NAME, GNSS_NAME, METHOD, TASK) writes FIG to the
-%   repository 'results' folder using the naming convention:
-%   IMU_NAME_GNSS_NAME_METHOD_taskTASK_results.pdf and .png.
-%   This mirrors the Python pipeline output structure.
+%   repository ``results`` folder using the naming convention:
+%   ``IMU_NAME_GNSS_NAME_METHOD_taskTASK_results.png``.
 %
 %   Example:
 %       save_plot(fig, 'IMU_X002', 'GNSS_X002', 'TRIAD', 5)
-%   saves results/IMU_X002_GNSS_X002_TRIAD_task5_results.pdf.
+%   saves ``results/IMU_X002_GNSS_X002_TRIAD_task5_results.png``.
 
     results_dir = get_results_dir();
     if ~exist(results_dir, 'dir')
         mkdir(results_dir);
     end
     base = sprintf('%s_%s_%s_task%d_results', imu_name, gnss_name, method, task);
-    pdf_path = fullfile(results_dir, [base '.pdf']);
     png_path = fullfile(results_dir, [base '.png']);
 
     set(fig, 'PaperPosition', [0 0 8 6]);
-    print(fig, pdf_path, '-dpdf', '-bestfit');
     exportgraphics(fig, png_path, 'Resolution', 300);
-    fprintf('Saved plot to %s and %s\n', pdf_path, png_path);
+    fprintf('Saved plot to %s\n', png_path);
 end


### PR DESCRIPTION
## Summary
- Show entire world map in Task_1 with global limits and dataset label
- Save figure only as PNG and keep it visible after saving
- Drop PDF output from save_plot to match new usage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68989745025483258d9e84c55aedf86b