### PR TITLE
Enable interactive plot saving and drop default PDFs

### DIFF
--- a/MATLAB/GNSS_IMU_Fusion_single.m
+++ b/MATLAB/GNSS_IMU_Fusion_single.m
@@ -549,7 +549,7 @@ for i_plot = 1:numel(erate_vals)
 end
 sgtitle('Task 3: Attitude Error Comparison');
 outbase = fullfile(results_dir, sprintf('%s_task3_errors_comparison', tag));
-save_plot_all(f, outbase, {'.fig','.pdf','.png'});
+save_plot_all(f, outbase, {'.png','.fig'});
 
 figure('Name', 'Quaternion Component Comparison', 'Position', [100, 600, 1000, 600]);
 quats_c1 = [q_tri, q_dav, q_svd];

--- a/MATLAB/Task_1.m
+++ b/MATLAB/Task_1.m
@@ -177,7 +177,7 @@ if exist('geoplot','file') == 2 && license('test','map_toolbox')
         lat_deg, lon_deg, cname, cdist_km));
 
     base = fullfile(results_dir, sprintf('%s_%s_task1_results', dataset_name, method));
-    save_plot_all(fig, base, {'.fig','.png','.pdf'});
+    save_plot_all(fig, base, {'.png','.fig'});
 else
     warning('Mapping Toolbox not found. Skipping geographic plot.');
     base = fullfile(results_dir, sprintf('%s_%s_task1_results', dataset_name, method));

--- a/MATLAB/Task_5.m
+++ b/MATLAB/Task_5.m
@@ -19,7 +19,7 @@ function result = Task_5(imu_path, gnss_path, method, truth, varargin)
 %       'vel_q_scale'      - scales Q(4:6,4:6) velocity process noise   [-]      (1.0)
 %       'vel_r'            - R(4:6,4:6) velocity measurement variance   [m^2/s^2] (0.25)
 %       'trace_first_n'    - if finite, process only the first N steps  [-]      (Inf)
-%       'plot_formats'     - cell array of extensions for plots         ('.pdf','.png','.fig')
+%       'plot_formats'     - cell array of extensions for plots         ('.png','.fig')
 %       'save_dir'         - directory for outputs (default results path)
 %       'scale_factor'     - accelerometer scale factor                 [-]      (required)
 
@@ -63,7 +63,7 @@ end
     addParameter(p, 'vel_q_scale', 1.0, @(x)isnumeric(x)&&isscalar(x)&&x>0); % [-]
     addParameter(p, 'vel_r', 0.25, @(x)isnumeric(x)&&isscalar(x)&&x>0);      % [m^2/s^2]
     addParameter(p, 'trace_first_n', Inf, @(x)isnumeric(x)&&isscalar(x)&&x>=0);
-    addParameter(p, 'plot_formats', {'.pdf','.png','.fig'}, @(c)iscellstr(c)||isstring(c));
+    addParameter(p, 'plot_formats', {'.png','.fig'}, @(c)iscellstr(c)||isstring(c));
     addParameter(p, 'save_dir', '', @(s)ischar(s)||isstring(s));
     addParameter(p, 'scale_factor', []);       % [-]
     parse(p, varargin{:});
