### PR TITLE
Improve Task 3 attitude error plotting and utilities

### DIFF
--- a/MATLAB/Task_3.m
+++ b/MATLAB/Task_3.m
@@ -20,6 +20,7 @@ if ~exist(results_dir,'dir'), mkdir(results_dir); end
 [~, gnss_base, ~] = fileparts(gnss_path);
 imu_id  = erase(imu_base, '.dat');
 gnss_id = erase(gnss_base, '.csv');
+dataset_name = sprintf('%s_%s_%s', imu_id, gnss_id, method);
 
 % ensure Task1/Task2 outputs exist (run them if missing)
 t1 = fullfile(results_dir, sprintf('Task1_init_%s_%s_%s.mat', imu_id, gnss_id, method));
@@ -60,6 +61,11 @@ catch
     q_svd = q_tri;
 end
 
+% ---- compute angular errors for validation ----
+[triad_grav_err_deg, triad_erate_err_deg]       = compute_wahba_errors(R_tri, g_body, w_body, g_ned, w_ned);
+[davenport_grav_err_deg, davenport_erate_err_deg] = compute_wahba_errors(R_dav, g_body, w_body, g_ned, w_ned);
+[svd_grav_err_deg, svd_erate_err_deg]           = compute_wahba_errors(R_svd, g_body, w_body, g_ned, w_ned);
+
 % ---- pack canonical struct that Task_4 expects ----
 task3_results = struct();
 task3_results.methods = {'TRIAD','Davenport','SVD'};
@@ -70,6 +76,62 @@ task3_results.q.TRIAD       = q_tri;
 task3_results.q.Davenport   = q_dav;
 task3_results.q.SVD         = q_svd;
 task3_results.meta = struct('imu_id',imu_id,'gnss_id',gnss_id,'method',method);
+
+% store error metrics for cross-language parity
+task3_results.grav_err_deg = struct('TRIAD', triad_grav_err_deg, ...
+                                   'Davenport', davenport_grav_err_deg, ...
+                                   'SVD', svd_grav_err_deg);
+task3_results.erate_err_deg = struct('TRIAD', triad_erate_err_deg, ...
+                                     'Davenport', davenport_erate_err_deg, ...
+                                     'SVD', svd_erate_err_deg);
+
+% ---- plot and save attitude error comparison ----
+ge = task3_results.grav_err_deg;
+ee = task3_results.erate_err_deg;
+meth = {'TRIAD','Davenport','SVD'};
+grav_vals = cellfun(@(m) double(ge.(m)), meth);
+erate_vals = cellfun(@(m) double(ee.(m)), meth);
+
+if any(~isfinite(grav_vals)), warning('Task3:grav NaN -> 0'); grav_vals(~isfinite(grav_vals)) = 0; end
+if any(~isfinite(erate_vals)), warning('Task3:erate NaN -> 0'); erate_vals(~isfinite(erate_vals)) = 0; end
+
+fprintf('[Task3] Gravity errors (deg): TRIAD=%.6g, Davenport=%.6g, SVD=%.6g\n', grav_vals);
+fprintf('[Task3] Earth-rate errors (deg): TRIAD=%.6g, Davenport=%.6g, SVD=%.6g\n', erate_vals);
+
+assert(~isempty(grav_vals) && ~isempty(erate_vals), 'Task3:NoData','No error data computed for plotting.');
+
+f = figure('Color','w');
+tiledlayout(1,2,'TileSpacing','compact');
+
+nexttile;
+bar(categorical(meth), grav_vals);
+ylabel('Error (degrees)'); title('Gravity Error');
+ymax = max(abs(grav_vals)); if ymax==0, ymax = 0.01; end
+ylim([-1 1]*1.1*ymax); grid on;
+for i = 1:numel(grav_vals)
+    text(i, grav_vals(i), sprintf('%.3g', grav_vals(i)), 'HorizontalAlignment','center', 'VerticalAlignment','bottom');
+end
+
+nexttile;
+bar(categorical(meth), erate_vals);
+ylabel('Error (degrees)'); title('Earth Rate Error');
+ymax = max(abs(erate_vals)); if ymax==0, ymax = 0.01; end
+ylim([-1 1]*1.1*ymax); grid on;
+for i = 1:numel(erate_vals)
+    text(i, erate_vals(i), sprintf('%.3g', erate_vals(i)), 'HorizontalAlignment','center', 'VerticalAlignment','bottom');
+end
+
+sgtitle('Task 3: Attitude Error Comparison');
+
+outbase = fullfile(results_dir, sprintf('%s_task3_errors_comparison', dataset_name));
+if exist('save_plot_all','file')
+    save_plot_all(f, outbase, {'.fig','.pdf','.png'});
+else
+    exportgraphics(f, [outbase '.pdf'], 'ContentType','vector');
+    exportgraphics(f, [outbase '.png'], 'Resolution',300);
+    savefig(f, [outbase '.fig']);
+end
+close(f);
 
 out_generic = fullfile(results_dir, sprintf('Task3_results_%s_%s.mat', imu_id, gnss_id));
 out_method  = fullfile(results_dir, sprintf('%s_%s_%s_task3_results.mat', imu_id, gnss_id, method));

