### PR TITLE
feat: unify task start messages via helper

### DIFF
--- a/MATLAB/Task_1.m
+++ b/MATLAB/Task_1.m
@@ -39,7 +39,7 @@ else
     tag = [imu_name '_' gnss_name '_' method];
 end
 
-fprintf('%s %s\n', char(hex2dec('25B6')), tag); % char(0x25B6) is the triangle symbol
+print_task_start(tag); % char(0x25B6) is the triangle symbol
 fprintf('Ensured results directory %s exists.\n', results_dir);
 if ~isempty(method)
     fprintf('Running attitude-estimation method: %s\n', method);

--- a/MATLAB/run_triad.m
+++ b/MATLAB/run_triad.m
@@ -39,7 +39,7 @@ tasks = { ...
     @( ) Task_5(cfg.imu_path, cfg.gnss_path, cfg.method)  ...
 };
 
-fprintf('%s %s\n', char(hex2dec('25B6')), run_id);
+print_task_start(run_id);
 for k = 1:numel(tasks)
     t0 = tic;
     try

--- a/MATLAB/run_triad_only.m
+++ b/MATLAB/run_triad_only.m
@@ -45,7 +45,7 @@ cfg.truth_path = ensure_input_file('TRUTH', cfg.truth_file, cfg.paths);
 rid = run_id(cfg.imu_path, cfg.gnss_path, cfg.method);
 print_timeline_matlab(rid, cfg.imu_path, cfg.gnss_path, cfg.truth_path, cfg.paths.matlab_results);
 
-fprintf('▶ %s\n', rid);
+print_task_start(rid);
 fprintf('MATLAB results dir: %s\n', cfg.paths.matlab_results);
 
 % ---- Tasks 1..7 (compulsory) ----

--- a/MATLAB/src/utils/print_task_start.m
+++ b/MATLAB/src/utils/print_task_start.m
@@ -1,0 +1,7 @@
+function print_task_start(taskName)
+%PRINT_TASK_START Prints a standard task start message
+%   This function ensures no \u warnings in MATLAB
+%   Usage: print_task_start('Task_1');
+%   taskName - descriptive name of the task being started
+fprintf('%s Running %s...\n', char(0x25B6), taskName);
+end

--- a/MATLAB/src/utils/trace_utils.m
+++ b/MATLAB/src/utils/trace_utils.m
@@ -52,7 +52,10 @@ function try_task(taskName, fhandle, varargin)
 
     trace_utils_boot();
     log_msg(repmat('=',1,80));
-    log_msg(sprintf('%s START %s', char(0x25B6), taskName));
+    if is_debug()
+        print_task_start(taskName);
+    end
+    log_msg(sprintf('START %s', taskName));
     try
         feval(fhandle, varargin{:});
         log_msg(sprintf('%s DONE %s', char(0x2713), taskName));

--- a/MATLAB/src/utils/try_task.m
+++ b/MATLAB/src/utils/try_task.m
@@ -15,7 +15,7 @@ if isa(taskFunc, 'char') && isa(taskName, 'function_handle')
     taskName = tmp;
 end
 
-fprintf('%s Running %s...\n', char(0x25B6), taskName);
+print_task_start(taskName);
 try
     feval(taskFunc, varargin{:});
     fprintf('%s %s completed successfully.\n', char(0x2713), taskName);

--- a/src/run_all_methods.py
+++ b/src/run_all_methods.py
@@ -39,6 +39,7 @@ import io
 from evaluate_filter_results import run_evaluation_npz
 
 from utils import compute_C_ECEF_to_NED
+from utils.print_task_start import print_task_start
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="%(message)s")
@@ -166,7 +167,7 @@ def main(argv=None):
     for (imu, gnss), m in itertools.product(cases, methods):
         tag = f"{pathlib.Path(imu).stem}_{pathlib.Path(gnss).stem}_{m}"
         log_path = pathlib.Path("results") / f"{tag}.log"
-        print(f"\u25b6 {tag}")
+        print_task_start(tag)
         imu_path = pathlib.Path(imu)
         gnss_path = pathlib.Path(gnss)
 

--- a/src/run_triad_only.py
+++ b/src/run_triad_only.py
@@ -28,6 +28,7 @@ from utils.trace_utils import (
     dump_structure,
     save_plot_interactive,
 )
+from utils.print_task_start import print_task_start
 
 set_debug(os.getenv("DEBUG", "").lower() in ("1", "true"))
 log_msg("run_triad_only.py loaded")
@@ -187,7 +188,7 @@ def main(argv: Iterable[str] | None = None) -> None:
 
     run_id = build_run_id(str(imu_path), str(gnss_path), method)
     log_path = results_dir / f"{run_id}.log"
-    print(f"\u25b6 {run_id}")
+    print_task_start(run_id)
 
     truth_path = resolve_truth_path()
 

--- a/src/utils/print_task_start.py
+++ b/src/utils/print_task_start.py
@@ -1,0 +1,4 @@
+def print_task_start(task_name: str):
+    """Print a standard task start message with a ▶ symbol."""
+    print(f"\u25B6 Running {task_name}...")
+

--- a/src/utils/trace_utils.py
+++ b/src/utils/trace_utils.py
@@ -25,6 +25,7 @@ import traceback
 from typing import Any, Dict
 
 import numpy as np
+from utils.print_task_start import print_task_start
 
 
 DEBUG = os.environ.get("DEBUG", "0").lower() in ("1", "true", "yes")
@@ -170,7 +171,7 @@ def try_task(func_or_name, name_or_func: str, *args, **kwargs) -> None:
     if isinstance(func_or_name, str) and callable(name_or_func):
         func, task_name = name_or_func, func_or_name
 
-    print(f"\u25b6 Running {task_name}...")
+    print_task_start(task_name)
     try:
         func(*args, **kwargs)
         print(f"\u2713 {task_name} completed successfully.")
@@ -190,7 +191,9 @@ def trace_task(task_name: str):
         @functools.wraps(fn)
         def wrapper(*args, **kwargs):
             log("=" * 80)
-            log(f"▶ START {task_name}")
+            if DEBUG:
+                print_task_start(task_name)
+            log(f"START {task_name}")
             for i, a in enumerate(args):
                 dump_structure(f"{task_name}.arg{i}", a)
             for k, v in kwargs.items():


### PR DESCRIPTION
## Summary
- add `print_task_start` helper in MATLAB and Python
- replace inline unicode arrows in task runners and utils with helper calls
- ensure debug tracing uses shared helper for consistent output

## Testing
- `octave -qf MATLAB/run_triad_only.m` *(fails: command not found)*
- `matlab -batch "run('MATLAB/run_triad_only.m');"` *(fails: command not found)*
- `PYTHONPATH=src:src/utils timeout 5 python src/run_triad_only.py` *(fails: ModuleNotFoundError: No module named 'timeline')*
- `PYTHONPATH=src python - <<'PY'\nfrom utils.print_task_start import print_task_start\nprint_task_start('Task_1')\nPY`


------
https://chatgpt.com/codex/tasks/task_e_689a5b30f92083259f18e49adc740d44