### PR TITLE
fix: parse truth timeline

### DIFF
--- a/MATLAB/utils/print_timeline_matlab.m
+++ b/MATLAB/utils/print_timeline_matlab.m
@@ -1,6 +1,8 @@
-function print_timeline_matlab(rid, imu_path, gnss_path, truth_path, out_dir)
+function [txt, meta] = print_timeline_matlab(rid, imu_path, gnss_path, truth_path, out_dir)
 %PRINT_TIMELINE_MATLAB Write timeline summary for datasets.
-%   PRINT_TIMELINE_MATLAB(RID, IMU_PATH, GNSS_PATH, TRUTH_PATH, OUT_DIR) writes a summary to console and file.
+%   TXT = PRINT_TIMELINE_MATLAB(RID, IMU_PATH, GNSS_PATH, TRUTH_PATH, OUT_DIR)
+%   writes a summary to console and file. Metadata is returned in META with
+%   fields ``IMU``, ``GNSS`` and ``TRUTH`` mirroring the Python implementation.
 %
 % Usage:
 %   print_timeline_matlab(''runid'', imu_path, gnss_path, truth_path, out_dir);
@@ -8,10 +10,11 @@ function print_timeline_matlab(rid, imu_path, gnss_path, truth_path, out_dir)
 % Writes a timeline summary to console and to <rid>_timeline.txt.
 % - Detects IMU time or synthesizes @400 Hz
 % - GNSS uses Posix_Time or builds from UTC_* columns, else @1Hz fallback
-% - TRUTH ignores '#' comments and uses col 1 as time
+% - TRUTH ignores '#' comments and uses column 2 as time
 
 lines = strings(0,1);
 notes = strings(0,1);
+meta = struct();
 
 % ---------- IMU ----------
 imu = readmatrix(imu_path,'FileType','text');
@@ -28,7 +31,8 @@ if isempty(col)
 else
     tI = imu(:,col);     notes = [notes; sprintf("IMU: used time-like column %d (dt_med=%.6f)", col, median(diff(tI)))];
 end
-lines = [lines; format_line('IMU', tI, nI)];
+[line, meta.IMU] = format_line('IMU', tI, nI);
+lines = [lines; line];
 
 % ---------- GNSS ----------
 opts = detectImportOptions(gnss_path,'Delimiter',',');
@@ -45,17 +49,28 @@ else
         tg = (0:nG-1)';   notes = [notes; "GNSS: fallback uniform @1Hz"];
     end
 end
-lines = [lines; format_line('GNSS', tg, nG)];
+[line, meta.GNSS] = format_line('GNSS', tg, nG);
+lines = [lines; line];
 
 % ---------- TRUTH ----------
 if ~isempty(truth_path) && isfile(truth_path)
-    to = detectImportOptions(truth_path, 'Delimiter',' ', 'CommentStyle','#', 'ConsecutiveDelimitersRule','join');
+    to = detectImportOptions(truth_path, 'Delimiter',' ', 'CommentStyle','#', ...
+        'ConsecutiveDelimitersRule','join', 'ReadVariableNames',false);
     Ts = readtable(truth_path, to);
-    ts = ensure_time_vec(Ts{:,1});
-    nS = numel(ts);
-    lines = [lines; format_line('TRUTH', ts, nS)];
+    if size(Ts,2) >= 2
+        ts = ensure_time_vec(Ts{:,2});
+        nS = numel(ts);
+        [line, meta.TRUTH] = format_line('TRUTH', ts, nS);
+        lines = [lines; line];
+    else
+        lines = [lines; "TRUTH | present but unreadable (see Notes)."];
+        meta.TRUTH = struct('n',0,'hz',NaN,'dt_med',NaN,'dt_min',NaN,'dt_max',NaN, ...
+            'dur_s',NaN,'t0',NaN,'t1',NaN,'monotonic',false);
+    end
 else
     lines = [lines; "TRUTH | present but unreadable (see Notes)."];
+    meta.TRUTH = struct('n',0,'hz',NaN,'dt_med',NaN,'dt_min',NaN,'dt_max',NaN, ...
+        'dur_s',NaN,'t0',NaN,'t1',NaN,'monotonic',false);
 end
 
 % ---------- Print + Save ----------
