### PR TITLE
feat: robust try_task invocation

### DIFF
--- a/MATLAB/src/utils/try_task.m
+++ b/MATLAB/src/utils/try_task.m
@@ -1,5 +1,19 @@
 function try_task(taskFunc, taskName, varargin)
 %TRY_TASK Execute a task and report errors without stopping execution.
+%   Usage:
+%       try_task(@Task_1, 'Task 1', arg1, arg2, ...)
+%       or
+%       try_task('Task 1', @Task_1, arg1, arg2, ...)
+%   Automatically detects swapped arguments and, when debugging is enabled,
+%   saves the caller workspace to ``<MATLAB/results>/<taskName>_workspace.mat``
+%   upon failure.
+
+% If first two args are swapped
+if isa(taskFunc, 'char') && isa(taskName, 'function_handle')
+    tmp = taskFunc;
+    taskFunc = taskName;
+    taskName = tmp;
+end
 
 fprintf('\u25B6 Running %s...\n', taskName);
 try
@@ -12,6 +26,21 @@ catch ME
         for s = 1:numel(ME.stack)
             fprintf('  %s:%d\n', ME.stack(s).file, ME.stack(s).line);
         end
+
+        % Dump caller workspace for post-mortem analysis
+        vars = evalin('caller', 'whos');
+        snap = struct();
+        for k = 1:numel(vars)
+            name = vars(k).name;
+            try
+                snap.(name) = evalin('caller', name);
+            catch
+            end
+        end
+        outdir = get_matlab_results_dir();
+        outfile = fullfile(outdir, sprintf('%s_workspace.mat', taskName));
+        save(outfile, '-struct', 'snap');
+        fprintf('[DEBUG] Workspace saved to %s\n', outfile);
     end
 end
 end


### PR DESCRIPTION
## Summary
- handle swapped function/name args in `try_task` and dump MATLAB caller workspace on failure
- mirror `try_task` improvements in Python `trace_utils`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a041fa36c8325bd77677fe2e9b822