### PR TITLE
Add unified debug utilities for MATLAB and Python

### DIFF
--- a/MATLAB/run_triad_only.m
+++ b/MATLAB/run_triad_only.m
@@ -3,24 +3,9 @@ function run_triad_only(cfg)
 %
 % Usage:
 %   run_triad_only();
-%   run_triad_only(struct(''dataset_id'',''X002''));
+%   run_triad_only(struct('dataset_id','X002'));
 
-% ---- paths / utils ----
-% Ensure utils are on the path before calling project_paths
-here = fileparts(mfilename('fullpath'));  % .../MATLAB
-utils_candidates = {
-    fullfile(here,'utils'),
-    fullfile(here,'src','utils'),
-    fullfile(here,'src','utils','attitude'),
-    fullfile(here,'src','utils','frames')
-};
-for i = 1:numel(utils_candidates)
-    p = utils_candidates{i};
-    if exist(p,'dir') && ~contains(path, [p pathsep])
-        addpath(p);
-    end
-end
-addpath(genpath(fullfile(pwd,'MATLAB','src')));  % ensure utils path
+addpath(genpath(fullfile(pwd,'MATLAB','src','utils')));
 set_debug(strcmpi(getenv('DEBUG'),'1') || strcmpi(getenv('DEBUG'),'true'));
 log_msg('[BOOT] run_triad_only.m loaded');
 paths = project_paths();  % adds utils; returns root/matlab/results

--- a/MATLAB/src/utils/dump_structure.m
+++ b/MATLAB/src/utils/dump_structure.m
@@ -1,0 +1,20 @@
+function dump_structure(varName, varValue)
+%DUMP_STRUCTURE Print basic details about a variable.
+
+fprintf('--- Dump of variable: %s ---\n', varName);
+
+if isstruct(varValue)
+    flds = fieldnames(varValue);
+    for k = 1:numel(flds)
+        fldVal = varValue.(flds{k});
+        sz = size(fldVal);
+        fprintf('  %s: %s [%s]\n', ...
+            flds{k}, class(fldVal), num2str(sz));
+    end
+elseif isnumeric(varValue) || islogical(varValue) || ischar(varValue)
+    sz = size(varValue);
+    fprintf('  %s: %s [%s]\n', varName, class(varValue), num2str(sz));
+else
+    disp(varValue);
+end
+end

--- a/MATLAB/src/utils/log_msg.m
+++ b/MATLAB/src/utils/log_msg.m
@@ -1,0 +1,11 @@
+function log_msg(varargin)
+%LOG_MSG Print a formatted debug message when DEBUG is enabled.
+
+DEBUG_FLAG = false;
+if evalin('base','exist(''DEBUG_FLAG'',''var'')')
+    DEBUG_FLAG = evalin('base','DEBUG_FLAG');
+end
+if DEBUG_FLAG
+    fprintf('[DEBUG] %s\n', sprintf(varargin{:}));
+end
+end

--- a/MATLAB/src/utils/set_debug.m
+++ b/MATLAB/src/utils/set_debug.m
@@ -1,0 +1,23 @@
+function set_debug(val)
+%SET_DEBUG Enable or disable debug logging.
+%   SET_DEBUG(true) enables debug messages. SET_DEBUG(false) disables them.
+%   Calling without arguments toggles the current state.
+
+persistent DEBUG_FLAG
+
+if nargin > 0
+    DEBUG_FLAG = logical(val);
+elseif isempty(DEBUG_FLAG)
+    DEBUG_FLAG = false;
+else
+    DEBUG_FLAG = ~DEBUG_FLAG;
+end
+
+assignin('base','DEBUG_FLAG',DEBUG_FLAG);
+
+if DEBUG_FLAG
+    fprintf('[DEBUG] Debug logging enabled\n');
+else
+    fprintf('[DEBUG] Debug logging disabled\n');
+end
+end