@@ -69,19 +84,25 @@ fid = fopen(out_path,'w'); fprintf(fid,'%s\n',txt); fclose(fid);
 fprintf('[DATA TIMELINE] Saved %s\n', out_path);
 end
 
-function s = format_line(tag, t, n)
+function [s, m] = format_line(tag, t, n)
 t = t(:);
 % Guard: ensure numeric time for diff
 if isdatetime(t), t = seconds(t - t(1)); end
 if isduration(t), t = seconds(t); end
 if iscell(t) || isstring(t), t = str2double(t); end
 dt = diff(t);
-if isempty(dt) || ~all(isfinite(dt)), hz = NaN; med = NaN; mn = NaN; mx = NaN; mono = false;
-else, hz = 1/median(dt); med = median(dt); mn = min(dt); mx = max(dt); mono = all(dt > 0);
+m = struct('n', n, 'hz', NaN, 'dt_med', NaN, 'dt_min', NaN, 'dt_max', NaN, ...
+    'dur_s', NaN, 't0', NaN, 't1', NaN, 'monotonic', false);
+if ~isempty(t)
+    m.t0 = t(1); m.t1 = t(end); m.dur_s = t(end) - t(1);
 end
-dur = t(end) - t(1);
+if ~isempty(dt) && all(isfinite(dt))
+    m.dt_med = median(dt); m.dt_min = min(dt); m.dt_max = max(dt);
+    if m.dt_med > 0, m.hz = 1/m.dt_med; end
+    m.monotonic = all(dt > 0);
+end
 s = sprintf('%-5s | n=%-7d hz=%0.6f  dt_med=%0.6f  min/max dt=(%0.6f,%0.6f)  dur=%0.3fs  t0=%0.6f  t1=%0.6f  monotonic=%s',...
-    tag, n, hz, med, mn, mx, dur, t(1), t(end), lower(string(mono)));
+    tag, m.n, m.hz, m.dt_med, m.dt_min, m.dt_max, m.dur_s, m.t0, m.t1, lower(string(m.monotonic)));
 end
 
 function t = ensure_time_vec(x)

--- a/src/utils/timeline.py
+++ b/src/utils/timeline.py
@@ -13,12 +13,22 @@ import pandas as pd
 
 
 def _read_truth_time(truth_path, notes):
-    """Read STATE_* truth file robustly:
+    """Read STATE_* truth file robustly.
 
-    - Ignore lines starting with '#'
-    - Split on any whitespace
-    - Coerce 1st column to numeric, drop NaN rows
-    - Return time starting at zero
+    Parameters
+    ----------
+    truth_path : str or Path
+        Path to the truth file (whitespace delimited).
+    notes : list[str]
+        Diagnostics are appended here on failure.
+
+    Returns
+    -------
+    np.ndarray | None
+        Time vector starting at zero or ``None`` if parsing fails.
+
+    The parser ignores lines starting with ``#`` and expects column 2 to
+    contain the relative time in seconds.
     """
     if not truth_path or not Path(truth_path).exists():
         return None
@@ -33,8 +43,8 @@ def _read_truth_time(truth_path, notes):
         keep_default_na=True,
     )
 
-    # coerce first column to numeric; drop bad rows
-    t = pd.to_numeric(st.iloc[:, 0], errors="coerce").to_numpy(np.float64)
+    col = 1 if st.shape[1] > 1 else 0
+    t = pd.to_numeric(st.iloc[:, col], errors="coerce").to_numpy(np.float64)
     mask = np.isfinite(t)
     t = t[mask]
     if t.size < 2:
@@ -283,4 +293,3 @@ print_timeline = print_timeline_summary
 
 
 __all__ = ["print_timeline_summary", "print_timeline"]
-


### PR DESCRIPTION
## Summary
- compute dataset timeline metadata for TRUTH using second column of STATE files
- expose timing metadata structs from MATLAB `print_timeline_matlab`
- mirror TRUTH time parsing update in Python timeline utility

## Testing
- `python -m flake8 src/utils/timeline.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899995db9288325ad42a7e34438221f