### PR TITLE
Refactor MATLAB plot helpers to export PNG only

### DIFF
--- a/MATLAB/src/save_all_task_plots.m
+++ b/MATLAB/src/save_all_task_plots.m
@@ -281,10 +281,9 @@ end
 
 % ========================= Save helper =========================
 function save_fig(outdir, base)
+%SAVE_FIG Save current figure as a PNG file in OUTDIR.
 f = gcf;
 png = fullfile(outdir, strcat(base,'.png'));
-fig = fullfile(outdir, strcat(base,'.fig'));
-exportgraphics(f, png, 'Resolution', 200);        % quick bitmap
-savefig(f, fig);                                  % interactive MATLAB figure
-fprintf('Saved: %s\nSaved: %s\n', png, fig);
+exportgraphics(f, png, 'Resolution', 200);
+fprintf('Saved: %s\n', png);
 end

--- a/MATLAB/src/save_plot.m
+++ b/MATLAB/src/save_plot.m
@@ -4,6 +4,8 @@ function save_plot(fig, imu_name, gnss_name, method, task)
 %   repository ``results`` folder using the naming convention:
 %   ``IMU_NAME_GNSS_NAME_METHOD_taskTASK_results.png``.
 %
+%   Only a PNG is produced; PDF generation has been removed.
+%
 %   Example:
 %       save_plot(fig, 'IMU_X002', 'GNSS_X002', 'TRIAD', 5)
 %   saves ``results/IMU_X002_GNSS_X002_TRIAD_task5_results.png``.
@@ -15,7 +17,6 @@ function save_plot(fig, imu_name, gnss_name, method, task)
     base = sprintf('%s_%s_%s_task%d_results', imu_name, gnss_name, method, task);
     png_path = fullfile(results_dir, [base '.png']);
 
-    set(fig, 'PaperPosition', [0 0 8 6]);
     exportgraphics(fig, png_path, 'Resolution', 300);
     fprintf('Saved plot to %s\n', png_path);
 end


### PR DESCRIPTION
## Summary
- Remove residual PDF export logic in `save_plot.m`, relying solely on `exportgraphics` for PNG output
- Simplify `save_fig` helper to write only PNG files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68989ba596ac8325801faafde5ad386a