### PR TITLE
refactor: add robust KF noise mapping

### DIFF
--- a/python/utils/__init__.py
+++ b/python/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for the Python pipeline."""
+
+from .state_index_map import state_index_map
+
+__all__ = ["state_index_map"]

--- a/python/utils/state_index_map.py
+++ b/python/utils/state_index_map.py
@@ -1,0 +1,34 @@
+"""Utility to build index maps for state vectors.
+
+This mirrors the MATLAB ``state_index_map`` helper.
+
+Usage:
+    layout = OrderedDict([('pos',3),('vel',3),('att',3)])
+    idx = state_index_map(layout)
+"""
+
+from typing import Dict, List
+
+
+def state_index_map(layout: Dict[str, int]) -> Dict[str, List[int]]:
+    """Create an index map for state vector blocks.
+
+    Parameters
+    ----------
+    layout : dict
+        Ordered mapping of block names to their sizes.
+
+    Returns
+    -------
+    dict
+        Mapping of block names to index ranges (1-based), including ``N``.
+    """
+    names = list(layout.keys())
+    s = 1
+    idx = {}
+    for name in names:
+        n = int(layout[name])
+        idx[name] = list(range(s, s + n))
+        s += n
+    idx['N'] = s - 1
+    return idx


### PR DESCRIPTION
## Summary
- validate velocity noise configuration inputs in Task_5
- replace hard-coded indices with `state_index_map` for process/measurement noise scaling
- expose matching `state_index_map` helper in Python utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689972f9154c8325b28ab351e15e8f90