### PR TITLE
Add multi-plot attitude angle output

### DIFF
--- a/MATLAB/src/task6_truth_overlay.m
+++ b/MATLAB/src/task6_truth_overlay.m
@@ -149,12 +149,19 @@ print(f_body, png_body, '-dpng', '-bestfit');
 close(f_body);
 
 f_att = figure('Visible','off');
-plot(t_imu, eul);
-legend({'Roll','Pitch','Yaw'}); grid on;
-xlabel('Time [s]'); ylabel('Angle [deg]');
+labels = {'Roll','Pitch','Yaw'};
+for i = 1:3
+    subplot(3,1,i);
+    plot(t_imu, eul(:,i));
+    ylabel(sprintf('%s [deg]', labels{i}));
+    grid on;
+    legend(labels{i}, 'Location','best');
+end
+xlabel('Time [s]');
+sgtitle(sprintf('Task 6: %s Attitude Angles (NED)', run_id), 'Interpreter','none');
 set(f_att,'PaperPositionMode','auto');
 
-pdf_att = fullfile(results_dir, sprintf('%s_task6_attitude_angles.pdf', run_id));
+pdf_att = fullfile(results_dir, sprintf('%s_task6_attitude_angles_NED.pdf', run_id));
 png_att = strrep(pdf_att,'.pdf','.png');
 print(f_att, pdf_att, '-dpdf', '-bestfit');
 print(f_att, png_att, '-dpng', '-bestfit');

--- a/python/src/scripts/plot_utils.py
+++ b/python/src/scripts/plot_utils.py
@@ -12,20 +12,21 @@ def save_plot(fig, outpath, title):
     plt.close(fig)
 
 
-def plot_attitude(time, quats, outpath):
+def plot_attitude(time, quats, outpath, title="Task 6: Attitude Angles Over Time"):
     r = R.from_quat(quats)
     euler = r.as_euler('xyz', degrees=True)
-    fig, axs = plt.subplots(3, 1, figsize=(6, 8))
+    fig, axs = plt.subplots(3, 1, figsize=(6, 8), sharex=True)
     labels = ['Roll', 'Pitch', 'Yaw']
     for i in range(3):
         axs[i].plot(time, euler[:, i])
         axs[i].set_ylabel(f"{labels[i]} (°)")
+        axs[i].grid(True)
+        axs[i].legend([labels[i]], loc="best", frameon=True)
     axs[-1].set_xlabel("Time (s)")
-    fig.suptitle("Task 6: Attitude Angles Over Time")
-    fig.tight_layout(rect=[0, 0, 1, 0.96])
+    fig.suptitle(title)
+    fig.tight_layout(rect=[0, 0, 1, 0.95])
     fig.savefig(outpath)
     plt.close(fig)
-
 
 
 def plot_zupt_detection(accel_data: np.ndarray, gyro_data: np.ndarray,


### PR DESCRIPTION
## Summary
- use shared `plot_attitude` helper to render roll, pitch, yaw subplots
- save attitude plot as `<TAG>_task6_attitude_angles_NED.[png|pdf]`
- mirror attitude plot changes in MATLAB task6 overlay script

## Testing
- `pytest`
- `flake8 python/src/GNSS_IMU_Fusion.py python/src/scripts/plot_utils.py`
- `octave --quiet --eval "cd('tests'); test_static_interval_matlab"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68989a262f9c8325a8d81b6a1b9a492c