### PR TITLE
refactor: coerce truth columns by name

### DIFF
--- a/MATLAB/load_truth_file.m
+++ b/MATLAB/load_truth_file.m
@@ -28,14 +28,15 @@ function T = load_truth_file(truth_path)
     end
 
     % Coerce non-numeric columns to numeric when possible
-    for i = 1:width(T)
-        if ~isnumeric(T{:,i})
-            T{:,i} = str2double(string(T{:,i}));
+    vn = T.Properties.VariableNames;
+    for i = 1:numel(vn)
+        col = T.(vn{i});
+        if iscell(col) || isstring(col)
+            T.(vn{i}) = str2double(string(col));
         end
     end
     % Build time vector starting at zero
     time_col = [];
-    vn = T.Properties.VariableNames;
     if any(strcmpi(vn,'Posix_Time'))
         t = T{:,strcmpi(vn,'Posix_Time')};
     elseif any(strcmpi(vn,'time'))


### PR DESCRIPTION
## Summary
- ensure `load_truth_file` coerces string columns using variable names and dot indexing

## Testing
- `octave -qf --eval "addpath('MATLAB'); T = load_truth_file('DATA/Truth/STATE_X001.txt');"` *(fails: 'delimitedTextImportOptions' undefined)*

------
https://chatgpt.com/codex/tasks/task_e_689b8c345b188322828654945ea08dc1