### PR TITLE
Streamline Task4 plotting and outputs

### DIFF
--- a/MATLAB/src/save_all_task_plots.m
+++ b/MATLAB/src/save_all_task_plots.m
@@ -20,35 +20,24 @@ else
     warning('Task 6 skipped: no truth provided.');
 end
 
-% ---- Optional: Task 7 diff grids (NED/ECEF/Body) if truth provided
-if exist('truth','var') && ~isempty(truth)
-    try
-        save_task7_plots(t_imu, fusedNED, fusedECEF, fusedBODY, truth, truthNED, truthECEF, truthBODY, outdir);
-        drawnow;
-    catch ME
-        warning('Task 7 plotting failed: %s', ME.message);
+    % ---- Optional: Task 7 diff grids (NED/ECEF/Body) if truth provided
+    if exist('truth','var') && ~isempty(truth)
+        try
+            save_task7_plots(t_imu, fusedNED, fusedECEF, fusedBODY, truth, truthNED, truthECEF, truthBODY, outdir);
+            drawnow;
+        catch ME
+            warning('Task 7 plotting failed: %s', ME.message);
+        end
     end
-end
-
-% ---- Optional: Task 4 plots if inputs are available
-if exist('gnssNED','var') && exist('gnssECEF','var') && exist('imuBODY','var')
-    try
-        save_task4_plots(truth.t, gnssNED, gnssECEF, imuBODY, outdir);  % uses truth.t for a timeline
-        drawnow;
-    catch ME
-        warning('Task 4 plotting failed: %s', ME.message);
+    % ---- Optional: Quaternion comparison if quaternions available
+    if exist('quatFused','var') && exist('truthQuat','var')
+        try
+            save_quaternion_comparison(t_imu, quatFused, truth, truthQuat, outdir);
+            drawnow;
+        catch ME
+            warning('Quaternion comparison failed: %s', ME.message);
+        end
     end
-end
-
-% ---- Optional: Quaternion comparison if quaternions available
-if exist('quatFused','var') && exist('truthQuat','var')
-    try
-        save_quaternion_comparison(t_imu, quatFused, truth, truthQuat, outdir);
-        drawnow;
-    catch ME
-        warning('Quaternion comparison failed: %s', ME.message);
-    end
-end
 end
 
 % ========================= Task 5 =========================
@@ -223,56 +212,6 @@ P.pos_fused = F.pos; P.vel_fused = F.vel; P.acc_fused = F.acc;
 P.pos_truth = T.pos; P.vel_truth = T.vel; P.acc_truth = T.acc;
 P.pos_residual = R.pos; P.vel_residual = R.vel; P.acc_residual = R.acc;
 P.rmse = rmse; P.final = final;
-end
-linkaxes(ax,'x'); xlim([t(1) t(end)]);
-end
-
-% ========================= Task 4 (NED/ECEF/Body only) =========================
-function save_task4_plots(t_gnss, gnssNED, gnssECEF, imuBODY, outdir)
-% Expects gnssNED.pos/vel/acc, gnssECEF.pos/vel/acc, imuBODY.acc (Nx3)
-trel = t_gnss(:) - t_gnss(1);
-
-% NED (GNSS measured vs. IMU-derived acceleration rotated to NED if provided)
-plot_task4_grid('Task4_NED', 'NED', trel, gnssNED);
-save_fig(outdir,'IMU_X002_GNSS_X002_TRIAD_task4_all_NED');
-
-% ECEF
-plot_task4_grid('Task4_ECEF', 'ECEF', trel, gnssECEF);
-save_fig(outdir,'IMU_X002_GNSS_X002_TRIAD_task4_all_ECEF');
-
-% Body (acc from IMU body)
-plot_task4_grid('Task4_Body', 'Body', trel, imuBODY);
-save_fig(outdir,'IMU_X002_GNSS_X002_TRIAD_task4_all_Body');
-end
-
-function plot_task4_grid(figName, frameName, t, S)
-figure('Name',figName,'WindowState','maximized');
-tiledlayout(3,3,'TileSpacing','compact','Padding','compact');
-sgtitle(sprintf('Task 4 – TRIAD – %s Frame (IMU-derived vs. Measured GNSS)', frameName),'FontWeight','bold');
-
-rows = {'Position','Velocity','Acceleration'};
-if strcmpi(frameName,'NED'), cols = {'North','East','Down'}; else, cols = {'X','Y','Z'}; end
-ylab = {'[m]','[m/s]','[m/s^2]'};
-
-dataP = S.pos; dataV = S.vel; dataA = S.acc;
-ax = gobjects(9,1); k = 0;
-for r = 1:3
-    for c = 1:3
-        k=k+1; ax(k)=nexttile; hold on; grid on;
-        if r==1
-            plot(t, dataP(:,c), 'k-', 'LineWidth', 1.1, 'DisplayName','Measured GNSS');
-        elseif r==2
-            plot(t, dataV(:,c), 'k-', 'LineWidth', 1.1, 'DisplayName','Measured GNSS');
-        else
-            plot(t, dataA(:,c), 'k-', 'LineWidth', 1.1, 'DisplayName','Measured GNSS');
-        end
-        title(sprintf('%s %s', rows{r}, cols{c}));
-        xlabel('Time [s]'); ylabel(ylab{r});
-        axis tight;
-        if r==1 && c==1
-            legend('Location','best');
-        end
-    end
 end
 linkaxes(ax,'x'); xlim([t(1) t(end)]);
 end

