### PR TITLE
Refine attitude angle plot naming and layout

### DIFF
--- a/MATLAB/src/task6_truth_overlay.m
+++ b/MATLAB/src/task6_truth_overlay.m
@@ -149,12 +149,18 @@ print(f_body, png_body, '-dpng', '-bestfit');
 close(f_body);
 
 f_att = figure('Visible','off');
-plot(t_imu, eul);
-legend({'Roll','Pitch','Yaw'}); grid on;
-xlabel('Time [s]'); ylabel('Angle [deg]');
+labels = {'Roll','Pitch','Yaw'};
+for i = 1:3
+    subplot(3,1,i); hold on;
+    plot(t_imu, eul(:,i), 'DisplayName', labels{i});
+    ylabel([labels{i} ' [deg]']); grid on;
+    legend('Location','best');
+    if i==1; title('Task 6: Attitude Angles (NED)'); end
+    if i==3; xlabel('Time [s]'); end
+end
 set(f_att,'PaperPositionMode','auto');
 
-pdf_att = fullfile(results_dir, sprintf('%s_task6_attitude_angles.pdf', run_id));
+pdf_att = fullfile(results_dir, sprintf('%s_task6_attitude_angles_NED.pdf', run_id));
 png_att = strrep(pdf_att,'.pdf','.png');
 print(f_att, pdf_att, '-dpdf', '-bestfit');
 print(f_att, png_att, '-dpng', '-bestfit');

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Typical result PDFs:
 - `task5_all_ecef.pdf` – Kalman filter results in ECEF frame
 - `task5_all_body.pdf` – Kalman filter results in body frame
 - `<method>_residuals.pdf` – position and velocity residuals
-- `<tag>_task6_attitude_angles.pdf` – attitude angles over time
+- `<tag>_task6_attitude_angles_NED.png` – attitude angles over time in NED frame
 - `<tag>_<frame>_overlay_truth.pdf` – fused output vs reference. Here `<tag>` is
   the dataset pair and method concatenated, e.g. `IMU_X002_GNSS_X002_Davenport`.
  - ``results/<tag>_task6_overlay_state_<frame>.pdf`` – Task 6 overlay with GNSS, IMU and raw state (PDF/PNG/``.fig``) plus ``.mat``

--- a/plot_summary.md
+++ b/plot_summary.md
@@ -12,7 +12,7 @@
 - **X001_TRIAD_task5_all_body.pdf**: Kalman filter results in body frame
 - **X001_TRIAD_task5_mixed_frames.pdf**: Kalman filter results in mixed frames
 - **X001_TRIAD_residuals.pdf**: Position and velocity residuals
-- **X001_TRIAD_task6_attitude_angles.pdf**: Attitude angles over time
+- **X001_TRIAD_task6_attitude_angles_NED.png**: Attitude angles over time (NED frame)
 - **<method>_<frame>_overlay_truth.pdf**: Fused results versus reference
 - **<method>_<frame>_overlay_state.pdf**: Fused results versus raw state file
 - **<tag>_task6_overlay_state_<frame>.pdf**: Task 6 overlay using raw state data

--- a/python/src/GNSS_IMU_Fusion.py
+++ b/python/src/GNSS_IMU_Fusion.py
@@ -1860,14 +1860,12 @@ def main():
         save_plot(fig_innov, innov_pdf, "Pre-fit Innovations")
 
     # Plot residuals and attitude using helper functions
+    frame = "NED"
     if not args.no_plots:
         res = compute_residuals(gnss_time, gnss_pos_ned, imu_time, fused_pos[method])
         plot_residuals(gnss_time, res, f"results/residuals_{tag}_{method}.pdf")
-        plot_attitude(
-            imu_time,
-            attitude_q_all[method],
-            f"results/attitude_angles_{tag}_{method}.pdf",
-        )
+        out_base = f"results/{tag}_task6_attitude_angles_{frame}"
+        plot_attitude(imu_time, attitude_q_all[method], out_base, frame)
 
     # Create plot summary
     summary = {
@@ -1886,7 +1884,7 @@ def main():
         f"{tag}_task5_all_body.pdf": "Kalman filter results in body frame",
         f"{tag}_{method.lower()}_residuals.pdf": "Position and velocity residuals",
         f"{tag}_{method.lower()}_innovations.pdf": "Pre-fit innovations",
-        f"{tag}_{method.lower()}_attitude_angles.pdf": "Attitude angles over time",
+        f"{tag}_task6_attitude_angles_{frame}.png": "Attitude angles over time (NED frame)",
     }
     summary_path = os.path.join("results", f"{tag}_plot_summary.md")
     with open(summary_path, "w") as f:
