### PR TITLE
feat: restore results dir helper

### DIFF
--- a/PYTHON/src/paths.py
+++ b/PYTHON/src/paths.py
@@ -16,5 +16,14 @@ def gnss_path(name: str) -> Path:
 def truth_path(name: str) -> Path:
     return TRUTH_DIR / name
 
-def ensure_py_results() -> None:
+def ensure_results_dir() -> Path:
+    """Ensure the Python results directory exists and return its path."""
     PY_RES_DIR.mkdir(parents=True, exist_ok=True)
+    return PY_RES_DIR
+
+
+# Backwards compatibility helper.  Older code imported ``ensure_py_results``
+# which simply ensured the directory existed without returning it.  Re-export
+# the new helper under that name so existing imports keep working.
+def ensure_py_results() -> Path:  # pragma: no cover - compatibility shim
+    return ensure_results_dir()


### PR DESCRIPTION
## Summary
- add `ensure_results_dir` helper that returns the Python results directory
- keep `ensure_py_results` as backwards compatible alias

## Testing
- `python3 PYTHON/src/run_triad_only.py --no-plots` *(fails: truth_path() missing required positional argument: 'name')*

------
https://chatgpt.com/codex/tasks/task_e_689b64dcb2788322ad073f31e5a865ab