--- a/MATLAB/src/task4_make_plots.m
+++ b/MATLAB/src/task4_make_plots.m
@@ -48,21 +48,21 @@ for i=1:3
     plot(tG, S.gnss_pos_ned(:,i), 'k-', 'LineWidth', lw1); hold on;
     plot(tI, S.imu_pos_g(:,i),    ':', 'LineWidth', lw2, 'Color', colIMU);
     grid on; xlabel('Time [s]'); ylabel('Position [m]'); title(labsP{i});
-    legend('Derived GNSS','Derived IMU (TRIAD)','Location','best'); legend boxoff; axis tight;
+    legend('GNSS (measured)','IMU (derived)','Location','best'); legend boxoff; axis tight;
 end
 for i=1:3
     nexttile;
     plot(tG, S.gnss_vel_ned(:,i), 'k-', 'LineWidth', lw1); hold on;
     plot(tI, S.imu_vel_g(:,i),    ':', 'LineWidth', lw2, 'Color', colIMU);
     grid on; xlabel('Time [s]'); ylabel('Velocity [m/s]'); title(labsV{i});
-    legend('Derived GNSS','Derived IMU (TRIAD)','Location','best'); legend boxoff; axis tight;
+    legend('GNSS (measured)','IMU (derived)','Location','best'); legend boxoff; axis tight;
 end
 for i=1:3
     nexttile;
     plot(tG, S.gnss_acc_ned(:,i), '--', 'Color',[0.4 0.4 0.4], 'LineWidth', lw1); hold on;
     plot(tI, S.imu_acc_g(:,i),     '-',  'LineWidth', lw2, 'Color', colIMU);
     grid on; xlabel('Time [s]'); ylabel('Acceleration [m/s^2]'); title(labsA{i});
-    legend('Derived GNSS','Derived IMU (TRIAD)','Location','best'); legend boxoff; axis tight;
+    legend('GNSS (measured)','IMU (derived)','Location','best'); legend boxoff; axis tight;
 end
 sgtitle('Task 4 – TRIAD – NED Frame (IMU-derived vs. Measured GNSS)');
 linkaxes(findall(gcf,'type','axes'),'x');
@@ -101,21 +101,21 @@ for i=1:3
     plot(tG, p_ecef_gnss(:,i), 'k-', 'LineWidth', lw1); hold on;
     plot(tI, p_ecef_imu(:,i),  ':', 'LineWidth', lw2, 'Color', colIMU);
     grid on; xlabel('Time [s]'); ylabel('Position [m]'); title(labsP{i});
-    legend('Measured GNSS','Derived IMU (TRIAD)','Location','best'); legend boxoff; axis tight;
+    legend('GNSS (measured)','IMU (derived)','Location','best'); legend boxoff; axis tight;
 end
 for i=1:3
     nexttile;
     plot(tG, v_ecef_gnss(:,i), 'k-', 'LineWidth', lw1); hold on;
     plot(tI, v_ecef_imu(:,i),  ':', 'LineWidth', lw2, 'Color', colIMU);
     grid on; xlabel('Time [s]'); ylabel('Velocity [m/s]'); title(labsV{i});
-    legend('Measured GNSS','Derived IMU (TRIAD)','Location','best'); legend boxoff; axis tight;
+    legend('GNSS (measured)','IMU (derived)','Location','best'); legend boxoff; axis tight;
 end
 for i=1:3
     nexttile;
     plot(tG, a_ecef_gnss(:,i), '--', 'Color',[0.4 0.4 0.4], 'LineWidth', lw1); hold on;
     plot(tI, a_ecef_imu(:,i),   '-',  'LineWidth', lw2, 'Color', colIMU);
     grid on; xlabel('Time [s]'); ylabel('Acceleration [m/s^2]'); title(labsA{i});
