### PR TITLE
chore: drop pdf output from matlab helpers

### DIFF
--- a/MATLAB/src/Task_1.m
+++ b/MATLAB/src/Task_1.m
@@ -174,7 +174,7 @@ if exist('geoplot', 'file') == 2 && license('test', 'map_toolbox')
     % Set plot title
     title('Initial Location on Earth Map');
 
-    % Save the plot as both PDF and PNG using a reasonable page size
+    % Save the plot as PNG using a reasonable page size
     set(gcf, 'PaperPositionMode', 'auto');
     base_fig = figure(gcf);
     save_plot(base_fig, imu_name, gnss_name, method, 1);

--- a/MATLAB/src/save_all_task_plots.m
+++ b/MATLAB/src/save_all_task_plots.m
@@ -343,11 +343,9 @@ end
 % ========================= Save helper =========================
 function save_fig(outdir, base)
 f = gcf;
-pdf = fullfile(outdir, strcat(base,'.pdf'));
 png = fullfile(outdir, strcat(base,'.png'));
 fig = fullfile(outdir, strcat(base,'.fig'));
-exportgraphics(f, pdf, 'ContentType','vector');   % crisp vectors
-exportgraphics(f, png, 'Resolution', 200);        % quick bitmap too
+exportgraphics(f, png, 'Resolution', 200);        % quick bitmap
 savefig(f, fig);                                  % interactive MATLAB figure
-fprintf('Saved: %s\nSaved: %s\nSaved: %s\n', pdf, png, fig);
+fprintf('Saved: %s\nSaved: %s\n', png, fig);
 end

--- a/MATLAB/src/save_plot.m
+++ b/MATLAB/src/save_plot.m
@@ -1,24 +1,22 @@
 function save_plot(fig, imu_name, gnss_name, method, task)
-%SAVE_PLOT Save figure as PDF and PNG in the results directory.
+%SAVE_PLOT Save figure as PNG in the results directory.
 %   SAVE_PLOT(FIG, IMU_NAME, GNSS_NAME, METHOD, TASK) writes FIG to the
 %   repository 'results' folder using the naming convention:
-%   IMU_NAME_GNSS_NAME_METHOD_taskTASK_results.pdf and .png.
+%   IMU_NAME_GNSS_NAME_METHOD_taskTASK_results.png.
 %   This mirrors the Python pipeline output structure.
 %
 %   Example:
 %       save_plot(fig, 'IMU_X002', 'GNSS_X002', 'TRIAD', 5)
-%   saves results/IMU_X002_GNSS_X002_TRIAD_task5_results.pdf.
+%   saves results/IMU_X002_GNSS_X002_TRIAD_task5_results.png.
 
     results_dir = get_results_dir();
     if ~exist(results_dir, 'dir')
         mkdir(results_dir);
     end
     base = sprintf('%s_%s_%s_task%d_results', imu_name, gnss_name, method, task);
-    pdf_path = fullfile(results_dir, [base '.pdf']);
     png_path = fullfile(results_dir, [base '.png']);
 
     set(fig, 'PaperPosition', [0 0 8 6]);
-    print(fig, pdf_path, '-dpdf', '-bestfit');
     exportgraphics(fig, png_path, 'Resolution', 300);
-    fprintf('Saved plot to %s and %s\n', pdf_path, png_path);
+    fprintf('Saved plot to %s\n', png_path);
 end


### PR DESCRIPTION
## Summary
- save_plot.m now exports PNG only with exportgraphics
- save_all_task_plots.m's save_fig helper writes PNG and FIG formats
- adjust Task_1 plotting comment to match PNG-only saving

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898973b7d70832592d52c6d306be4de