@@ -603,7 +603,7 @@ plot_state_grid(imu_time, p_n_fused, v_n_fused, a_n_fused, 'NED', ...
 % --- Combined Position, Velocity and Acceleration ---
 fig = figure('Name', 'KF Results: P/V/A', 'Position', [100 100 1200 900]);
 labels = {'North', 'East', 'Down'};
-all_file = fullfile(results_dir, sprintf('%s_Task5_AllResults.pdf', run_id));
+all_file = fullfile(results_dir, sprintf('%s_Task5_AllResults.png', run_id));
 if exist(all_file, 'file'); delete(all_file); end
 for i = 1:3
     % Position

--- a/MATLAB/src/utils/save_plot_all.m
+++ b/MATLAB/src/utils/save_plot_all.m
@@ -2,10 +2,10 @@ function save_plot_all(h, basepath, formats)
 %SAVE_PLOT_ALL Save MATLAB figure to multiple formats.
 %   save_plot_all(h, basepath, formats) saves figure handle h (or gcf) to
 %   the extensions listed in cell array ``formats``. If ``formats`` is
-%   omitted, only a ``.fig`` is written.
+%   omitted, ``.png`` and ``.fig`` are written.
 %
 %   Usage:
-%       save_plot_all(gcf, 'results/demo', {'.fig','.png','.pdf'})
+%       save_plot_all(gcf, 'results/demo', {'.png','.fig'})
 %
 %   See also: SAVEFIG, EXPORTGRAPHICS
 
@@ -13,7 +13,7 @@ function save_plot_all(h, basepath, formats)
     if nargin < 2 || isempty(basepath)
         error('basepath required');
     end
-    if nargin < 3 || isempty(formats), formats = {'.fig'}; end
+    if nargin < 3 || isempty(formats), formats = {'.png','.fig'}; end
 
     [outdir,~,~] = fileparts(basepath);
     if ~isempty(outdir) && ~exist(outdir,'dir')
@@ -38,4 +38,6 @@ function save_plot_all(h, basepath, formats)
         end
         fprintf('Saved -> %s\n', outfile);
     end
+
+    figure(h);
 end

--- a/src/GNSS_IMU_Fusion.py
+++ b/src/GNSS_IMU_Fusion.py
@@ -34,7 +34,7 @@ import numpy as np
 import pandas as pd
 from filterpy.kalman import KalmanFilter
 
-from scripts.plot_utils import save_plot, plot_attitude
+from scripts.plot_utils import plot_attitude
 from utils import (
     is_static,
     compute_C_ECEF_to_NED,
@@ -264,9 +264,7 @@ def main():
             fig.suptitle("Task 1: Initial Location on Earth")
             fig.tight_layout()
             out = Path("results") / f"{tag}_task1_location_map"
-            save_plot_all(fig, str(out), formats=(".png",))
-            plt.show()
-            plt.close(fig)
+            save_plot_all(fig, str(out), show_plot=True)
             logging.info("Location map saved")
     else:
         logging.info("Skipping plot generation (--no-plots)")
@@ -654,9 +652,7 @@ def main():
     fig.tight_layout()
     if not args.no_plots:
         outbase = f"results/{tag}_task3_errors_comparison"
-        fig.savefig(outbase + ".pdf")
-        fig.savefig(outbase + ".png", dpi=300)
-    plt.close(fig)
+        save_plot_all(fig, outbase, show_plot=True)
     logging.info("Error comparison plot saved")
 
     # Collect quaternion data for both cases
@@ -688,9 +684,8 @@ def main():
 
     plt.tight_layout()
     if not args.no_plots:
-        save_plot_all(fig, f"results/{tag}_task3_quaternions_comparison", formats=(".png",))
-        plt.show()
-    plt.close()
+        save_plot_all(fig, f"results/{tag}_task3_quaternions_comparison", show_plot=True)
+    
     logging.info("Quaternion comparison plot saved")
 
     if truth_quat0 is not None and not args.no_plots:
@@ -707,9 +702,7 @@ def main():
         ax_truth.set_ylabel("Value")
         ax_truth.set_title("Task 3: Quaternion vs. Truth")
         ax_truth.legend(loc="best")
-        save_plot_all(fig_truth, f"results/{tag}_task3_quaternions_truth", formats=(".png",))
-        plt.show()
-        plt.close(fig_truth)
+        save_plot_all(fig_truth, f"results/{tag}_task3_quaternions_truth", show_plot=True)
 
     # --------------------------------
     # Subtask 3.8: Store Rotation Matrices for Later Tasks
@@ -1061,9 +1054,7 @@ def main():
     fig_comp.suptitle(f"Task 4 – {method} – NED Frame (IMU vs. GNSS)")
     fig_comp.tight_layout(rect=[0, 0, 1, 0.95])
     if not args.no_plots:
-        save_plot_all(fig_comp, f"results/{tag}_task4_all_ned", formats=(".png",))
-        plt.show()
-    plt.close(fig_comp)
+        save_plot_all(fig_comp, f"results/{tag}_task4_all_ned", show_plot=True)
     logging.info("NED frame plot saved")
 
     # Plot 1: Data in mixed frames (GNSS position/velocity in ECEF, IMU acceleration in body)
@@ -1120,9 +1111,7 @@ def main():
     fig_ecef.suptitle(f"Task 4 – {method} – ECEF Frame (IMU vs. GNSS)")
     fig_ecef.tight_layout(rect=[0, 0, 1, 0.95])
     if not args.no_plots:
-        save_plot_all(fig_ecef, f"results/{tag}_task4_all_ecef", formats=(".png",))
-        plt.show()
-    plt.close(fig_ecef)
+        save_plot_all(fig_ecef, f"results/{tag}_task4_all_ecef", show_plot=True)
     logging.info("All data in ECEF frame plot saved")
 
     # Plot 4: All data in body frame
@@ -1157,9 +1146,7 @@ def main():
     fig_body.suptitle(f"Task 4 – {method} – Body Frame (IMU vs. GNSS)")
     fig_body.tight_layout(rect=[0, 0, 1, 0.95])
     if not args.no_plots:
-        save_plot_all(fig_body, f"results/{tag}_task4_all_body", formats=(".png",))
-        plt.show()
-    plt.close(fig_body)
+        save_plot_all(fig_body, f"results/{tag}_task4_all_body", show_plot=True)
     logging.info("All data in body frame plot saved")
 
     # ================================
@@ -1586,13 +1573,13 @@ def main():
         )
 
     plt.tight_layout()
-    out_png = f"results/{tag}_task5_results_ned_{method}.png"
+    base = f"results/{tag}_task5_results_ned_{method}"
     if not args.no_plots:
-        save_plot(fig, out_png, f"Task 5 – {method} – NED Frame")
-        plt.show()
-    logging.info(f"Subtask 5.8.2: {method} plot saved as '{out_png}'")
+        fig.suptitle(f"Task 5 – {method} – NED Frame")
+        save_plot_all(fig, base, show_plot=True)
+    logging.info(f"Subtask 5.8.2: {method} plot saved as '{base}.png'")
     logging.debug(
-        f"# Subtask 5.8.2: {method} plotting completed. Saved as '{out_png}'."
+        f"# Subtask 5.8.2: {method} plotting completed. Saved as '{base}.png'"
     )
 
 
@@ -1644,9 +1631,7 @@ def main():
     fig_ned_all.suptitle(f"Task 5 – {method} – NED Frame (Fused vs. Measured GNSS)")
     fig_ned_all.tight_layout(rect=[0, 0, 1, 0.95])
     if not args.no_plots:
-        save_plot_all(fig_ned_all, f"results/{tag}_task5_all_ned", formats=(".png",))
-        plt.show()
-    plt.close(fig_ned_all)
+        save_plot_all(fig_ned_all, f"results/{tag}_task5_all_ned", show_plot=True)
     logging.info("All data in NED frame plot saved")
 
     logging.info("Plotting all data in ECEF frame.")
@@ -1707,9 +1692,7 @@ def main():
     fig_ecef_all.suptitle(f"Task 5 – {method} – ECEF Frame (Fused vs. Measured GNSS)")
     fig_ecef_all.tight_layout(rect=[0, 0, 1, 0.95])
     if not args.no_plots:
-        save_plot_all(fig_ecef_all, f"results/{tag}_task5_all_ecef", formats=(".png",))
-        plt.show()
-    plt.close(fig_ecef_all)
+        save_plot_all(fig_ecef_all, f"results/{tag}_task5_all_ecef", show_plot=True)
     logging.info("All data in ECEF frame plot saved")
 
     logging.info("Plotting all data in body frame.")
@@ -1768,33 +1751,31 @@ def main():
     fig_body_all.suptitle(f"Task 5 – {method} – Body Frame (Fused vs. Measured GNSS)")
     fig_body_all.tight_layout(rect=[0, 0, 1, 0.95])
     if not args.no_plots:
-        save_plot_all(fig_body_all, f"results/{tag}_task5_all_body", formats=(".png",))
-        plt.show()
-    plt.close(fig_body_all)
+        save_plot_all(fig_body_all, f"results/{tag}_task5_all_body", show_plot=True)
     logging.info("All data in body frame plot saved")
 
     # Plot pre-fit innovations
     # Plot residuals using helper functions
     if not args.no_plots:
         res = compute_residuals(gnss_time, gnss_pos_ned, imu_time, fused_pos[method])
-        plot_residuals(gnss_time, res, f"results/residuals_{tag}_{method}.pdf")
+        plot_residuals(gnss_time, res, f"results/residuals_{tag}_{method}")
 
     # Create plot summary
     summary = {
-        f"{tag}_location_map.pdf": "Initial location on Earth map",
-        f"{tag}_task3_errors_comparison.pdf": "Attitude initialization error comparison",
-        f"{tag}_task3_quaternions_comparison.pdf": "Quaternion components for initialization",
-        f"{tag}_task4_comparison_ned.pdf": "GNSS vs IMU data in NED frame",
-        f"{tag}_task4_mixed_frames.pdf": "GNSS/IMU data in mixed frames",
+        f"{tag}_location_map.png": "Initial location on Earth map",
+        f"{tag}_task3_errors_comparison.png": "Attitude initialization error comparison",
+        f"{tag}_task3_quaternions_comparison.png": "Quaternion components for initialization",
+        f"{tag}_task4_comparison_ned.png": "GNSS vs IMU data in NED frame",
+        f"{tag}_task4_mixed_frames.png": "GNSS/IMU data in mixed frames",
         f"{tag}_task4_all_ned.png": "Integrated data in NED frame",
         f"{tag}_task4_all_ecef.png": "Integrated data in ECEF frame",
         f"{tag}_task4_all_body.png": "Integrated data in body frame",
-        f"{tag}_task5_results_{method}.pdf": f"Kalman filter results using {method}",
-        f"{tag}_task5_mixed_frames.pdf": "Kalman filter results in mixed frames",
+        f"{tag}_task5_results_{method}.png": f"Kalman filter results using {method}",
+        f"{tag}_task5_mixed_frames.png": "Kalman filter results in mixed frames",
         f"{tag}_task5_all_ned.png": "Kalman filter results in NED frame",
         f"{tag}_task5_all_ecef.png": "Kalman filter results in ECEF frame",
         f"{tag}_task5_all_body.png": "Kalman filter results in body frame",
-        f"{tag}_{method.lower()}_residuals.pdf": "Position and velocity residuals",
+        f"{tag}_{method.lower()}_residuals.png": "Position and velocity residuals",
     }
     summary_path = os.path.join("results", f"{tag}_plot_summary.md")
     with open(summary_path, "w") as f:

--- a/src/evaluate_filter_results.py
+++ b/src/evaluate_filter_results.py
@@ -21,6 +21,7 @@ from tabulate import tabulate
 import time
 from velocity_utils import derive_velocity
 from utils import compute_C_ECEF_to_NED, ecef_to_geodetic
+from python.utils.save_plot_all import save_plot_all
 
 
 def _find_cols(df: pd.DataFrame, options: Sequence[Sequence[str]]) -> Sequence[str]:
@@ -126,16 +127,9 @@ def run_evaluation(
         axes[1, i].grid(True)
     fig.suptitle("Task 7 – GNSS - Predicted Residuals")
     fig.tight_layout(rect=[0, 0, 1, 0.95])
-    out_path = plot_path(out_dir, tag or "", 7, "3", "residuals_position_velocity")
-    fig.savefig(out_path)
-    print(f"Saved {out_path}")
-    try:
-        from utils import save_plot_mat, save_plot_fig
-        save_plot_mat(fig, str(out_path.with_suffix(".mat")))
-        save_plot_fig(fig, str(out_path.with_suffix(".fig")))
-    except Exception:
-        pass
-    plt.close(fig)
+    out_path = plot_path(out_dir, tag or "", 7, "3", "residuals_position_velocity", ext="png").with_suffix("")
+    save_plot_all(fig, str(out_path), show_plot=True)
+    print(f"Saved {out_path}.png")
 
     # Histograms of residuals
     for arr, name in [(res_pos, "position"), (res_vel, "velocity")]:
@@ -147,16 +141,9 @@ def run_evaluation(
             axes[i].grid(True)
         fig.suptitle(f"Task 7 – Histogram of {name} residuals")
         fig.tight_layout(rect=[0, 0, 1, 0.95])
-        hist_path = plot_path(out_dir, tag or "", 7, f"hist_{name}", "residuals")
-        fig.savefig(hist_path)
-        print(f"Saved {hist_path}")
-        try:
-            from utils import save_plot_mat, save_plot_fig
-            save_plot_mat(fig, str(hist_path.with_suffix(".mat")))
-            save_plot_fig(fig, str(hist_path.with_suffix(".fig")))
-        except Exception:
-            pass
-        plt.close(fig)
+        hist_path = plot_path(out_dir, tag or "", 7, f"hist_{name}", "residuals", ext="png").with_suffix("")
+        save_plot_all(fig, str(hist_path), show_plot=True)
+        print(f"Saved {hist_path}.png")
 
     quat = att[quat_cols].to_numpy()
     rot = R.from_quat(quat[:, [1, 2, 3, 0]])  # w,x,y,z -> x,y,z,w
@@ -172,15 +159,8 @@ def run_evaluation(
     axs[2].set_xlabel("Time [s]")
     fig.suptitle("Task 7 – Attitude Angles")
     fig.tight_layout(rect=[0, 0, 1, 0.95])
-    att_out = plot_path(out_dir, tag or "", 7, "4", "attitude_angles_euler")
-    fig.savefig(att_out)
-    try:
-        from utils import save_plot_mat, save_plot_fig
-        save_plot_mat(fig, str(att_out.with_suffix(".mat")))
-        save_plot_fig(fig, str(att_out.with_suffix(".fig")))
-    except Exception:
-        pass
-    plt.close(fig)
+    att_out = plot_path(out_dir, tag or "", 7, "4", "attitude_angles_euler", ext="png").with_suffix("")
+    save_plot_all(fig, str(att_out), show_plot=True)
 
 
 def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) -> None:
@@ -267,10 +247,9 @@ def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) ->
         axes[1, i].grid(True)
     fig.suptitle("Task 7 – GNSS - Predicted Residuals")
     fig.tight_layout(rect=[0, 0, 1, 0.95])
-    out_path = plot_path(out_dir, tag or "", 7, "3", "residuals_position_velocity")
-    fig.savefig(out_path)
-    print(f"Saved {out_path}")
-    plt.close(fig)
+    out_path = plot_path(out_dir, tag or "", 7, "3", "residuals_position_velocity", ext="png").with_suffix("")
+    save_plot_all(fig, str(out_path), show_plot=True)
+    print(f"Saved {out_path}.png")
 
     rot = R.from_quat(quat[:, [1, 2, 3, 0]])
     euler = rot.as_euler("xyz", degrees=True)
@@ -284,10 +263,9 @@ def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) ->
     axs[2].set_xlabel("Time [s]")
     fig.suptitle("Task 7 – Attitude Angles")
     fig.tight_layout(rect=[0, 0, 1, 0.95])
-    att_path = plot_path(out_dir, tag or "", 7, "4", "attitude_angles_euler")
-    fig.savefig(att_path)
-    print(f"Saved {att_path}")
-    plt.close(fig)
+    att_path = plot_path(out_dir, tag or "", 7, "4", "attitude_angles_euler", ext="png").with_suffix("")
+    save_plot_all(fig, str(att_path), show_plot=True)
+    print(f"Saved {att_path}.png")
 
     # Error norm plots
     norm_pos = np.linalg.norm(res_pos, axis=1)
@@ -304,10 +282,9 @@ def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) ->
     ax.legend()
     ax.grid(True)
     fig.tight_layout()