--- a/MATLAB/src/utils/try_task.m
+++ b/MATLAB/src/utils/try_task.m
@@ -1,0 +1,17 @@
+function try_task(taskFunc, taskName, varargin)
+%TRY_TASK Execute a task and report errors without stopping execution.
+
+fprintf('\u25B6 Running %s...\n', taskName);
+try
+    feval(taskFunc, varargin{:});
+    fprintf('\u2713 %s completed successfully.\n', taskName);
+catch ME
+    fprintf('\u274C Error in %s: %s\n', taskName, ME.message);
+    if evalin('base','exist(''DEBUG_FLAG'',''var'') && DEBUG_FLAG')
+        fprintf('Stack trace:\n');
+        for s = 1:numel(ME.stack)
+            fprintf('  %s:%d\n', ME.stack(s).file, ME.stack(s).line);
+        end
+    end
+end
+end

--- a/src/run_triad_only.py
+++ b/src/run_triad_only.py
@@ -14,15 +14,28 @@ Usage
 
 from __future__ import annotations
 
+import os
+import sys
+
+sys.path.append(os.path.join(os.getcwd(), "src", "utils"))
+from trace_utils import (
+    set_debug,
+    log_msg,
+    trace_task,
+    dump_structure,
+    save_plot_interactive,
+)
+
+set_debug(os.getenv("DEBUG", "").lower() in ("1", "true"))
+log_msg("run_triad_only.py loaded")
+
 import argparse
 import json
 import logging
 import math
-import os
 import pathlib
 import re
 import subprocess
-import sys
 import time
 import io
 from contextlib import redirect_stdout
@@ -34,13 +47,6 @@ import pandas as pd
 from scipy.spatial.transform import Rotation as R
 import scipy.io as sio
 from tabulate import tabulate
-
-# ensure utils import and debug bootstrap
-sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "utils"))
-from utils.trace_utils import trace_task, dump_structure, save_plot_interactive, log  # noqa
-
-log("[BOOT] run_triad_only.py loaded")
 
 from evaluate_filter_results import run_evaluation_npz
 from run_all_methods import run_case, compute_C_NED_to_ECEF

--- a/src/utils/trace_utils.py
+++ b/src/utils/trace_utils.py
@@ -29,6 +29,23 @@ import numpy as np
 
 DEBUG = os.environ.get("DEBUG", "0").lower() in ("1", "true", "yes")
 
+
+def set_debug(val: bool) -> None:
+    """Enable or disable debug logging."""
+
+    global DEBUG
+    DEBUG = bool(val)
+    state = "enabled" if DEBUG else "disabled"
+    print(f"[DEBUG] Debug logging {state}")
+
+
+def log_msg(msg: str, *args) -> None:
+    """Log a debug message when ``DEBUG`` is active."""
+
+    if DEBUG:
+        text = msg % args if args else msg
+        print(f"[DEBUG] {text}")
+
 LOG_DIR = os.path.join(os.getcwd(), "results")
 os.makedirs(LOG_DIR, exist_ok=True)
 LOG_PATH = os.path.join(LOG_DIR, "debug_log.txt")
@@ -137,6 +154,19 @@ def dump_locals_npz(task_name: str, local_vars: Dict[str, Any]) -> None:
         log(f"[DUMP] {task_name}: saved locals NPZ with {len(safe)} items")
     except Exception as e:  # pragma: no cover - debug helper
         log(f"[ERROR] {task_name}: npz dump failed: {e}")
+
+
+def try_task(func, task_name: str, *args, **kwargs) -> None:
+    """Run ``func`` and report errors without stopping execution."""
+
+    print(f"\u25B6 Running {task_name}...")
+    try:
+        func(*args, **kwargs)
+        print(f"\u2713 {task_name} completed successfully.")
+    except Exception as e:
+        print(f"\u274C Error in {task_name}: {e}")
+        if DEBUG:
+            traceback.print_exc(file=sys.stdout)
 
 
 def trace_task(task_name: str):


### PR DESCRIPTION
## Summary
- Introduce simple `set_debug`, `log_msg`, `dump_structure`, and `try_task` helpers for MATLAB and Python, controlled by the `DEBUG` environment variable
- Wire debug utilities into `run_triad_only` scripts for both languages to auto-enable logging and variable inspection
- Expand Python trace utilities with runtime debug toggling and task wrappers

## Testing
- `pytest tests/test_utils.py -q`
- `pytest tests/test_utils_additional.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6899fd0308548325821603a0a8571b0b