### PR TITLE
Ensure body plot files are non-empty

### DIFF
--- a/tests/test_new_plots.py
+++ b/tests/test_new_plots.py
@@ -44,6 +44,10 @@ def test_body_frame_plots(tmp_path, monkeypatch):
     for pattern in expected:
         matches = list(res_dir.glob(pattern))
         assert matches, f"Missing plot {pattern}"
+        for f in matches:
+            assert (
+                f.stat().st_size > 0
+            ), f"Empty plot file {f}"
 
     # cleanup
     for f in res_dir.glob("*.pdf"):


### PR DESCRIPTION
## Summary
- test: verify generated body frame plots are non-empty by checking file sizes

## Testing
- `pytest tests/test_new_plots.py::test_body_frame_plots`

------
https://chatgpt.com/codex/tasks/task_e_689b2501b0dc83228e4a46eddaa8a6f2