### PR TITLE
Include Python utils directory in MATLAB paths

### DIFF
--- a/MATLAB/src/utils/project_paths.m
+++ b/MATLAB/src/utils/project_paths.m
@@ -31,6 +31,7 @@ utils_candidates = {
     fullfile(paths.matlab, 'src', 'utils')
     fullfile(paths.root, 'MATLAB', 'utils')
     fullfile(paths.root, 'src', 'utils')
+    fullfile(paths.root, 'PYTHON', 'src', 'utils')
 };
 
 found_any = false;

--- a/MATLAB/task5_plot_comparison.m
+++ b/MATLAB/task5_plot_comparison.m
@@ -13,8 +13,8 @@ function task5_plot_comparison(run_id)
 %
 %   See also: plot_frame_comparison, Task_5
 
-% add utils folder to path
-addpath(fullfile(fileparts(fileparts(mfilename('fullpath'))),'src','utils'));
+% Ensure repository paths are initialized so utility functions can be found
+project_paths();
 
     if nargin < 1 || isempty(run_id)
         error('task5_plot_comparison:MissingRunID', 'RUN_ID is required');

--- a/MATLAB/utils/project_paths.m
+++ b/MATLAB/utils/project_paths.m
@@ -25,6 +25,7 @@ utils_candidates = {
     fullfile(paths.matlab,'src','utils')
     fullfile(paths.root,'MATLAB','utils')
     fullfile(paths.root,'src','utils')
+    fullfile(paths.root,'PYTHON','src','utils')
 };
 
 found_any = false;


### PR DESCRIPTION
## Summary
- Include `PYTHON/src/utils` in MATLAB `project_paths` helper
- Initialize paths via `project_paths()` in `task5_plot_comparison`

## Testing
- `octave -q --eval "addpath('MATLAB/utils'); project_paths(); which('plot_frame_comparison')"`
- `make test` *(fails: Multiple top-level packages discovered in a flat-layout)*

------
https://chatgpt.com/codex/tasks/task_e_689b8c312d388322bbf42fc10ae7654e