### PR TITLE
Drop unused attitude plots and save interactive figures

### DIFF
--- a/python/utils/save_plot_all.py
+++ b/python/utils/save_plot_all.py
@@ -1,4 +1,5 @@
 import subprocess
+import pickle
 from pathlib import Path
 from typing import Iterable
 
@@ -97,15 +98,22 @@ def save_plot_all(
     formats : Iterable[str], optional
         Iterable of extensions (e.g. ``(".png",)``). ``".fig"``
         triggers MATLAB export using the engine or command line when included.
+        ``".pickle"`` or ``".pkl"`` serialises the figure for interactive
+        reloading in Python.
     """
     _ensure_dir(basepath)
 
-    # raster/vector exports
-    for ext in (e.lower() for e in formats if e.lower() in {".png", ".pdf", ".svg"}):
-        fig.savefig(basepath + ext, dpi=300, bbox_inches="tight")
-        print(f"Saved -> {basepath + ext}")
+    fmt_lower = [e.lower() for e in formats]
+    for ext in fmt_lower:
+        if ext in {".png", ".pdf", ".svg"}:
+            fig.savefig(basepath + ext, dpi=300, bbox_inches="tight")
+            print(f"Saved -> {basepath + ext}")
+        elif ext in {".pickle", ".pkl"}:
+            with open(basepath + ext, "wb") as fh:
+                pickle.dump(fig, fh)
+            print(f"Saved -> {basepath + ext}")
 
-    if ".fig" not in [e.lower() for e in formats]:
+    if ".fig" not in fmt_lower:
         return
 
     schema = _extract_axes_schema(fig)

--- a/src/GNSS_IMU_Fusion.py
+++ b/src/GNSS_IMU_Fusion.py
@@ -1747,32 +1747,10 @@ def main():
     logging.info("All data in body frame plot saved")
 
     # Plot pre-fit innovations
-    fig_innov, ax_innov = plt.subplots(3, 1, sharex=True, figsize=(8, 6))
-    labels = ["North", "East", "Down"]
-    innov_pos = innov_pos_all[method]
-    innov_vel = innov_vel_all[method]
-    for i in range(3):
-        ax_innov[i].plot(innov_pos[:, i], label="Position")
-        ax_innov[i].plot(innov_vel[:, i], label="Velocity", linestyle="--")
-        ax_innov[i].set_ylabel(f"{labels[i]} residual")
-        ax_innov[i].grid(True)
-    ax_innov[0].legend(loc="best")
-    ax_innov[-1].set_xlabel("GNSS update index")
-    fig_innov.suptitle("Task 5 – Pre-fit Innovations (Fused vs. Measured GNSS)")
-    fig_innov.tight_layout()
-    innov_pdf = f"results/{tag}_{method.lower()}_innovations.pdf"
-    if not args.no_plots:
-        save_plot(fig_innov, innov_pdf, "Pre-fit Innovations")
-
-    # Plot residuals and attitude using helper functions
+    # Plot residuals using helper functions
     if not args.no_plots:
         res = compute_residuals(gnss_time, gnss_pos_ned, imu_time, fused_pos[method])
         plot_residuals(gnss_time, res, f"results/residuals_{tag}_{method}.pdf")
-        plot_attitude(
-            imu_time,
-            attitude_q_all[method],
-            f"results/attitude_angles_{tag}_{method}.pdf",
-        )
 
     # Create plot summary
     summary = {
@@ -1790,8 +1768,6 @@ def main():
         f"{tag}_task5_all_ecef.png": "Kalman filter results in ECEF frame",
         f"{tag}_task5_all_body.png": "Kalman filter results in body frame",
         f"{tag}_{method.lower()}_residuals.pdf": "Position and velocity residuals",
-        f"{tag}_{method.lower()}_innovations.pdf": "Pre-fit innovations",
-        f"{tag}_{method.lower()}_attitude_angles.pdf": "Attitude angles over time",
     }
     summary_path = os.path.join("results", f"{tag}_plot_summary.md")
     with open(summary_path, "w") as f:
@@ -1825,20 +1801,6 @@ def main():
 
     # --- Attitude angles ----------------------------------------------------
     euler = R.from_quat(attitude_q_all[method]).as_euler("xyz", degrees=True)
-    if not args.no_plots:
-        plt.figure()
-        plt.plot(imu_time, euler[:, 0], label="Roll")
-        plt.plot(imu_time, euler[:, 1], label="Pitch")
-        plt.plot(imu_time, euler[:, 2], label="Yaw")
-        plt.xlabel("Time (s)")
-        plt.ylabel("Angle (deg)")
-        plt.legend(loc="best")
-        plt.title(f"Task 6: {tag} Attitude Angles")
-        png = Path("results") / f"{tag}_task6_attitude_angles.png"
-        pdf = png.with_suffix(".pdf")
-        plt.savefig(png)
-        plt.savefig(pdf)
-        plt.close()
 
     C_NED_to_ECEF = C_ECEF_to_NED.T
     pos_ecef = np.array([C_NED_to_ECEF @ p + ref_r0 for p in fused_pos[method]])
@@ -1972,8 +1934,6 @@ def main():
             gnss_vel_ned,
             tag,
         )
-
-        save_attitude_over_time(imu_time, euler_deg, dataset_id, method)
 
         plot_all_methods(
             imu_time,

--- a/src/plot_overlay.py
+++ b/src/plot_overlay.py
@@ -4,6 +4,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 import matplotlib.pyplot as plt
+from python.utils.save_plot_all import save_plot_all
 
 
 def _norm(v: np.ndarray) -> np.ndarray:
@@ -48,8 +49,9 @@ def plot_overlay(
         Only "state" is supported.  The "truth" option is obsolete.
     suffix : str or None, optional
         Filename suffix appended to ``"{method}_{frame}"`` when saving the
-        figure. Defaults to ``"_overlay_state.pdf"`` when truth data is
-        supplied and ``"_overlay.pdf"`` otherwise.
+        figure. Defaults to ``"_overlay_state"`` when truth data is
+        supplied and ``"_overlay"`` otherwise. Extensions are added based on
+        the ``formats`` argument to :func:`save_plot_all`.
     filename : str or None, optional
         Full filename (relative to ``out_dir``) for the saved figure. When
         provided, overrides the ``method``/``frame`` naming scheme and the
@@ -62,7 +64,7 @@ def plot_overlay(
         t_truth, pos_truth, vel_truth, acc_truth = truth
 
     if suffix is None:
-        suffix = "_overlay_state.pdf" if t_truth is not None else "_overlay.pdf"
+        suffix = "_overlay_state" if t_truth is not None else "_overlay"
 
     axis_labels = {
         "NED": ["\u0394N [m]", "\u0394E [m]", "\u0394D [m]"],
@@ -165,18 +167,10 @@ def plot_overlay(
     fig.suptitle(title)
     fig.tight_layout(rect=[0, 0, 1, 0.9])
     if filename is not None:
-        out_path = Path(out_dir) / filename
+        out_path = Path(out_dir) / Path(filename).with_suffix("")
     else:
         out_path = Path(out_dir) / f"{method}_{frame}{suffix}"
 
-    fname_pdf = out_path.with_suffix(".pdf")
-    fname_png = out_path.with_suffix(".png")
-    fig.savefig(fname_pdf, dpi=300, bbox_inches="tight")
-    fig.savefig(fname_png, dpi=150, bbox_inches="tight")
-    try:
-        from utils import save_plot_mat
-        save_plot_mat(fig, str(out_path.with_suffix(".mat")))
-    except Exception:
-        pass
-    print(f"Saved overlay figure {fname_pdf}")
+    save_plot_all(fig, str(out_path), formats=(".pickle", ".fig"))
+    print(f"Saved overlay figure {out_path}.pickle")
     plt.close(fig)

--- a/src/task7_ned_residuals_plot.py
+++ b/src/task7_ned_residuals_plot.py
@@ -8,7 +8,8 @@ Usage:
 This implements the functionality of ``task7_ned_residuals_plot.m`` from the
 MATLAB code base. The estimator time vector is shifted to start at zero so that
 Task 6 and Task 7 plots share the same x-axis. Figures are written under
-``results/<dataset>/``.
+``results/<dataset>/`` in Python ``.pickle`` and MATLAB ``.mat`` (via ``.fig``)
+formats.
 """
 
 from __future__ import annotations
@@ -18,6 +19,7 @@ from pathlib import Path
 
 import numpy as np
 import matplotlib.pyplot as plt
+from python.utils.save_plot_all import save_plot_all
 
 from src.utils import compute_C_ECEF_to_NED
 
@@ -143,15 +145,8 @@ def plot_residuals(
     fig.suptitle(f"{dataset} Task 7 NED Residuals")
     fig.tight_layout(rect=[0, 0, 1, 0.95])
     out_dir.mkdir(parents=True, exist_ok=True)
-    pdf = out_dir / f"{dataset}_task7_ned_residuals.pdf"
-    png = out_dir / f"{dataset}_task7_ned_residuals.png"
-    fig.savefig(pdf)
-    fig.savefig(png)
-    try:
-        from utils import save_plot_mat
-        save_plot_mat(fig, str(out_dir / f"{dataset}_task7_ned_residuals.mat"))
-    except Exception:
-        pass
+    base = out_dir / f"{dataset}_task7_ned_residuals"
+    save_plot_all(fig, str(base), formats=(".pickle", ".fig"))
     plt.close(fig)
 
     fig, ax = plt.subplots()
@@ -164,18 +159,11 @@ def plot_residuals(
     ax.grid(True)
     fig.suptitle(f"{dataset} Task 7 NED Residual Norms")
     fig.tight_layout(rect=[0, 0, 1, 0.95])
-    norm_pdf = out_dir / f"{dataset}_task7_ned_residual_norms.pdf"
-    norm_png = out_dir / f"{dataset}_task7_ned_residual_norms.png"
-    fig.savefig(norm_pdf)
-    fig.savefig(norm_png)
-    try:
-        from utils import save_plot_mat
-        save_plot_mat(fig, str(out_dir / f"{dataset}_task7_ned_residual_norms.mat"))
-    except Exception:
-        pass
+    norm_base = out_dir / f"{dataset}_task7_ned_residual_norms"
+    save_plot_all(fig, str(norm_base), formats=(".pickle", ".fig"))
     plt.close(fig)
 
-    saved = sorted(out_dir.glob(f"{dataset}_task7_ned_residual*.pdf"))
+    saved = sorted(out_dir.glob(f"{dataset}_task7_ned_residual*.pickle"))
     if saved:
         print("Files saved in", out_dir)
         for f in saved:
@@ -211,7 +199,7 @@ def main() -> None:
 
     out_dir = args.output_dir
     plot_residuals(t_rel, res_pos, res_vel, res_acc, args.dataset, out_dir)
-    saved = sorted(out_dir.glob(f"{args.dataset}_task7_ned_residual*.pdf"))
+    saved = sorted(out_dir.glob(f"{args.dataset}_task7_ned_residual*.pickle"))
     if saved:
         print("Files saved in", out_dir)
         for f in saved:

--- a/task6_overlay_plot.py
+++ b/task6_overlay_plot.py
@@ -9,11 +9,11 @@ Usage:
 This script synchronizes the time bases of the estimator output and ground
 truth, then generates a single figure with position, velocity and acceleration
 components overlaid. Only the fused estimate and truth are shown. Figures are
-written under ``results/<run_id>/`` using the filename pattern
-``<run_id>_task6_overlay_state_<frame>.pdf`` where ``run_id`` combines the
-dataset and method, e.g. ``IMU_X003_GNSS_X002_TRIAD``.
-With ``--debug`` the script prints diagnostic information about the input
-datasets before plotting.
+written under ``results/<run_id>/`` using the base filename
+``<run_id>_task6_overlay_state_<frame>`` with Python ``.pickle`` and MATLAB
+``.mat`` companions where ``run_id`` combines the dataset and method, e.g.
+``IMU_X003_GNSS_X002_TRIAD``. With ``--debug`` the script prints diagnostic
+information about the input datasets before plotting.
 """
 
 from __future__ import annotations
@@ -25,6 +25,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from scipy.interpolate import interp1d
 import warnings
+from python.utils.save_plot_all import save_plot_all
 
 
 # ---------------------------------------------------------------------------
@@ -245,13 +246,11 @@ def plot_overlay(
     fig.tight_layout(rect=[0, 0, 1, 0.95])
     run_id = f"{dataset}_{method}"
     out_dir.mkdir(parents=True, exist_ok=True)
-    pdf_path = out_dir / f"{run_id}_task6_overlay_state_{frame}.pdf"
-    png_path = out_dir / f"{run_id}_task6_overlay_state_{frame}.png"
-    fig.savefig(pdf_path)
-    fig.savefig(png_path)
+    base = out_dir / f"{run_id}_task6_overlay_state_{frame}"
+    save_plot_all(fig, str(base), formats=(".pickle", ".fig"))
     plt.close(fig)
-    print(f"Saved overlay figure to {pdf_path}")
-    return pdf_path
+    print(f"Saved overlay figure to {base}.pickle")
+    return base.with_suffix(".pickle")
 
 
 def plot_rmse(
@@ -288,13 +287,11 @@ def plot_rmse(
     fig.tight_layout()
 
     out_dir.mkdir(parents=True, exist_ok=True)
-    pdf_path = out_dir / f"{dataset}_{method}_Task6_{frame}_RMSE.pdf"
-    png_path = out_dir / f"{dataset}_{method}_Task6_{frame}_RMSE.png"
-    fig.savefig(pdf_path)
-    fig.savefig(png_path)
+    base = out_dir / f"{dataset}_{method}_Task6_{frame}_RMSE"
+    save_plot_all(fig, str(base), formats=(".pickle", ".fig"))
     plt.close(fig)
-    print(f"Saved RMSE figure to {pdf_path}")
-    return pdf_path
+    print(f"Saved RMSE figure to {base}.pickle")
+    return base.with_suffix(".pickle")
 
 
 # ---------------------------------------------------------------------------

--- a/task7_ecef_residuals_plot.py
+++ b/task7_ecef_residuals_plot.py
@@ -12,9 +12,10 @@ by Task 4, the ``--truth-file`` argument is optional.  Otherwise the
 STATE_X text log must be provided or inferrable from the dataset name.
 The truth trajectory is synchronised to the estimator by cross-correlating
 position and velocity magnitudes before interpolation to the estimator time
-vector.  Position, velocity and acceleration residuals are plotted.  The time axis is
-converted to ``t - t[0]`` so Task 6 and Task 7 share the same reference.
-Figures are saved as PDF and PNG under ``results/<tag>/`` where ``tag``
+vector. Position, velocity and acceleration residuals are plotted. The time
+axis is converted to ``t - t[0]`` so Task 6 and Task 7 share the same
+reference. Figures are saved in interactive Python ``.pickle`` and MATLAB
+``.mat`` (via ``.fig`` export) formats under ``results/<tag>/`` where ``tag``
 combines the dataset, GNSS file and method.
 """
 
@@ -28,6 +29,7 @@ import matplotlib.pyplot as plt
 
 from validate_with_truth import load_estimate, assemble_frames
 from naming import make_tag, plot_filename
+from python.utils.save_plot_all import save_plot_all
 import re
 
 
@@ -83,11 +85,8 @@ def plot_residuals(
     fig.suptitle(f"{tag} Task 7 ECEF Residuals")
     fig.tight_layout(rect=[0, 0, 1, 0.95])
     out_dir.mkdir(parents=True, exist_ok=True)
-    pdf_name = plot_filename(dataset, gnss, method, 7, "3", "ecef_residuals")
-    pdf = out_dir / pdf_name
-    png = pdf.with_suffix(".png")
-    fig.savefig(pdf)
-    fig.savefig(png)
+    base = out_dir / Path(plot_filename(dataset, gnss, method, 7, "3", "ecef_residuals")).with_suffix("")
+    save_plot_all(fig, str(base), formats=(".pickle", ".fig"))
     plt.close(fig)
 
     # Norm plot
@@ -101,14 +100,11 @@ def plot_residuals(
     ax.grid(True)
     fig.suptitle(f"{tag} Task 7 ECEF Residual Norms")
     fig.tight_layout(rect=[0, 0, 1, 0.95])
-    norm_name = plot_filename(dataset, gnss, method, 7, "3", "ecef_residual_norms")
-    norm_pdf = out_dir / norm_name
-    norm_png = norm_pdf.with_suffix(".png")
-    fig.savefig(norm_pdf)
-    fig.savefig(norm_png)
+    norm_base = out_dir / Path(plot_filename(dataset, gnss, method, 7, "3", "ecef_residual_norms")).with_suffix("")
+    save_plot_all(fig, str(norm_base), formats=(".pickle", ".fig"))
     plt.close(fig)
 
-    saved = sorted(out_dir.glob(f"{tag}_task7_*ecef_residual*.pdf"))
+    saved = sorted(out_dir.glob(f"{tag}_task7_*ecef_residual*.pickle"))
     if saved:
         print("Files saved in", out_dir)
         for f in saved:

--- a/tests/test_plot_overlay.py
+++ b/tests/test_plot_overlay.py
@@ -30,7 +30,7 @@ def test_plot_overlay_with_truth(tmp_path):
         vel_truth=vel,
         acc_truth=acc,
     )
-    assert (tmp_path / "TEST_ECEF_overlay_state.pdf").exists()
+    assert (tmp_path / "TEST_ECEF_overlay_state.pickle").exists()
 
 
 def test_plot_overlay_fused_only(tmp_path):
@@ -60,7 +60,7 @@ def test_plot_overlay_fused_only(tmp_path):
         vel_truth=vel,
         acc_truth=acc,
     )
-    assert (tmp_path / "TEST_ECEF_overlay_state.pdf").exists()
+    assert (tmp_path / "TEST_ECEF_overlay_state.pickle").exists()
 
 
 def test_plot_overlay_custom_filename(tmp_path):
@@ -90,4 +90,4 @@ def test_plot_overlay_custom_filename(tmp_path):
         vel_truth=vel,
         acc_truth=acc,
     )
-    assert (tmp_path / "custom.pdf").exists()
+    assert (tmp_path / "custom.pickle").exists()

--- a/tests/test_task6_rmse_plot.py
+++ b/tests/test_task6_rmse_plot.py
@@ -27,5 +27,5 @@ def test_task6_rmse_plot(tmp_path):
         tmp_path,
     )
 
-    assert (tmp_path / "TESTDATA_TEST_Task6_ECEF_RMSE.pdf").exists()
+    assert (tmp_path / "TESTDATA_TEST_Task6_ECEF_RMSE.pickle").exists()
 

--- a/tests/test_task7_ned_residuals_plot.py
+++ b/tests/test_task7_ned_residuals_plot.py
@@ -19,5 +19,5 @@ def test_plot_residuals(tmp_path: Path):
     )
     out_dir = tmp_path
     plot_residuals(t, res_pos, res_vel, res_acc, "TEST", out_dir)
