### PR TITLE
Handle string paths for Task 5

### DIFF
--- a/MATLAB/Task_5.m
+++ b/MATLAB/Task_5.m
@@ -52,6 +52,18 @@ end
         method = 'TRIAD';
     end
 
+    % Allow string or char inputs for file paths and convert to char
+    pin = inputParser;
+    addRequired(pin, 'imu_path', @(x) isstring(x) || ischar(x));
+    addRequired(pin, 'gnss_path', @(x) isstring(x) || ischar(x));
+    addRequired(pin, 'method',    @(x) isstring(x) || ischar(x));
+    addOptional(pin, 'gnss_pos_ned', [], @(x) isempty(x) || isnumeric(x));
+    parse(pin, imu_path, gnss_path, method, gnss_pos_ned);
+    imu_path    = char(pin.Results.imu_path);
+    gnss_path   = char(pin.Results.gnss_path);
+    method      = char(pin.Results.method);
+    gnss_pos_ned = pin.Results.gnss_pos_ned;
+
     % Optional noise parameters
     p = inputParser;
     addParameter(p, 'accel_noise', 0.1);       % [m/s^2]

--- a/MATLAB/task5_autotune.m
+++ b/MATLAB/task5_autotune.m
@@ -10,6 +10,10 @@ function [best_q, best_r, report] = task5_autotune(imu_path, gnss_path, method, 
     if nargin < 4 || isempty(grid_q), grid_q = [5, 10, 20, 40]; end
     if nargin < 5 || isempty(grid_r), grid_r = [0.25, 0.5, 1.0]; end
 
+    % Ensure paths are strings for Task_5 compatibility
+    imu_path = string(imu_path);
+    gnss_path = string(gnss_path);
+
     results = [];
     k = 1;
     best_rmse = inf; best_q = grid_q(1); best_r = grid_r(1);


### PR DESCRIPTION
## Summary
- Ensure `task5_autotune` converts IMU and GNSS file paths to strings before calling `Task_5`.
- Update `Task_5` to accept string or char file paths via `inputParser` and internally convert to char arrays.

## Testing
- `make test` *(fails: Multiple top-level packages discovered in a flat-layout)*

------
https://chatgpt.com/codex/tasks/task_e_689b99bea5648322976e7b0a9f87edf2