-    legend('Derived GNSS','Derived IMU (TRIAD)','Location','best'); legend boxoff; axis tight;
+    legend('GNSS (measured)','IMU (derived)','Location','best'); legend boxoff; axis tight;
 end
 sgtitle('Task 4 – TRIAD – ECEF Frame (IMU-derived vs. Measured GNSS)');
 linkaxes(findall(gcf,'type','axes'),'x');
@@ -182,21 +182,21 @@ try
         plot(tG, gnss_pos_body(:,i), 'k-', 'LineWidth', lw1); hold on;
         plot(tG, imu_pos_body(:,i),  ':', 'LineWidth', lw2, 'Color', colIMU);
         grid on; xlabel('Time [s]'); ylabel('m'); title(labsP{i});
-        legend('Derived GNSS','Derived IMU (TRIAD)','Location','best'); legend boxoff; axis tight;
+        legend('GNSS (measured)','IMU (derived)','Location','best'); legend boxoff; axis tight;
     end
     for i=1:3
         nexttile; % Velocity
         plot(tG, gnss_vel_body(:,i), 'k-', 'LineWidth', lw1); hold on;
         plot(tG, imu_vel_body(:,i),  ':', 'LineWidth', lw2, 'Color', colIMU);
         grid on; xlabel('Time [s]'); ylabel('m/s'); title(labsV{i});
-        legend('Derived GNSS','Derived IMU (TRIAD)','Location','best'); legend boxoff; axis tight;
+        legend('GNSS (measured)','IMU (derived)','Location','best'); legend boxoff; axis tight;
     end
     for i=1:3
         nexttile; % Acceleration: Derived GNSS vs Measured IMU
         plot(tG, gnss_acc_body(:,i), '--', 'Color',[0.4 0.4 0.4], 'LineWidth', lw1); hold on;
         plot(tI, acc_body_corr(1:numel(tI),i), '-', 'LineWidth', lw2, 'Color', colIMU);
         grid on; xlabel('Time [s]'); ylabel('m/s^2'); title(labsA{i});
-        legend('Derived GNSS','Measured IMU (Body accel)','Location','best'); legend boxoff; axis tight;
+        legend('GNSS (measured)','IMU (derived)','Location','best'); legend boxoff; axis tight;
     end
     sgtitle('Task 4 – TRIAD – Body Frame (IMU-derived vs. GNSS-derived; IMU accel measured)');
     linkaxes(findall(gcf,'type','axes'),'x');
@@ -212,29 +212,25 @@ catch ME
     warning('Body frame plot skipped: %s', ME.message);
 end
 
-%% Auto-save PDFs/PNGs
+%% Auto-save PNGs
 try
-    base = fullfile(results_dir, rid);
     % Save current open figures in order: NED, ECEF, Body
     figs = findall(0,'Type','figure');
-    % Reverse to save in creation order approximation
+    % Reverse to approximate creation order
     for f = flipud(figs(:)')
         nm = get(f,'Name');
         if contains(nm,'NED')
-            out = sprintf('%s_task4_grid_NED.pdf', rid);
+            out = sprintf('%s_task4_comparison_NED.png', rid);
         elseif contains(nm,'ECEF')
-            out = sprintf('%s_task4_grid_ECEF.pdf', rid);
+            out = sprintf('%s_task4_comparison_ECEF.png', rid);
         elseif contains(nm,'Body')
-            out = sprintf('%s_task4_grid_Body.pdf', rid);
+            out = sprintf('%s_task4_comparison_Body.png', rid);
         else
             continue;
         end
         set(f,'PaperPositionMode','auto');
-        print(f, fullfile(results_dir, out), '-dpdf', '-bestfit');
-        try
-            print(f, fullfile(results_dir, strrep(out,'.pdf','.png')), '-dpng', '-r300');
-        catch
-        end
+        print(f, fullfile(results_dir, out), '-dpng', '-r300');
+        figure(f); drawnow;
     end
 catch ME
     warning('Auto-save of Task 4 plots failed: %s', ME.message);


### PR DESCRIPTION
## Summary
- Remove legacy Task4 "all" plot generation from the save-all helper
- Update Task4 comparison script to overlay GNSS vs IMU and save PNGs named `<RID>_task4_comparison_<frame>.png`

## Testing
- `pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_6898974919d483258b70ed54a7f07aa6