### PR TITLE
feat(task1): cache inputs/outputs and add full-earth interactive maps for Python and MATLAB

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,13 @@ run_triad_only(struct('dataset_id','X002','method','TRIAD'));
 % uses DATA/... and writes to MATLAB/results/
 ```
 
+Task 1 outputs are cached for reuse:
+
+- Python Task 1 saves an interactive HTML map under `results/`.
+- MATLAB Task 1 opens a popup and saves a `.fig` under `MATLAB/results/`.
+- Both stacks persist Task 1 inputs/outputs. Reload them via `src/task1_cache.py`
+  (Python) or by loading the `.mat` file (MATLAB).
+
 Notes
 
 - Python saves to `results/` and MATLAB saves to `MATLAB/results/` on purpose.

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ cartopy
 geomaglib>=1.2.1
 pyproj
 fastdtw
+plotly>=5.0

--- a/src/gnss_imu_fusion/init.py
+++ b/src/gnss_imu_fusion/init.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
 
 import numpy as np
 import pandas as pd
@@ -28,6 +28,7 @@ def compute_reference_vectors(
     Optional[np.ndarray],
     np.ndarray,
     np.ndarray,
+    List[str],
 ]:
     """Return latitude/longitude and reference vectors in the NED frame."""
     logging.info("Subtask 1.1: Setting initial latitude and longitude from GNSS ECEF data.")
@@ -76,6 +77,7 @@ def compute_reference_vectors(
         mag_ned,
         initial_vel_ned,
         np.array([x_ecef, y_ecef, z_ecef]),
+        list(gnss_data.columns),
     )
 
 

--- a/src/task1_cache.py
+++ b/src/task1_cache.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable, Tuple, Any
+
+import numpy as np
+
+
+def save_task1_artifacts(out_dir: str | Path, tag: str, meta: Dict[str, Any], arrays: Dict[str, np.ndarray], gnss_columns: Iterable[str]) -> Tuple[Path, Path]:
+    """Save Task 1 arrays to NPZ and metadata to JSON.
+
+    Parameters
+    ----------
+    out_dir : path-like
+        Directory where files will be stored.
+    tag : str
+        Common filename stem (e.g., ``IMU_X001_GNSS_X001_TRIAD``).
+    meta : dict
+        Metadata describing the dataset and method.
+    arrays : dict
+        Numeric arrays to persist.
+    gnss_columns : iterable of str
+        Column names from the GNSS file.
+    Returns
+    -------
+    (npz_path, json_path) : tuple of :class:`Path`
+        Paths of the written NPZ and JSON files.
+    """
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    npz_path = out_dir / f"{tag}_task1_artifacts.npz"
+    json_path = out_dir / f"{tag}_task1_results.json"
+
+    np.savez(npz_path, **arrays)
+    json_out = {"meta": meta, "gnss_columns": list(gnss_columns)}
+    json_path.write_text(json.dumps(json_out, indent=2))
+    print(f"Task 1: saved artifacts -> {npz_path.name}, {json_path.name}")
+    return npz_path, json_path
+
+
+def load_task1_artifacts(npz_path: str | Path) -> Dict[str, Any]:
+    """Load Task 1 arrays and metadata from disk.
+
+    Parameters
+    ----------
+    npz_path : path-like
+        Path to ``*_task1_artifacts.npz`` file.
+
+    Returns
+    -------
+    dict
+        Combined dictionary with arrays, ``gnss_columns`` and ``meta``.
+    """
+    npz_path = Path(npz_path)
+    data = {k: v for k, v in np.load(npz_path, allow_pickle=True).items()}
+    json_path = npz_path.with_name(npz_path.name.replace("_artifacts.npz", "_results.json"))
+    if json_path.exists():
+        meta_json = json.loads(json_path.read_text())
+        data["gnss_columns"] = meta_json.get("gnss_columns", [])
+        data["meta"] = meta_json.get("meta", {})
+    return data
+
+
+__all__ = ["save_task1_artifacts", "load_task1_artifacts"]


### PR DESCRIPTION
## Summary
- cache Task 1 reference data to NPZ/JSON and MATLAB MAT files
- generate world-view interactive maps with Plotly (Python) and geoaxes (MATLAB)
- document Task 1 caching and add plotly dependency

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'task6_overlay_plot')*
- `python src/GNSS_IMU_Fusion.py --imu-file DATA/IMU/IMU_X001_small.dat --gnss-file DATA/GNSS/GNSS_X001_small.csv --method TRIAD`
- `matlab -batch "addpath('MATLAB'); Task_1('DATA/IMU/IMU_X001_small.dat','DATA/GNSS/GNSS_X001_small.csv','TRIAD'); exit"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b4ae6336883229bd983ab4ac76f9d