--- a/MATLAB/utils/compute_wahba_errors.m
+++ b/MATLAB/utils/compute_wahba_errors.m
@@ -1,0 +1,44 @@
+function [grav_err_deg, earth_err_deg] = compute_wahba_errors(C_bn, g_b, omega_b, g_ref, omega_ref)
+%COMPUTE_WAHBA_ERRORS Angular errors for gravity and Earth rate.
+%   [EG, EO] = COMPUTE_WAHBA_ERRORS(C_BN, G_B, OMEGA_B, G_REF, OMEGA_REF)
+%   returns the angle between measured and reference gravity vectors and
+%   between Earth rotation vectors, matching the Python helper of the same
+%   name.
+%
+%   Inputs:
+%     C_bn      - body-to-NED rotation matrix
+%     g_b       - gravity vector measured in the body frame
+%     omega_b   - Earth rotation vector measured in the body frame
+%     g_ref     - reference gravity in the NED frame
+%     omega_ref - reference Earth rotation in the NED frame
+%
+%   Outputs:
+%     grav_err_deg  - gravity vector angular error in degrees
+%     earth_err_deg - Earth-rate vector angular error in degrees
+%
+%   Frames:
+%     g_b, omega_b are expressed in the body frame.
+%     g_ref, omega_ref are expressed in the NED frame.
+%
+%   See also: angle_between
+%
+%   Usage:
+%       [eg, eo] = compute_wahba_errors(C_bn, g_b, omega_b, g_ref, omega_ref)
+%
+%   This mirrors ``gnss_imu_fusion.init_vectors.compute_wahba_errors`` in
+%   the Python implementation to keep cross-language parity.
+
+    g_pred = C_bn * g_b;
+    omega_pred = C_bn * omega_b;
+
+    grav_err_deg = angle_between(g_pred, g_ref);
+    earth_err_deg = angle_between(omega_pred, omega_ref);
+end
+
+function deg = angle_between(v1, v2)
+%ANGLE_BETWEEN Angle between two 3-D vectors in degrees.
+%   DEG = ANGLE_BETWEEN(V1, V2)
+%   returns the angle between V1 and V2 in degrees.
+    cos_theta = max(min(dot(v1, v2) / (norm(v1) * norm(v2)), 1.0), -1.0);
+    deg = acosd(cos_theta);
+end


### PR DESCRIPTION
## Summary
- Compute Wahba gravity and earth-rate errors in MATLAB Task_3 and store/plot them with autoscaled bar charts.
- Save Task 3 error plots in PDF/PNG/FIG formats and print numeric values with NaN handling.
- Add reusable `compute_wahba_errors.m` utility and mirror plotting workflow in Python pipeline.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689982fe28548325a449422ad69f3322