### PR TITLE
Check truth files exist before overlay

### DIFF
--- a/MATLAB/src/validate_with_truth.m
+++ b/MATLAB/src/validate_with_truth.m
@@ -1,0 +1,43 @@
+function validate_with_truth(est_file, truth_file, output_dir)
+%VALIDATE_WITH_TRUTH Stub to mirror Python validate_with_truth behavior.
+%   Checks that expected IMU and GNSS files exist before generating
+%   overlays. If files are missing, a warning is issued and overlay
+%   generation is skipped.
+%
+%   Usage:
+%       validate_with_truth('path/to/IMU_X001_GNSS_X001_method_kf_output.mat', ...
+%                          'path/to/truth.csv', 'results');
+%
+%   TODO: Implement full validation and plotting logic.
+
+arguments
+    est_file (1,:) char
+    truth_file (1,:) char
+    output_dir (1,:) char = 'results'
+end
+
+m = regexp(est_file, '(IMU_\w+)_(GNSS_\w+)_([A-Za-z]+)_kf_output', 'tokens', 'once');
+if ~isempty(m)
+    dataset_dir = fileparts(truth_file);
+    imu_file = fullfile(dataset_dir, [m{1}, '.dat']);
+    gnss_file = fullfile(dataset_dir, [m{2}, '.csv']);
+    missing = {};
+    if ~isfile(imu_file)
+        missing{end+1} = imu_file; %#ok<AGROW>
+    end
+    if ~isfile(gnss_file)
+        missing{end+1} = gnss_file; %#ok<AGROW>
+    end
+    if ~isempty(missing)
+        for i = 1:numel(missing)
+            warning('validate_with_truth:MissingFile', ...
+                'Overlay skipped. Expected file not found: %s', missing{i});
+        end
+        return;
+    end
+end
+
+% Placeholder for overlay generation to mirror Python implementation.
+% plot_overlay(...); % TODO: implement plotting
+
+end

--- a/python/src/validate_with_truth.py
+++ b/python/src/validate_with_truth.py
@@ -1173,38 +1173,45 @@ def main():
         imu_file = dataset_dir / f"{m.group(1)}.dat"
         gnss_file = dataset_dir / f"{m.group(2)}.csv"
         method = m.group(3)
-        try:
-            frames = assemble_frames(
-                est, imu_file, gnss_file, truth_file=args.truth_file
+        missing = [str(p) for p in (imu_file, gnss_file) if not p.exists()]
+        if missing:
+            print(
+                "Warning: overlay skipped. Expected file(s) not found: "
+                + ", ".join(missing)
             )
-            tag = f"{m.group(1)}_{m.group(2)}_{method}"
-            for frame_name, data in frames.items():
-                t_i, p_i, v_i, a_i = data["imu"]
-                t_g, p_g, v_g, a_g = data["gnss"]
-                t_f, p_f, v_f, a_f = data["fused"]
-                truth = data.get("truth")
-                filename = f"{tag}_task6_overlay_state_{frame_name}.pdf"
-                plot_overlay(
-                    frame_name,
-                    method,
-                    t_i,
-                    p_i,
-                    v_i,
-                    a_i,
-                    t_g,
-                    p_g,
-                    v_g,
-                    a_g,
-                    t_f,
-                    p_f,
-                    v_f,
-                    a_f,
-                    args.output,
-                    truth,
-                    filename=filename,
+        else:
+            try:
+                frames = assemble_frames(
+                    est, imu_file, gnss_file, truth_file=args.truth_file
                 )
-        except Exception as e:
-            print(f"Overlay plot failed: {e}")
+                tag = f"{m.group(1)}_{m.group(2)}_{method}"
+                for frame_name, data in frames.items():
+                    t_i, p_i, v_i, a_i = data["imu"]
+                    t_g, p_g, v_g, a_g = data["gnss"]
+                    t_f, p_f, v_f, a_f = data["fused"]
+                    truth = data.get("truth")
+                    filename = f"{tag}_task6_overlay_state_{frame_name}.pdf"
+                    plot_overlay(
+                        frame_name,
+                        method,
+                        t_i,
+                        p_i,
+                        v_i,
+                        a_i,
+                        t_g,
+                        p_g,
+                        v_g,
+                        a_g,
+                        t_f,
+                        p_f,
+                        v_f,
+                        a_f,
+                        args.output,
+                        truth,
+                        filename=filename,
+                    )
+            except Exception as e:
+                print(f"Overlay plot failed: {e}")
 
     for line in summary_lines:
         print(line)


### PR DESCRIPTION
## Summary
- warn and skip overlay generation if expected IMU or GNSS truth files are missing
- mirror the file existence check in new MATLAB `validate_with_truth` stub for cross-language parity

## Testing
- `pytest python/src/test_validate_with_truth.py` *(fails: FileNotFoundError: '/workspace/IMU/python/src/data/simple_gnss.csv')*

------
https://chatgpt.com/codex/tasks/task_e_6898ea614f58832586f510b698b8c9d4