### PR TITLE
Handle corrupt result archives in batch runners

### DIFF
--- a/MATLAB/src/run_all_datasets.m
+++ b/MATLAB/src/run_all_datasets.m
@@ -39,7 +39,12 @@ for i = 1:numel(imu_files)
             warning('Missing expected output %s', result_file);
             continue;
         end
-        result = load(result_file);
+        try
+            result = load(result_file);
+        catch ME
+            warning('Failed to load %s: %s', result_file, ME.message);
+            continue; % skip MATLAB export if result file is bad
+        end
         var_name = sprintf('result_%s_%s_%s', imuName, gnssName, method);
         assignin('base', var_name, result);
         save(fullfile(results_dir,[var_name '.mat']), '-struct', 'result');


### PR DESCRIPTION
## Summary
- protect `run_all_datasets.py` against corrupted NPZ outputs by catching `zipfile.BadZipFile`, removing the broken archive, and skipping MATLAB export
- mirror the same safeguard in `MATLAB/src/run_all_datasets.m` with a `try/catch` around `load`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898ea5f29ec8325bbaa4350c5616ca9