### PR TITLE
Clarify static interval detection docstring

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -80,7 +80,11 @@ def ensure_dependencies(requirements: Optional[pathlib.Path] = None) -> None:
 def detect_static_interval(accel_data, gyro_data, window_size=200,
                            accel_var_thresh=0.01, gyro_var_thresh=1e-6,
                            min_length=100):
-    """Find the longest initial static segment using variance thresholding.
+    """Find the longest static segment in the data using variance thresholding.
+
+    The search spans the entire dataset to locate the longest interval
+    where both accelerometer and gyroscope variances remain below the
+    specified thresholds.
 
     Parameters
     ----------


### PR DESCRIPTION
## Summary
- Clarify that `detect_static_interval` searches the entire dataset and returns the longest static segment it finds.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b24fe98588322a557faa8f191dfe3