### PR TITLE
feat: auto-resolve truth file via env var

### DIFF
--- a/MATLAB/src/run_all_methods.m
+++ b/MATLAB/src/run_all_methods.m
@@ -12,6 +12,10 @@ function run_all_methods()
     method = 'TRIAD';
 
     root_dir  = fileparts(fileparts(mfilename('fullpath')));
+    utils_dir = fullfile(fileparts(mfilename('fullpath')), 'utils');
+    if exist(utils_dir,'dir') && ~contains(path, [utils_dir pathsep])
+        addpath(utils_dir);
+    end
     imu_path  = fullfile(root_dir, dataset.imu);
     gnss_path = fullfile(root_dir, dataset.gnss);
 
@@ -27,7 +31,7 @@ function run_all_methods()
     Task_5(imu_path, gnss_path, method);
 
     res_file = fullfile(get_results_dir(), sprintf('IMU_X002_GNSS_X002_%s_task5_results.mat', method));
-    truth_file = fullfile(root_dir, 'STATE_X001.txt');
+    truth_file = resolve_truth_path();
     if isfile(res_file) && isfile(truth_file)
         [~, imu_name, ~]  = fileparts(dataset.imu);
         [~, gnss_name, ~] = fileparts(dataset.gnss);

--- a/MATLAB/src/run_triad_only.m
+++ b/MATLAB/src/run_triad_only.m
@@ -33,8 +33,6 @@ if ~isfield(cfg,'dataset_id'), cfg.dataset_id = 'X002'; end
 if ~isfield(cfg,'method'),     cfg.method     = 'TRIAD'; end
 if ~isfield(cfg,'imu_file'),   cfg.imu_file   = 'IMU_X002.dat'; end
 if ~isfield(cfg,'gnss_file'),  cfg.gnss_file  = 'GNSS_X002.csv'; end
-% Single-truth-file policy (always this name)
-if ~isfield(cfg,'truth_file'), cfg.truth_file = 'STATE_X001.txt'; end
 
 % Plot options defaults to avoid missing-field errors in Task 4/5
 if ~isfield(cfg,'plots') || ~isstruct(cfg.plots)
@@ -54,7 +52,7 @@ cfg.paths = paths;
 % ---- resolve inputs from DATA directory ----
 cfg.imu_path   = fullfile(data_dir, 'IMU',   cfg.imu_file);
 cfg.gnss_path  = fullfile(data_dir, 'GNSS',  cfg.gnss_file);
-cfg.truth_path = fullfile(data_dir, 'TRUTH', cfg.truth_file);
+cfg.truth_path = resolve_truth_path();
 
 % ---- run id + timeline (before tasks) ----
 rid = run_id(cfg.imu_path, cfg.gnss_path, cfg.method);

--- a/MATLAB/src/utils/resolve_truth_path.m
+++ b/MATLAB/src/utils/resolve_truth_path.m
@@ -2,9 +2,16 @@ function truth_path = resolve_truth_path()
 %RESOLVE_TRUTH_PATH Canonicalize the truth file path.
 %   truth_path = resolve_truth_path()
 %       Returns the path string to the truth file if found, or an empty char
-%       if it does not exist.
+%       if it does not exist. Checks the IMU_TRUTH_PATH environment variable
+%       before searching default locations.
 
     root = fileparts(fileparts(mfilename('fullpath')));
+    env = getenv('IMU_TRUTH_PATH');
+    if ~isempty(env) && isfile(env)
+        truth_path = env;
+        fprintf('Using TRUTH: %s\n', truth_path);
+        return;
+    end
     candidates = {
         fullfile(root, 'DATA', 'TRUTH', 'STATE_X001.txt'),
         fullfile(root, 'DATA', 'TRUTH', 'STATE_X001_small.txt')

--- a/python/src/utils/resolve_truth_path.py
+++ b/python/src/utils/resolve_truth_path.py
@@ -7,6 +7,7 @@ preferred path for the truth file if it exists.
 from __future__ import annotations
 
 from pathlib import Path
+import os
 
 
 def resolve_truth_path() -> str | None:
@@ -14,6 +15,10 @@ def resolve_truth_path() -> str | None:
 
     Returns the canonical truth file path if found, otherwise ``None``.
     """
+    env = os.getenv("IMU_TRUTH_PATH")
+    if env and Path(env).exists():
+        print(f"Using TRUTH: {env}")
+        return env
     root = Path(__file__).resolve().parents[2]
     candidates = [
         root / "DATA" / "TRUTH" / "STATE_X001.txt",


### PR DESCRIPTION
## Summary
- add `_resolve_truth_path` helper and use env var `IMU_TRUTH_PATH`
- auto-wire truth path for Python and MATLAB runners
- update utilities to search env var and fall back to default truth files

## Testing
- `pytest -q`
- `pytest python/src/test_env.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6898df0f6c9883259303a1793016252a