### PR TITLE
Handle empty input in zero_base_time

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -14,7 +14,10 @@ import logging
 
 
 def zero_base_time(t):
-    """Return time vector shifted to start at zero."""
+    """Return time vector shifted to start at zero.
+
+    If *t* is empty, an empty ``float64`` array is returned.
+    """
     t = np.asarray(t, dtype=np.float64)
     if t.size == 0:
         return t

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from src.utils import compute_C_ECEF_to_NED
+from src.utils import compute_C_ECEF_to_NED, zero_base_time
 
 np = pytest.importorskip("numpy")
 
@@ -11,3 +11,9 @@ def test_rotation_matrix_orthonormal():
     # Orthonormal check
     identity = C @ C.T
     assert np.allclose(identity, np.eye(3), atol=1e-6)
+
+
+def test_zero_base_time():
+    assert zero_base_time([]).size == 0
+    t = np.array([5.0, 6.5, 7.0])
+    assert np.allclose(zero_base_time(t), t - 5.0)


### PR DESCRIPTION
## Summary
- clarify `zero_base_time` behavior for empty inputs
- test `zero_base_time` with empty list and time shift

## Testing
- `pytest tests/test_utils.py::test_zero_base_time`

------
https://chatgpt.com/codex/tasks/task_e_689b24ff64188322bd1520d6446a37f3