### PR TITLE
fix(task1): corrected plots as per new requirements

### DIFF
--- a/MATLAB/Task_1.m
+++ b/MATLAB/Task_1.m
@@ -156,16 +156,14 @@ fprintf('Longitude (deg):             %.6f\n', lon_deg);
 fprintf('\nSubtask 1.5: Plotting location on Earth map.\n');
 
 fig = figure('Name','Task 1 – Initial Location (World View)');
-gx = geoaxes(fig); %#ok<LAXES>
-try
-    geobasemap(gx,'landcover');
-catch
-    geobasemap(gx,'none');
-end
-hold(gx,'on');
-geoscatter(gx,lat_deg,lon_deg,40,'filled');
-set(gx,'LatitudeLim',[-90 90],'LongitudeLim',[-180 180]);
-title(gx,'Task 1 – Initial Location (World View)');
+ax = worldmap('World');
+setm(ax,'Origin',[0 0 0]);
+hold on;
+load coastlines;
+plotm(coastlat,coastlon,'k');
+plotm(lat_deg,lon_deg,'r.');
+geolimits([-90 90],[-180 180]);
+title('Task 1 – Initial Location (World View)');
 fig_path = fullfile(results_dir, sprintf('%s_task1_location_map.fig', tag));
 savefig(fig, fig_path);
 

--- a/PYTHON/scripts/run_task1.py
+++ b/PYTHON/scripts/run_task1.py
@@ -1,85 +1,80 @@
+"""Task 1: plot GNSS track on a whole-earth map.
+
+This script loads GNSS latitude/longitude data using ``src.paths`` and
+produces a global map using Cartopy.  The plot is saved both as a PNG image
+and as a pickled Matplotlib figure for interactive reuse.
+"""
+
 from __future__ import annotations
 
 import argparse
+import pickle
 from pathlib import Path
-import numpy as np
+
+import cartopy.crs as ccrs  # type: ignore
 import matplotlib.pyplot as plt
+import pandas as pd
 
-from src.utils.plot_io import save_plot, ensure_output_dirs
-from src.utils.ecef_llh import ecef_to_lla
-from src.utils.io_paths import infer_run_name
-
-
-CITIES = {
-    "Hamburg": (53.5511, 9.9937),
-    "Bremen": (53.0793, 8.8017),
-}
+from src.paths import gnss_path, imu_path, PY_RES_DIR, ensure_py_results
 
 
-def nearest_city(lat: float, lon: float) -> str | None:
-    min_dist = float("inf")
-    nearest = None
-    for name, (clat, clon) in CITIES.items():
-        d = (lat - clat) ** 2 + (lon - clon) ** 2
-        if d < min_dist:
-            min_dist = d
-            nearest = name
-    return nearest
+def run(imu_file: str, gnss_file: str, method: str = "TRIAD") -> None:
+    """Generate a whole-earth location plot for *Task 1*.
 
+    Parameters
+    ----------
+    imu_file : str
+        IMU dataset filename (e.g. ``IMU_X002.dat``).
+    gnss_file : str
+        GNSS dataset filename (e.g. ``GNSS_X002.csv``).
+    method : str, optional
+        Name of the attitude initialisation method, by default ``"TRIAD"``.
+    """
 
-def run(gnss_file: Path, imu_file: Path, run_name: str | None = None) -> None:
-    if run_name is None:
-        run_name = infer_run_name(gnss_file, imu_file)
+    ensure_py_results()
 
-    data = np.genfromtxt(gnss_file, delimiter=",", names=True)
-    x, y, z = data["X_ECEF_m"], data["Y_ECEF_m"], data["Z_ECEF_m"]
-    lat, lon, _ = ecef_to_lla(x, y, z)
+    # Load GNSS coordinates from standard DATA directory
+    gnss = pd.read_csv(gnss_path(gnss_file))
 
-    out_dir = ensure_output_dirs(run_name, "Task_1")
+    # Prepare whole-earth plot
+    fig = plt.figure(figsize=(10, 5))
+    ax = plt.axes(projection=ccrs.PlateCarree())
+    ax.set_global()
+    ax.coastlines()
+    ax.gridlines(draw_labels=True)
+    ax.scatter(
+        gnss["Longitude_deg"],
+        gnss["Latitude_deg"],
+        s=10,
+        c="red",
+        transform=ccrs.PlateCarree(),
+    )
 
