### PR TITLE
fix: ensure utils on MATLAB path for Task 4

### DIFF
--- a/MATLAB/src/Task_4.m
+++ b/MATLAB/src/Task_4.m
@@ -16,7 +16,10 @@ function result = Task_4(imu_path, gnss_path, method)
 paths = project_paths();
 results_dir = paths.matlab_results;
 lib_path = fullfile(paths.root,'MATLAB','lib');
+utils_path = fullfile(paths.matlab,'src','utils');
+% Ensure library and utility helpers (e.g. zero_base_time) are on the path
 if exist(lib_path,'dir'), addpath(lib_path); end
+if exist(utils_path,'dir'), addpath(utils_path); end
 
 % pull configuration from caller
 try


### PR DESCRIPTION
## Summary
- Ensure Task 4 adds MATLAB utility directory to the path so helpers like `zero_base_time` are available
- Document path setup for library and utility helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898e800b2d8832591acbfff7273dea9