### PR TITLE
Switch plots to PNG and expand triad visualisations

### DIFF
--- a/python/utils/save_plot_all.py
+++ b/python/utils/save_plot_all.py
@@ -84,7 +84,7 @@ def _try_matlab_cli(mat_path: str, fig_out: str) -> bool:
 def save_plot_all(
     fig: "matplotlib.figure.Figure",
     basepath: str,
-    formats: Iterable[str] = (".png", ".pdf", ".svg", ".fig"),
+    formats: Iterable[str] = (".png",),
 ) -> None:
     """Save a matplotlib ``fig`` to multiple ``formats``.
 
@@ -95,8 +95,8 @@ def save_plot_all(
     basepath : str
         Path without extension where files will be written.
     formats : Iterable[str], optional
-        Iterable of extensions (e.g. ``(".png", ".pdf")``). ``".fig"``
-        triggers MATLAB export using the engine or command line.
+        Iterable of extensions (e.g. ``(".png",)``). ``".fig"``
+        triggers MATLAB export using the engine or command line when included.
     """
     _ensure_dir(basepath)
 

--- a/tests/test_new_plots.py
+++ b/tests/test_new_plots.py
@@ -38,13 +38,13 @@ def test_body_frame_plots(tmp_path, monkeypatch):
 
     res_dir = Path("results")
     expected = [
-        "*_task4_all_body.pdf",
-        "*_task5_all_body.pdf",
+        "*_task4_all_body.png",
+        "*_task5_all_body.png",
     ]
     for pattern in expected:
         matches = list(res_dir.glob(pattern))
         assert matches, f"Missing plot {pattern}"
 
     # cleanup
-    for f in res_dir.glob("*.pdf"):
+    for f in res_dir.glob("*.png"):
         f.unlink()


### PR DESCRIPTION
## Summary
- Default to saving plots as PNG images
- Show full-world map and dataset info for Task 1 location plot
- Add truth comparison for Task 3 quaternion plot and emit PNG outputs
- Save Task 4/5 plots as PNG and adjust tests accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899741d26848325bc68effe71c76f9b