### PR TITLE
Fix MATLAB Unicode logging

### DIFF
--- a/MATLAB/Task_1.m
+++ b/MATLAB/Task_1.m
@@ -39,7 +39,7 @@ else
     tag = [imu_name '_' gnss_name '_' method];
 end
 
-fprintf('%s %s\n', char(hex2dec('25B6')), tag); % \u25B6 is the triangle symbol
+fprintf('%s %s\n', char(hex2dec('25B6')), tag); % char(0x25B6) is the triangle symbol
 fprintf('Ensured results directory %s exists.\n', results_dir);
 if ~isempty(method)
     fprintf('Running attitude-estimation method: %s\n', method);

--- a/MATLAB/Task_4.m
+++ b/MATLAB/Task_4.m
@@ -311,7 +311,7 @@ end
 
 if ~g_loaded
     % Compute normal gravity at current latitude / height (WGS-84)
-    h_m = 0;   % default height if we can\u2019t read it
+    h_m = 0;   % default height if we can't read it
     if exist('GNSS','var') && istable(GNSS) && any(strcmpi(GNSS.Properties.VariableNames,'Height_deg'))
         h_m = GNSS.Height_deg(1);  % file uses "Height_deg" but values are meters
     elseif exist('gnss_data','var') && istable(gnss_data) && any(strcmpi(gnss_data.Properties.VariableNames,'Height_deg'))

--- a/MATLAB/src/utils/trace_utils.m
+++ b/MATLAB/src/utils/trace_utils.m
@@ -52,10 +52,10 @@ function try_task(taskName, fhandle, varargin)
 
     trace_utils_boot();
     log_msg(repmat('=',1,80));
-    log_msg(sprintf('\u25B6 START %s', taskName));
+    log_msg(sprintf('%s START %s', char(0x25B6), taskName));
     try
         feval(fhandle, varargin{:});
-        log_msg(sprintf('\u2713 DONE %s', taskName));
+        log_msg(sprintf('%s DONE %s', char(0x2713), taskName));
     catch ME
         log_msg(sprintf('[ERROR] %s failed: %s', taskName, ME.message));
         log_msg(getReport(ME, 'extended', 'hyperlinks','off'));

--- a/MATLAB/src/utils/try_task.m
+++ b/MATLAB/src/utils/try_task.m
@@ -15,12 +15,12 @@ if isa(taskFunc, 'char') && isa(taskName, 'function_handle')
     taskName = tmp;
 end
 
-fprintf('\u25B6 Running %s...\n', taskName);
+fprintf('%s Running %s...\n', char(0x25B6), taskName);
 try
     feval(taskFunc, varargin{:});
-    fprintf('\u2713 %s completed successfully.\n', taskName);
+    fprintf('%s %s completed successfully.\n', char(0x2713), taskName);
 catch ME
-    fprintf('\u274C Error in %s: %s\n', taskName, ME.message);
+    fprintf('%s Error in %s: %s\n', char(0x274C), taskName, ME.message);
     if evalin('base','exist(''DEBUG_FLAG'',''var'') && DEBUG_FLAG')
         fprintf('Stack trace:\n');
         for s = 1:numel(ME.stack)


### PR DESCRIPTION
## Summary
- Replace unsupported `\u` escapes in MATLAB debug helpers with explicit `char(0x…)` symbols
- Clean up residual unicode escapes in Task_1 and Task_4 comments

## Testing
- `matlab -batch "addpath('MATLAB'); run_triad_only(); exit"` *(command not found)*
- `PYTHONPATH=src/utils DEBUG=1 python -u src/run_triad_only.py > /tmp/run.log 2>&1` *(shows ▶ IMU_X002_GNSS_X002_TRIAD in log)*


------
https://chatgpt.com/codex/tasks/task_e_689a553cd21083259f640bc5bcb8144b