-    try:
-        import cartopy.crs as ccrs  # type: ignore
-        proj = ccrs.PlateCarree()
-        fig = plt.figure(figsize=(10, 5))
-        ax = plt.axes(projection=proj)
-        ax.coastlines()
-        ax.gridlines(draw_labels=True)
-        ax.plot(lon, lat, transform=ccrs.Geodetic(), label="GNSS track")
-        ax.legend()
-        ax.plot(lon[0], lat[0], "go", label="start")
-        ax.plot(lon[-1], lat[-1], "ro", label="end")
-        start_city = nearest_city(lat[0], lon[0])
-        end_city = nearest_city(lat[-1], lon[-1])
-        if start_city:
-            ax.annotate(start_city, (lon[0], lat[0]))
-        if end_city:
-            ax.annotate(end_city, (lon[-1], lat[-1]))
-        save_plot(fig, out_dir, "task1_world_track")
-    except Exception:
-        fig, ax = plt.subplots(figsize=(10, 5))
-        ax.set_xlim(-180, 180)
-        ax.set_ylim(-90, 90)
-        ax.set_xlabel("Longitude [deg]")
-        ax.set_ylabel("Latitude [deg]")
-        ax.plot(lon, lat, label="GNSS track")
-        ax.legend()
-        ax.plot(lon[0], lat[0], "go", label="start")
-        ax.plot(lon[-1], lat[-1], "ro", label="end")
-        start_city = nearest_city(lat[0], lon[0])
-        end_city = nearest_city(lat[-1], lon[-1])
-        if start_city:
-            ax.annotate(start_city, (lon[0], lat[0]))
-        if end_city:
-            ax.annotate(end_city, (lon[-1], lat[-1]))
-        save_plot(fig, out_dir, "task1_world_track")
-    finally:
-        plt.close(fig)
+    imu_name = Path(imu_file).stem
+    gnss_name = Path(gnss_file).stem
+    tag = f"{imu_name}_{gnss_name}_{method}_task1_location_map"
+
+    # Save static image
+    png_path = PY_RES_DIR / f"{tag}.png"
+    fig.savefig(png_path, dpi=300)
+
+    # Save interactive figure using pickle
+    pkl_path = PY_RES_DIR / f"{tag}.pickle"
+    with open(pkl_path, "wb") as fh:
+        pickle.dump(fig, fh)
+
+    plt.close(fig)
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Task 1: world map track")
-    parser.add_argument("--gnss", type=Path, required=True, help="Path to GNSS CSV file")
-    parser.add_argument("--imu", type=Path, required=True, help="Path to IMU data file")
-    parser.add_argument("--run", type=str, default=None, help="Run name (e.g., X001)")
+    parser = argparse.ArgumentParser(description="Task 1: whole-earth plot")
+    parser.add_argument("--imu", required=True, help="IMU dataset filename")
+    parser.add_argument("--gnss", required=True, help="GNSS dataset filename")
+    parser.add_argument(
+        "--method",
+        default="TRIAD",
+        help="Attitude initialisation method name",
+    )
     args = parser.parse_args()
-    run(args.gnss, args.imu, args.run)
+    run(args.imu, args.gnss, args.method)
+


### PR DESCRIPTION
## Summary
- Fix MATLAB Task 1 world map plotting using `worldmap` and `geolimits` to avoid latitude limit errors and display the whole Earth.
- Rework Python Task 1 script to load GNSS data via `src.paths`, plot a global map with Cartopy, and save both PNG and pickled figure outputs.

## Testing
- `PYTHONPATH=PYTHON pytest PYTHON/tests/test_no_plots_without_cartopy.py::test_no_plots_without_cartopy -q` *(failed: ImportError: cannot import name 'ensure_results_dir' from 'paths')*
- `PYTHONPATH=PYTHON python PYTHON/scripts/run_task1.py --imu IMU_X002.dat --gnss GNSS_X002.csv --method TRIAD` *(failed: URLError: Tunnel connection failed: 403 Forbidden during cartopy shapefile download)*

------
https://chatgpt.com/codex/tasks/task_e_689b595928b08322b7dd006fe4f3d7b4