### PR TITLE
Fix run_id import in run_triad_only

### DIFF
--- a/PYTHON/src/run_triad_only.py
+++ b/PYTHON/src/run_triad_only.py
@@ -51,7 +51,7 @@ from utils import save_mat
 # Import helper utilities from the utils package
 from utils.timeline import print_timeline
 from utils.resolve_truth_path import resolve_truth_path
-from run_id import run_id as build_run_id
+from utils.run_id import run_id as build_run_id
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "tools"))
 


### PR DESCRIPTION
## Summary
- Fix import path for `run_id` in `run_triad_only.py` to use utilities module

## Testing
- `python PYTHON/src/run_triad_only.py --help`
- `pytest PYTHON/tests/test_assemble_frames.py -q` *(fails: ModuleNotFoundError: No module named 'src')*
- `pip install -e .[tests]` *(fails: Multiple top-level packages discovered in a flat-layout)*

------
https://chatgpt.com/codex/tasks/task_e_689b7a13655883229f1156ce51cd7fc9