-    assert (out_dir / "TEST_task7_ned_residuals.pdf").exists()
-    assert (out_dir / "TEST_task7_ned_residual_norms.pdf").exists()
+    assert (out_dir / "TEST_task7_ned_residuals.pickle").exists()
+    assert (out_dir / "TEST_task7_ned_residual_norms.pickle").exists()

--- a/tests/test_validate_with_truth.py
+++ b/tests/test_validate_with_truth.py
@@ -233,11 +233,11 @@ def test_overlay_truth_generation(tmp_path, monkeypatch):
     validate_main()
 
     expected = {
-        "IMU_X001_small_GNSS_X001_small_TRIAD_task6_overlay_state_NED.pdf",
-        "IMU_X001_small_GNSS_X001_small_TRIAD_task6_overlay_state_ECEF.pdf",
-        "IMU_X001_small_GNSS_X001_small_TRIAD_task6_overlay_state_Body.pdf",
+        "IMU_X001_small_GNSS_X001_small_TRIAD_task6_overlay_state_NED.pickle",
+        "IMU_X001_small_GNSS_X001_small_TRIAD_task6_overlay_state_ECEF.pickle",
+        "IMU_X001_small_GNSS_X001_small_TRIAD_task6_overlay_state_Body.pickle",
     }
-    produced = {p.name for p in Path("results").glob("*_task6_overlay_state_*.pdf")}
+    produced = {p.name for p in Path("results").glob("*_task6_overlay_state_*.pickle")}
     assert expected.issubset(produced), f"Missing overlays: {expected - produced}"
 
     # verify raw STATE overlay generation via task6_plot_truth.py
@@ -262,7 +262,7 @@ def test_overlay_truth_generation(tmp_path, monkeypatch):
     task6_main()
     state_files = {
         p.name for p in Path("results").glob(
-            "IMU_X001_small_GNSS_X001_small_TRIAD_task6_overlay_state_*.pdf"
+            "IMU_X001_small_GNSS_X001_small_TRIAD_task6_overlay_state_*.pickle"
         )
     }
     assert state_files, "Missing state overlay plots"


### PR DESCRIPTION
## Summary
- remove triad innovations and attitude angle plots from GNSS_IMU_Fusion
- export Task 6/7 overlay and residual plots as Python pickle and MATLAB .mat instead of PDFs
- extend save_plot_all to handle pickle output and update tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68997d0d33c08325940f061d360e8a4c