-    norm_path = plot_path(out_dir, tag or "", 7, "3", "error_norms")
-    fig.savefig(norm_path)
-    print(f"Saved {norm_path}")
-    plt.close(fig)
+    norm_path = plot_path(out_dir, tag or "", 7, "3", "error_norms", ext="png").with_suffix("")
+    save_plot_all(fig, str(norm_path), show_plot=True)
+    print(f"Saved {norm_path}.png")
 
     # Subtask 7.5: difference Truth - Fused in multiple frames
     if fused_time is not None and fused_pos is not None and fused_vel is not None:
@@ -405,20 +382,10 @@ def subtask7_5_diff_plot(
 
         fig.suptitle(f"Truth - Fused Differences ({frame} Frame)")
         fig.tight_layout(rect=[0, 0, 1, 0.95])
-        base = plot_path(out_dir, run_id, 7, "5", "diff_truth_fused_over_time")
-        pdf = base.with_name(base.stem + f"_{frame}.pdf")
-        png = pdf.with_suffix(".png")
-        fig.savefig(pdf)
-        print(f"Saved {pdf}")
-        fig.savefig(png)
-        print(f"Saved {png}")
-        try:
-            from utils import save_plot_mat, save_plot_fig
-            save_plot_mat(fig, str(pdf.with_suffix(".mat")))
-            save_plot_fig(fig, str(pdf.with_suffix(".fig")))
-        except Exception:
-            pass
-        plt.close(fig)
+        base = plot_path(out_dir, run_id, 7, "5", "diff_truth_fused_over_time", ext="png").with_suffix("")
+        fig_base = base.with_name(base.name + f"_{frame}")
+        save_plot_all(fig, str(fig_base), show_plot=True)
+        print(f"Saved {fig_base}.png")
 
         pos_thr = 1.0
         vel_thr = 1.0

--- a/src/gnss_imu_fusion/plots.py
+++ b/src/gnss_imu_fusion/plots.py
@@ -40,8 +40,7 @@ def save_zupt_variance(
     plt.tight_layout()
     plt.title("ZUPT Detection and Accelerometer Variance")
     base = Path("results") / f"IMU_{dataset_id}_ZUPT_variance"
-    save_plot_all(plt.gcf(), str(base))
-    plt.close()
+    save_plot_all(plt.gcf(), str(base), show_plot=True)
 
 
 def save_euler_angles(
@@ -73,8 +72,7 @@ def save_euler_angles(
     plt.tight_layout()
     plt.title("Attitude Angles (Roll/Pitch/Yaw) vs. Time")
     base = Path("results") / f"{dataset_id}_{method}_attitude_angles_over_time"
-    save_plot_all(plt.gcf(), str(base))
-    plt.close()
+    save_plot_all(plt.gcf(), str(base), show_plot=True)
 
 
 def save_residual_plots(
@@ -115,8 +113,7 @@ def save_residual_plots(
     plt.legend(loc="best")
     plt.tight_layout()
     filename = plot_path("results", tag, 5, "residuals", "position_residuals")
-    save_plot_all(plt.gcf(), str(Path(filename).with_suffix("")))
-    plt.close()
+    save_plot_all(plt.gcf(), str(Path(filename).with_suffix("")), show_plot=True)
 
     plt.figure(figsize=(10, 5))
     for i, label in enumerate(labels):
@@ -127,8 +124,7 @@ def save_residual_plots(
     plt.legend(loc="best")
     plt.tight_layout()
     filename = plot_path("results", tag, 5, "residuals", "velocity_residuals")
-    save_plot_all(plt.gcf(), str(Path(filename).with_suffix("")))
-    plt.close()
+    save_plot_all(plt.gcf(), str(Path(filename).with_suffix("")), show_plot=True)
 
 
 def save_attitude_over_time(
@@ -160,8 +156,7 @@ def save_attitude_over_time(
     plt.tight_layout()
     plt.title("Attitude Angles (Roll/Pitch/Yaw) Over Time")
     base = Path("results") / f"{dataset_id}_{method}_attitude_angles_over_time"
-    save_plot_all(plt.gcf(), str(base))
-    plt.close()
+    save_plot_all(plt.gcf(), str(base), show_plot=True)
 
 
 def save_velocity_profile(t: np.ndarray, vel_filter: np.ndarray, vel_gnss: np.ndarray) -> None:
@@ -177,8 +172,7 @@ def save_velocity_profile(t: np.ndarray, vel_filter: np.ndarray, vel_gnss: np.nd
     plt.legend(loc="best")
     plt.tight_layout()
     base = Path("results") / "velocity_profile"
-    save_plot_all(plt.gcf(), str(base))
-    plt.close()
+    save_plot_all(plt.gcf(), str(base), show_plot=True)
 
 
 def plot_all_methods(
@@ -227,6 +221,5 @@ def plot_all_methods(
                 ax.legend()
 
     plt.tight_layout()
-    save_plot_all(fig, str(Path(savefile).with_suffix("")))
-    plt.close(fig)
+    save_plot_all(fig, str(Path(savefile).with_suffix("")), show_plot=True)
 

--- a/src/plot_fused_vs_truth.py
+++ b/src/plot_fused_vs_truth.py
@@ -7,6 +7,7 @@ from typing import Iterable
 
 import numpy as np
 import matplotlib.pyplot as plt
+from python.utils.save_plot_all import save_plot_all
 
 
 def plot_fused_vs_truth(
@@ -29,7 +30,8 @@ def plot_fused_vs_truth(
     fused : array-like of shape (N, 3)
         Fused GNSS+IMU estimate in the same frame as ``truth``.
     output_path : str or Path
-        Where to write the generated figure (PDF or PNG).
+        Base path where the figure will be written. ``.png`` and ``.pickle``
+        are appended automatically.
     frame_label : str, optional
         Name of the reference frame for the title, e.g. ``"ECEF"``.
     unit : str, optional
@@ -83,7 +85,6 @@ def plot_fused_vs_truth(
     fig.suptitle(title)
     fig.tight_layout(rect=[0, 0, 1, 0.95])
 
-    output_path = Path(output_path)
+    output_path = Path(output_path).with_suffix("")
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(output_path)
-    plt.close(fig)
+    save_plot_all(fig, str(output_path), show_plot=True)

--- a/src/plot_overlay.py
+++ b/src/plot_overlay.py
@@ -171,6 +171,5 @@ def plot_overlay(
     else:
         out_path = Path(out_dir) / f"{method}_{frame}{suffix}"
 
-    save_plot_all(fig, str(out_path), formats=(".pickle", ".fig"))
+    save_plot_all(fig, str(out_path), show_plot=True)
     print(f"Saved overlay figure {out_path}.pickle")
-    plt.close(fig)

--- a/src/scripts/validate_filter.py
+++ b/src/scripts/validate_filter.py
@@ -1,5 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as plt
+from python.utils.save_plot_all import save_plot_all
 
 
 def compute_residuals(gnss_times, gnss_pos, filt_times, filt_pos):
@@ -11,7 +12,7 @@ def compute_residuals(gnss_times, gnss_pos, filt_times, filt_pos):
     return res
 
 
-def plot_residuals(gnss_times, res, outpath):
+def plot_residuals(gnss_times, res, outbase):
     fig, axs = plt.subplots(2, 1, figsize=(8, 6))
     axs[0].plot(gnss_times, res[:, 0], label='North')
     axs[0].plot(gnss_times, res[:, 1], label='East')
@@ -30,5 +31,4 @@ def plot_residuals(gnss_times, res, outpath):
 
     fig.suptitle('Position & Velocity Residuals')
     fig.tight_layout(rect=[0, 0, 1, 0.96])
-    fig.savefig(outpath)
-    plt.close(fig)
+    save_plot_all(fig, outbase, show_plot=True)

--- a/src/task7_ned_residuals_plot.py
+++ b/src/task7_ned_residuals_plot.py
@@ -8,8 +8,7 @@ Usage:
 This implements the functionality of ``task7_ned_residuals_plot.m`` from the
 MATLAB code base. The estimator time vector is shifted to start at zero so that
 Task 6 and Task 7 plots share the same x-axis. Figures are written under
-``results/<dataset>/`` in Python ``.pickle`` and MATLAB ``.mat`` (via ``.fig``)
-formats.
+``results/<dataset>/`` and saved as ``.png`` and ``.pickle`` formats.
 """
 
 from __future__ import annotations
@@ -146,8 +145,7 @@ def plot_residuals(
     fig.tight_layout(rect=[0, 0, 1, 0.95])
     out_dir.mkdir(parents=True, exist_ok=True)
     base = out_dir / f"{dataset}_task7_ned_residuals"
-    save_plot_all(fig, str(base), formats=(".pickle", ".fig"))
-    plt.close(fig)
+    save_plot_all(fig, str(base), show_plot=True)
 
     fig, ax = plt.subplots()
     ax.plot(t, np.linalg.norm(res_pos, axis=1), label="|pos|")
@@ -160,8 +158,7 @@ def plot_residuals(
     fig.suptitle(f"{dataset} Task 7 NED Residual Norms")
     fig.tight_layout(rect=[0, 0, 1, 0.95])
     norm_base = out_dir / f"{dataset}_task7_ned_residual_norms"
-    save_plot_all(fig, str(norm_base), formats=(".pickle", ".fig"))
-    plt.close(fig)
+    save_plot_all(fig, str(norm_base), show_plot=True)
 
     saved = sorted(out_dir.glob(f"{dataset}_task7_ned_residual*.pickle"))
     if saved:

--- a/src/validate_3sigma.py
+++ b/src/validate_3sigma.py
@@ -20,6 +20,7 @@ import logging
 import numpy as np
 from scipy.spatial.transform import Rotation as R, Slerp
 import matplotlib.pyplot as plt
+from python.utils.save_plot_all import save_plot_all
 
 # Reuse the robust loader from validate_with_truth
 from validate_with_truth import load_estimate
@@ -164,8 +165,7 @@ def main() -> None:
         ax.set_ylabel(f"Position {lab} error [m]")
         ax.legend()
         fig.tight_layout()
-        fig.savefig(out_dir / f"pos_err_{lab}.pdf")
-        plt.close(fig)
+        save_plot_all(fig, str(out_dir / f"pos_err_{lab}"), show_plot=True)
 
     for i, lab in enumerate(labels_vel):
         fig, ax = plt.subplots()
@@ -177,8 +177,7 @@ def main() -> None:
         ax.set_ylabel(f"Velocity {lab} error [m/s]")
         ax.legend()
         fig.tight_layout()
-        fig.savefig(out_dir / f"vel_err_{lab}.pdf")
-        plt.close(fig)
+        save_plot_all(fig, str(out_dir / f"vel_err_{lab}"), show_plot=True)
 
     for i, lab in enumerate(labels_quat):
         fig, ax = plt.subplots()
@@ -190,8 +189,7 @@ def main() -> None:
         ax.set_ylabel(f"Quaternion {lab} error")
         ax.legend()
         fig.tight_layout()
-        fig.savefig(out_dir / f"quat_err_{lab}.pdf")
-        plt.close(fig)
+        save_plot_all(fig, str(out_dir / f"quat_err_{lab}"), show_plot=True)
 
     print(
         f"Final position error: {final_pos:.3f} m, RMSE: {rmse_pos:.3f} m"

--- a/task6_csv_statistics.py
+++ b/task6_csv_statistics.py
@@ -19,6 +19,7 @@ from statistics import mean, median, mode
 
 import matplotlib.pyplot as plt
 import pandas as pd
+from python.utils.save_plot_all import save_plot_all
 
 
 def task6(csv_file: str = "data_task6.csv", output_dir: Path | str = "results") -> tuple[float | None, float | None, float | None]:
@@ -87,10 +88,8 @@ def task6(csv_file: str = "data_task6.csv", output_dir: Path | str = "results") 
     plt.ylabel("Frequency")
     plt.grid(True, linestyle="--", alpha=0.7)
     base = output_path / "task6_histogram"
-    plt.savefig(base.with_suffix(".pdf"))
-    plt.savefig(base.with_suffix(".png"))
-    plt.close()
-    print(f"Histogram saved as {base.with_suffix('.pdf')} and .png")
+    save_plot_all(plt.gcf(), str(base), show_plot=True)
+    print(f"Histogram saved as {base.with_suffix('.png')} and .pickle")
 
     print("Returning statistical measures: (mean, median, mode)")
     return data_mean, data_median, data_mode

--- a/task6_fused_truth_multi_analysis.py
+++ b/task6_fused_truth_multi_analysis.py
@@ -8,7 +8,8 @@ This script loads truth data in the ECEF frame, converts it to NED and Body
 frames, generates an approximate fused trajectory in NED, converts it to ECEF
 and Body frames, and compares the results. Differences are summarised and
 plotted for each frame/component. Plots are written under ``results/`` using the
-filename pattern ``analysis_diff_<frame>_<component>.png`` (and ``.pdf``).
+filename pattern ``analysis_diff_<frame>_<component>`` with ``.png`` and
+``.pickle`` outputs.
 """
 
 from __future__ import annotations
@@ -20,6 +21,7 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 from scipy.spatial.transform import Rotation
+from python.utils.save_plot_all import save_plot_all
 
 # ---------------------------------------------------------------------------
 # constants
@@ -157,10 +159,8 @@ def analyze_component(time: np.ndarray, diff: np.ndarray, frame: str, comp: str)
     plt.title(f"Difference {frame} {comp}")
     plt.grid(True)
     plt.tight_layout()
-    fname = RESULTS_DIR / f"analysis_diff_{frame}_{comp}.png"
-    plt.savefig(fname)
-    plt.savefig(fname.with_suffix(".pdf"))
-    plt.close()
+    fname = RESULTS_DIR / f"analysis_diff_{frame}_{comp}"
+    save_plot_all(plt.gcf(), str(fname), show_plot=True)
 
 
 def analyze_all(time: np.ndarray, truth: dict, fused: dict) -> None:

--- a/task6_overlay_plot.py
+++ b/task6_overlay_plot.py
@@ -10,8 +10,8 @@ This script synchronizes the time bases of the estimator output and ground
 truth, then generates a single figure with position, velocity and acceleration
 components overlaid. Only the fused estimate and truth are shown. Figures are
 written under ``results/<run_id>/`` using the base filename
-``<run_id>_task6_overlay_state_<frame>`` with Python ``.pickle`` and MATLAB
-``.mat`` companions where ``run_id`` combines the dataset and method, e.g.
+``<run_id>_task6_overlay_state_<frame>`` and saved as ``.png`` and ``.pickle``
+where ``run_id`` combines the dataset and method, e.g.
 ``IMU_X003_GNSS_X002_TRIAD``. With ``--debug`` the script prints diagnostic
 information about the input datasets before plotting.
 """
@@ -247,8 +247,7 @@ def plot_overlay(
     run_id = f"{dataset}_{method}"
     out_dir.mkdir(parents=True, exist_ok=True)
     base = out_dir / f"{run_id}_task6_overlay_state_{frame}"
-    save_plot_all(fig, str(base), formats=(".pickle", ".fig"))
-    plt.close(fig)
+    save_plot_all(fig, str(base), show_plot=True)
     print(f"Saved overlay figure to {base}.pickle")
     return base.with_suffix(".pickle")
 
@@ -288,8 +287,7 @@ def plot_rmse(
 
     out_dir.mkdir(parents=True, exist_ok=True)
     base = out_dir / f"{dataset}_{method}_Task6_{frame}_RMSE"
-    save_plot_all(fig, str(base), formats=(".pickle", ".fig"))
-    plt.close(fig)
+    save_plot_all(fig, str(base), show_plot=True)
     print(f"Saved RMSE figure to {base}.pickle")
     return base.with_suffix(".pickle")
 
@@ -380,7 +378,7 @@ def main() -> None:
     )
 
     run_id = f"{args.dataset}_{args.method}"
-    saved = sorted(out_dir.glob(f"{run_id}_task6_*.pdf"))
+    saved = sorted(out_dir.glob(f"{run_id}_task6_*.pickle"))
     if saved:
         print("Saved files under", out_dir)
         for f in saved:

--- a/task7_ecef_residuals_plot.py
+++ b/task7_ecef_residuals_plot.py
@@ -6,17 +6,16 @@ Usage:
         --output-dir results
 
 This script loads a fused estimator output file and the corresponding
-ground truth trajectory.  If the estimator output already contains the
+ground truth trajectory. If the estimator output already contains the
 ``truth_pos_ecef``, ``truth_vel_ecef`` and ``truth_time`` fields produced
-by Task 4, the ``--truth-file`` argument is optional.  Otherwise the
+by Task 4, the ``--truth-file`` argument is optional. Otherwise the
 STATE_X text log must be provided or inferrable from the dataset name.
 The truth trajectory is synchronised to the estimator by cross-correlating
 position and velocity magnitudes before interpolation to the estimator time
 vector. Position, velocity and acceleration residuals are plotted. The time
 axis is converted to ``t - t[0]`` so Task 6 and Task 7 share the same
-reference. Figures are saved in interactive Python ``.pickle`` and MATLAB
-``.mat`` (via ``.fig`` export) formats under ``results/<tag>/`` where ``tag``
-combines the dataset, GNSS file and method.
+reference. Figures are saved under ``results/<tag>/`` as ``.png`` and
+``.pickle`` where ``tag`` combines the dataset, GNSS file and method.
 """
 
 from __future__ import annotations
@@ -86,8 +85,7 @@ def plot_residuals(
     fig.tight_layout(rect=[0, 0, 1, 0.95])
     out_dir.mkdir(parents=True, exist_ok=True)
     base = out_dir / Path(plot_filename(dataset, gnss, method, 7, "3", "ecef_residuals")).with_suffix("")
-    save_plot_all(fig, str(base), formats=(".pickle", ".fig"))
-    plt.close(fig)
+    save_plot_all(fig, str(base), show_plot=True)
 
     # Norm plot
     fig, ax = plt.subplots()
@@ -101,8 +99,7 @@ def plot_residuals(
     fig.suptitle(f"{tag} Task 7 ECEF Residual Norms")
     fig.tight_layout(rect=[0, 0, 1, 0.95])
     norm_base = out_dir / Path(plot_filename(dataset, gnss, method, 7, "3", "ecef_residual_norms")).with_suffix("")
-    save_plot_all(fig, str(norm_base), formats=(".pickle", ".fig"))
-    plt.close(fig)
+    save_plot_all(fig, str(norm_base), show_plot=True)
 
     saved = sorted(out_dir.glob(f"{tag}_task7_*ecef_residual*.pickle"))
     if saved:

--- a/task7_temperature_analysis.py
+++ b/task7_temperature_analysis.py
@@ -7,9 +7,9 @@ Usage:
 This script reads a CSV file containing a single column of temperature
 measurements in degrees Celsius, filters the data to the range
 ``0``–``30``\u00b0C and computes basic statistics. A histogram with a
-vertical line at the mean is saved under ``results/``. The function
-contains print statements for debugging and mirrors the MATLAB stub
-``task7_temperature_analysis.m``.
+vertical line at the mean is saved under ``results/`` as ``.png`` and
+``.pickle``. The function contains print statements for debugging and
+mirrors the MATLAB stub ``task7_temperature_analysis.m``.
 """
 
 from __future__ import annotations
@@ -20,6 +20,7 @@ from statistics import mean, median
 
 import matplotlib.pyplot as plt
 import pandas as pd
+from python.utils.save_plot_all import save_plot_all
 
 
 def task7(csv_file: str = "temperatures.csv", output_dir: Path | str = "results") -> tuple[float | None, float | None]:
@@ -103,10 +104,8 @@ def task7(csv_file: str = "temperatures.csv", output_dir: Path | str = "results"
     plt.legend()
     plt.grid(True, linestyle="--", alpha=0.7)
     base = output_path / "task7_temperature_histogram"
-    plt.savefig(base.with_suffix(".pdf"))
-    plt.savefig(base.with_suffix(".png"))
-    plt.close()
-    print(f"Histogram saved as {base.with_suffix('.pdf')} and .png")
+    save_plot_all(plt.gcf(), str(base), show_plot=True)
+    print(f"Histogram saved as {base.with_suffix('.png')} and .pickle")
 
     print("Returning statistical measures: (mean, median)")
     return data_mean, data_median

--- a/tests/test_evaluate_filter_results.py
+++ b/tests/test_evaluate_filter_results.py
@@ -12,8 +12,8 @@ def test_run_evaluation_npz_mismatched_lengths(tmp_path):
     f = tmp_path / "data.npz"
     np.savez(f, residual_pos=res_pos, residual_vel=res_vel, time_residuals=t, attitude_q=quat)
     run_evaluation_npz(str(f), str(tmp_path), tag="TEST")
-    assert (tmp_path / "TEST_task7_3_residuals_position_velocity.pdf").exists()
-    assert (tmp_path / "TEST_task7_4_attitude_angles_euler.pdf").exists()
+    assert (tmp_path / "TEST_task7_3_residuals_position_velocity.png").exists()
+    assert (tmp_path / "TEST_task7_4_attitude_angles_euler.png").exists()
 
 
 def test_run_evaluation_npz_quat_longer(tmp_path):
@@ -24,8 +24,8 @@ def test_run_evaluation_npz_quat_longer(tmp_path):
     f = tmp_path / "data.npz"
     np.savez(f, residual_pos=res_pos, residual_vel=res_vel, time_residuals=t, attitude_q=quat)
     run_evaluation_npz(str(f), str(tmp_path), tag="TEST")
-    assert (tmp_path / "TEST_task7_3_residuals_position_velocity.pdf").exists()
-    assert (tmp_path / "TEST_task7_4_attitude_angles_euler.pdf").exists()
+    assert (tmp_path / "TEST_task7_3_residuals_position_velocity.png").exists()
+    assert (tmp_path / "TEST_task7_4_attitude_angles_euler.png").exists()
 
 
 def test_run_evaluation_npz_diff_plot(tmp_path):
@@ -47,6 +47,6 @@ def test_run_evaluation_npz_diff_plot(tmp_path):
         vel_ned=fused_vel,
     )
     run_evaluation_npz(str(f), str(tmp_path), tag="TEST")
-    assert (tmp_path / "TEST_task7_5_diff_truth_fused_over_time_NED.pdf").exists()
-    assert (tmp_path / "TEST_task7_5_diff_truth_fused_over_time_ECEF.pdf").exists()
-    assert (tmp_path / "TEST_task7_5_diff_truth_fused_over_time_Body.pdf").exists()
+    assert (tmp_path / "TEST_task7_5_diff_truth_fused_over_time_NED.png").exists()
+    assert (tmp_path / "TEST_task7_5_diff_truth_fused_over_time_ECEF.png").exists()
+    assert (tmp_path / "TEST_task7_5_diff_truth_fused_over_time_Body.png").exists()

--- a/tests/test_plot_fused_vs_truth.py
+++ b/tests/test_plot_fused_vs_truth.py
@@ -8,6 +8,6 @@ def test_plot_fused_vs_truth(tmp_path):
     t = np.linspace(0, 1, 5)
     truth = np.vstack([t, t * 0, -t]).T
     fused = truth + 0.1
-    out_file = tmp_path / "plot.pdf"
-    plot_fused_vs_truth(t, truth, fused, out_file, frame_label="ECEF")
-    assert out_file.exists()
+    out_base = tmp_path / "plot"
+    plot_fused_vs_truth(t, truth, fused, out_base, frame_label="ECEF")
+    assert (out_base.with_suffix(".png")).exists()

--- a/tests/test_plot_overlay.py
+++ b/tests/test_plot_overlay.py
@@ -84,7 +84,7 @@ def test_plot_overlay_custom_filename(tmp_path):
         vel,
         acc,
         tmp_path,
-        filename="custom.pdf",
+        filename="custom.png",
         t_truth=t,
         pos_truth=pos,
         vel_truth=vel,

--- a/tests/test_results_structure.py
+++ b/tests/test_results_structure.py
@@ -7,7 +7,7 @@ def test_results_flat_structure(tmp_path):
     results = tmp_path / "results"
     results.mkdir()
     # create sample files
-    (results / "IMU_X001_GNSS_X001_TRIAD_task6_demo.pdf").touch()
+    (results / "IMU_X001_GNSS_X001_TRIAD_task6_demo.png").touch()
     (results / "sample_task7_plot.png").touch()
     (results / "legacy").mkdir()
     (results / "legacy" / "old.txt").touch()

--- a/tests/test_validate_3sigma.py
+++ b/tests/test_validate_3sigma.py
@@ -65,7 +65,7 @@ def test_time_shift_allows_overlap(tmp_path, monkeypatch):
     )
 
     main()
-    assert (tmp_path / "pos_err_X.pdf").exists()
+    assert (tmp_path / "pos_err_X.png").exists()
 
 
 def test_auto_time_shift(tmp_path, monkeypatch):
@@ -95,4 +95,4 @@ def test_auto_time_shift(tmp_path, monkeypatch):
     )
 
     main()
-    assert (tmp_path / "vel_err_Vx.pdf").exists()
+    assert (tmp_path / "vel_err_Vx.png").exists()


### PR DESCRIPTION
## Summary
- replace PDF default with PNG+pickle in `save_plot_all` and always display figures
- mirror interactive PNG+FIG defaults for MATLAB plotting
- update Task scripts and utilities to call `save_plot_all(..., show_plot=True)` and drop hardcoded PDF paths

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68999460d7788325b504d29f6931ff0c