### PR TITLE
Fix zero_base_time for empty inputs

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -16,6 +16,8 @@ import logging
 def zero_base_time(t):
     """Return time vector shifted to start at zero."""
     t = np.asarray(t, dtype=np.float64)
+    if t.size == 0:
+        return t
     return t - t[0]
 
 

--- a/tests/test_utils_additional.py
+++ b/tests/test_utils_additional.py
@@ -4,6 +4,7 @@ from src.utils import (
     save_static_zupt_params,
     ecef_to_ned,
     compute_C_ECEF_to_NED,
+    zero_base_time,
 )
 
 np = pytest.importorskip("numpy")
@@ -51,3 +52,9 @@ def test_ecef_to_ned_multi_vector():
     C = compute_C_ECEF_to_NED(ref_lat, ref_lon)
     expected = np.array([C @ (p - ref_ecef) for p in pos_ecef])
     assert np.allclose(ned, expected)
+
+
+def test_zero_base_time_empty_and_shift():
+    assert zero_base_time([]).size == 0
+    t = np.array([5.0, 6.5, 7.0])
+    assert np.allclose(zero_base_time(t), t - 5.0)


### PR DESCRIPTION
## Summary
- avoid IndexError when zero_base_time receives an empty array
- add regression test for zero_base_time behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b231e54b88322ad1a0ca826778e2c