### PR TITLE
Add tracing utilities for Python and MATLAB tasks

### DIFF
--- a/MATLAB/src/utils/trace_utils.m
+++ b/MATLAB/src/utils/trace_utils.m
@@ -1,0 +1,56 @@
+function try_task(taskName, taskFunc, varargin)
+%TRY_TASK Execute a task with logging and error capture.
+%   Usage:
+%       try_task('Task3', @Task_3, arg1, arg2)
+
+    log_msg(sprintf('▶ START %s', taskName));
+    try
+        feval(taskFunc, varargin{:});
+        log_msg(sprintf('✓ DONE %s', taskName));
+    catch ME
+        log_msg(sprintf('[ERROR] %s failed: %s', taskName, ME.message));
+        log_msg(getReport(ME, 'extended', 'hyperlinks', 'off'));
+        dump_vars_matlab(sprintf('%s_locals.mat', taskName));
+        % Continue execution
+    end
+end
+
+function dump_vars_matlab(filename)
+%DUMP_VARS_MATLAB Save caller workspace variables for debugging.
+    vars = evalin('caller', 'whos');
+    S = struct();
+    for k = 1:length(vars)
+        try
+            S.(vars(k).name) = evalin('caller', vars(k).name);
+        catch
+            % skip variables that cannot be read
+        end
+    end
+    save(fullfile('MATLAB','results',filename), '-struct', 'S');
+    log_msg(sprintf('[DUMP] Saved variables to %s', filename));
+end
+
+function log_msg(msg)
+%LOG_MSG Write a debug message when DEBUG is enabled.
+    persistent debug_mode log_path
+    if isempty(debug_mode)
+        env = getenv('DEBUG');
+        debug_mode = any(strcmpi(env, {'1','true','yes'}));
+        log_dir = fullfile('MATLAB','results');
+        if exist(log_dir, 'dir') ~= 7
+            mkdir(log_dir);
+        end
+        log_path = fullfile(log_dir, 'debug_log.txt');
+    end
+    if ~debug_mode
+        return
+    end
+    ts = datestr(now, 'yyyy-mm-dd HH:MM:SS');
+    line = sprintf('[%s] %s', ts, msg);
+    fprintf('%s\n', line);
+    fid = fopen(log_path, 'a');
+    if fid ~= -1
+        fprintf(fid, '%s\n', line);
+        fclose(fid);
+    end
+end

--- a/src/utils/trace_utils.py
+++ b/src/utils/trace_utils.py
@@ -1,0 +1,96 @@
+"""Utilities for task-level tracing and debug logging.
+
+This module provides decorators and helpers to wrap task execution with
+logging, variable inspection and error capture.
+
+Usage
+-----
+from utils.trace_utils import trace_task, log, debug_var
+
+Environment
+-----------
+DEBUG environment variable enables logging when set to 1/true/yes.
+All logs and dumps are stored under ``./results``.
+"""
+
+import os
+import sys
+import pickle
+import functools
+import inspect
+import traceback
+import numpy as np
+
+DEBUG = os.environ.get("DEBUG", "0").lower() in ("1", "true", "yes")
+
+LOG_DIR = os.path.join(os.getcwd(), "results")
+os.makedirs(LOG_DIR, exist_ok=True)
+LOG_PATH = os.path.join(LOG_DIR, "debug_log.txt")
+
+def log(msg: str) -> None:
+    """Write a debug message when DEBUG is enabled."""
+    if not DEBUG:
+        return
+    from datetime import datetime
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    line = f"[{ts}] {msg}"
+    print(line)
+    with open(LOG_PATH, "a", encoding="utf-8") as f:
+        f.write(line + "\n")
+
+def debug_var(name: str, val, n: int = 5) -> None:
+    """Log basic information about a variable.
+
+    Parameters
+    ----------
+    name : str
+        Variable name to display in the log.
+    val : Any
+        The variable to inspect.
+    n : int, optional
+        Number of items to preview for arrays or tables, by default 5.
+    """
+    if not DEBUG:
+        return
+    try:
+        import pandas as pd  # lazy import
+        if hasattr(val, "shape"):
+            log(f"{name}: type={type(val).__name__}, shape={val.shape}")
+        elif isinstance(val, (list, tuple, dict)):
+            log(f"{name}: type={type(val).__name__}, len={len(val)}")
+        else:
+            log(f"{name}: type={type(val).__name__}")
+        if isinstance(val, np.ndarray):
+            log(f"  preview: {val[:n]}")
+        elif isinstance(val, pd.DataFrame):
+            log("  preview:\n" + str(val.head(n)))
+    except Exception as e:  # pragma: no cover - debug helper
+        log(f"[WARN] debug_var failed for {name}: {e}")
+
+def dump_vars(filename: str, local_vars: dict) -> None:
+    """Save all non-private locals to NPZ for post-mortem analysis."""
+    try:
+        safe_vars = {k: v for k, v in local_vars.items() if not k.startswith("_")}
+        np.savez(os.path.join(LOG_DIR, filename), **safe_vars)
+        log(f"[DUMP] Saved variables to {filename}")
+    except Exception as e:  # pragma: no cover - debug helper
+        log(f"[ERROR] Failed to dump vars: {e}")
+
+def trace_task(task_name: str):
+    """Decorator for task entry points with error capture and continuation."""
+    def deco(fn):
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            log(f"▶ START {task_name}")
+            try:
+                out = fn(*args, **kwargs)
+                log(f"✓ DONE {task_name}")
+                return out
+            except Exception as e:  # pragma: no cover - debug helper
+                log(f"[ERROR] {task_name} failed: {e}")
+                log(traceback.format_exc())
+                dump_vars(f"{task_name}_locals.npz", locals())
+                # Continue execution by returning None
+                return None
+        return wrapper
+    return deco


### PR DESCRIPTION
## Summary
- add `trace_utils.py` with logging, variable dumps, and error-tolerant task decorator
- add matching `trace_utils.m` implementing `try_task`, variable dumping, and logging

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899c71aba9c8325b8869ad3150bd9ba