### PR TITLE
Fix truth timing extraction and Task 5 setup

### DIFF
--- a/MATLAB/Task_5.m
+++ b/MATLAB/Task_5.m
@@ -121,6 +121,13 @@ end
     % Load attitude estimate from Task 3 results using TaskIO
     t3_path = fullfile(results_dir, sprintf('%s_%s_%s_task3_results.mat', imu_name, gnss_name, method));
     Task3 = TaskIO.load('Task3', t3_path);
+    % Also load the raw struct to access per-method results later
+    S = load(t3_path);
+    if isfield(S, 'task3_results')
+        task3_results = S.task3_results;
+    else
+        task3_results = S;
+    end
     mi = find(strcmpi(Task3.methods, method), 1);
     if isempty(mi)
         error('Task5:NoMethod','Method %s not in Task3.methods', method);

--- a/MATLAB/src/utils/read_truth_state.m
+++ b/MATLAB/src/utils/read_truth_state.m
@@ -1,15 +1,17 @@
 function t = read_truth_state(truth_path)
 %READ_TRUTH_STATE Returns time vector from STATE_X001.txt
 % Handles lines starting with '#', multiple spaces/tabs, and headers.
+% The second numeric column is treated as time in seconds.
     opts = detectImportOptions(truth_path, 'FileType','text', ...
         'Delimiter', {'\t',' ',';','|',','}, ...
         'CommentStyle','#', 'ConsecutiveDelimitersRule','join');
     T = readtable(truth_path, opts);
-    firstNumCol = find(varfun(@isnumeric,T,'OutputFormat','uniform'), 1, 'first');
-    if isempty(firstNumCol)
-        error('No numeric column in truth file to use as time.');
+    numCols = find(varfun(@isnumeric,T,'OutputFormat','uniform'));
+    if numel(numCols) < 2
+        error('Not enough numeric columns in truth file to extract time.');
     end
-    t = T{:, firstNumCol};
+    % Column 1 is the sample count; column 2 is time in seconds.
+    t = T{:, numCols(2)};
     t = t(~isnan(t));
     t = t(:);
 end

--- a/src/utils/read_truth_state.py
+++ b/src/utils/read_truth_state.py
@@ -18,13 +18,14 @@ def read_truth_state(truth_path: str | Path) -> np.ndarray:
     Returns
     -------
     numpy.ndarray
-        1-D array of time values in seconds.
+        1-D array of time values in seconds from column 1 of the file.
     """
 
     data = read_state_file(truth_path)
     if data.size == 0:
         return np.array([])
-    return np.asarray(data[:, 0]).reshape(-1)
+    # Column 0 holds the sample count while column 1 is time in seconds.
+    return np.asarray(data[:, 1]).reshape(-1)
 
 
 __all__ = ["read_truth_state"]


### PR DESCRIPTION
## Summary
- Correct truth time parsing to read the second column (seconds) in both MATLAB and Python helpers
- Ensure Task_5 loads Task 3 results so per-method Wahba error computation succeeds

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899bc7ff82c8325a91da5546489edfd