### PR TITLE
Fix truth file path resolution

### DIFF
--- a/MATLAB/src/utils/resolve_truth_path.m
+++ b/MATLAB/src/utils/resolve_truth_path.m
@@ -5,7 +5,8 @@ function truth_path = resolve_truth_path()
 %       if it does not exist. Checks the IMU_TRUTH_PATH environment variable
 %       before searching default locations.
 
-    root = fileparts(fileparts(mfilename('fullpath')));
+    % Climb from utils/ -> src -> MATLAB -> repo root
+    root = fileparts(fileparts(fileparts(fileparts(mfilename('fullpath')))));
     env = getenv('IMU_TRUTH_PATH');
     if ~isempty(env) && isfile(env)
         truth_path = env;

--- a/python/src/run_all_datasets.py
+++ b/python/src/run_all_datasets.py
@@ -35,7 +35,8 @@ def _resolve_truth_path(defaults=None):
     if env and Path(env).exists():
         return env
     # 2) known candidates relative to repo root (python/src/ -> repo = parents[2])
-    root = Path(__file__).resolve().parents[2] if len(Path(__file__).resolve().parents) >= 2 else Path.cwd()
+    here = Path(__file__).resolve()
+    root = here.parents[2] if len(here.parents) >= 3 else here.parent
     cands = (defaults or []) + [
         root / "DATA" / "TRUTH" / "STATE_X001.txt",
         root / "DATA" / "TRUTH" / "STATE_X001_small.txt",

--- a/python/src/run_all_methods.py
+++ b/python/src/run_all_methods.py
@@ -49,7 +49,8 @@ def _resolve_truth_path(defaults=None):
     if env and Path(env).exists():
         return env
     # 2) known candidates relative to repo root (python/src/ -> repo = parents[2])
-    root = Path(__file__).resolve().parents[2] if len(Path(__file__).resolve().parents) >= 2 else Path.cwd()
+    here = Path(__file__).resolve()
+    root = here.parents[2] if len(here.parents) >= 3 else here.parent
     cands = (defaults or []) + [
         root / "DATA" / "TRUTH" / "STATE_X001.txt",
         root / "DATA" / "TRUTH" / "STATE_X001_small.txt",

--- a/python/src/run_triad_only.py
+++ b/python/src/run_triad_only.py
@@ -44,7 +44,8 @@ def _resolve_truth_path(defaults=None):
     if env and Path(env).exists():
         return env
     # 2) known candidates relative to repo root (python/src/ -> repo = parents[2])
-    root = Path(__file__).resolve().parents[2] if len(Path(__file__).resolve().parents) >= 2 else Path.cwd()
+    here = Path(__file__).resolve()
+    root = here.parents[2] if len(here.parents) >= 3 else here.parent
     cands = (defaults or []) + [
         root / "DATA" / "TRUTH" / "STATE_X001.txt",
         root / "DATA" / "TRUTH" / "STATE_X001_small.txt",

--- a/tests/test_resolve_truth_path.py
+++ b/tests/test_resolve_truth_path.py
@@ -1,0 +1,16 @@
+"""Tests for automatic truth path resolution."""
+
+from pathlib import Path
+
+
+def test_resolve_truth_path(monkeypatch):
+    """Ensure ``_resolve_truth_path`` finds ``DATA/TRUTH/STATE_X001.txt`` by default."""
+    root = Path(__file__).resolve().parents[1]
+    monkeypatch.syspath_prepend(str(root / "python" / "src"))
+    monkeypatch.delenv("IMU_TRUTH_PATH", raising=False)
+    import run_triad_only  # noqa: E402
+
+    expected = root / "DATA" / "TRUTH" / "STATE_X001.txt"
+    path = run_triad_only._resolve_truth_path()
+    assert Path(path) == expected
+


### PR DESCRIPTION
## Summary
- ensure Python runners search for truth data from the repo root
- mirror truth path logic in MATLAB utility
- add test verifying default truth file discovery

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898e31e73cc83258023b0b5a53a598f