@@ -1917,23 +1915,6 @@ def main():
 
     accel_bias = acc_biases.get(method, np.zeros(3))
     gyro_bias = gyro_biases.get(method, np.zeros(3))
-
-    # --- Attitude angles ----------------------------------------------------
-    euler = R.from_quat(attitude_q_all[method]).as_euler("xyz", degrees=True)
-    if not args.no_plots:
-        plt.figure()
-        plt.plot(imu_time, euler[:, 0], label="Roll")
-        plt.plot(imu_time, euler[:, 1], label="Pitch")
-        plt.plot(imu_time, euler[:, 2], label="Yaw")
-        plt.xlabel("Time (s)")
-        plt.ylabel("Angle (deg)")
-        plt.legend(loc="best")
-        plt.title(f"Task 6: {tag} Attitude Angles")
-        png = Path("results") / f"{tag}_task6_attitude_angles.png"
-        pdf = png.with_suffix(".pdf")
-        plt.savefig(png)
-        plt.savefig(pdf)
-        plt.close()
 
     C_NED_to_ECEF = C_ECEF_to_NED.T
     pos_ecef = np.array([C_NED_to_ECEF @ p + ref_r0 for p in fused_pos[method]])

--- a/python/src/scripts/plot_utils.py
+++ b/python/src/scripts/plot_utils.py
@@ -12,18 +12,35 @@ def save_plot(fig, outpath, title):
     plt.close(fig)
 
 
-def plot_attitude(time, quats, outpath):
+def plot_attitude(time, quats, out_base: str, frame: str = "NED"):
+    """Plot roll, pitch and yaw angles over time.
+
+    Parameters
+    ----------
+    time : np.ndarray
+        Time vector corresponding to ``quats``.
+    quats : np.ndarray
+        Quaternion sequence ``(N,4)`` in ``xyzw`` order.
+    out_base : str
+        Output path without file extension.
+    frame : str, optional
+        Reference frame label used in the plot title and file name.
+    """
+
     r = R.from_quat(quats)
-    euler = r.as_euler('xyz', degrees=True)
-    fig, axs = plt.subplots(3, 1, figsize=(6, 8))
-    labels = ['Roll', 'Pitch', 'Yaw']
-    for i in range(3):
-        axs[i].plot(time, euler[:, i])
-        axs[i].set_ylabel(f"{labels[i]} (°)")
-    axs[-1].set_xlabel("Time (s)")
-    fig.suptitle("Task 6: Attitude Angles Over Time")
-    fig.tight_layout(rect=[0, 0, 1, 0.96])
-    fig.savefig(outpath)
+    euler = r.as_euler("xyz", degrees=True)
+    fig, axs = plt.subplots(3, 1, figsize=(6, 8), sharex=True)
+    labels = ["Roll", "Pitch", "Yaw"]
+    for i, lab in enumerate(labels):
+        axs[i].plot(time, euler[:, i], label=lab)
+        axs[i].set_ylabel(f"{lab} [deg]")
+        axs[i].legend(loc="best")
+        axs[i].grid(True)
+    axs[-1].set_xlabel("Time [s]")
+    fig.suptitle(f"Task 6: Attitude Angles ({frame})")
+    fig.tight_layout(rect=[0, 0, 1, 0.95])
+    fig.savefig(f"{out_base}.pdf")
+    fig.savefig(f"{out_base}.png")
     plt.close(fig)
 
 


### PR DESCRIPTION
## Summary
- Streamline GNSS/IMU fusion by using a single `plot_attitude` helper to generate roll, pitch, and yaw subplots
- Save Task 6 attitude plots as `<TAG>_task6_attitude_angles_NED.{pdf,png}` and remove redundant plotting code
- Mirror plotting changes in MATLAB and update documentation references

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898974f14088325973e72941048e470