### PR TITLE
Limit Task 5 processing to available IMU samples

### DIFF
--- a/MATLAB/Task_5.m
+++ b/MATLAB/Task_5.m
@@ -385,17 +385,19 @@ prev_a_ned = zeros(3,1);
 prev_vel = x(4:6);
 
 % --- Pre-allocate Log Arrays ---
-num_steps = size(acc_body_raw, 1);
+total_samples = size(acc_body_raw, 1);
 if isfinite(max_steps)
-    num_steps = min(num_steps, max_steps);
+    steps = min(total_samples, max_steps);
+else
+    steps = total_samples;
 end
-x_log = zeros(15, num_steps);
+x_log = zeros(15, steps);
 fprintf('Task 5: x_log initialized with size %dx%d\n', size(x_log));
-euler_log = zeros(3, num_steps);
-zupt_log = zeros(1, num_steps);
-zupt_vel_norm = nan(1, num_steps); % velocity norm after each ZUPT
-acc_log = zeros(3, num_steps); % Acceleration from propagated IMU data
-num_imu_samples = num_steps;
+euler_log = zeros(3, steps);
+zupt_log = zeros(1, steps);
+zupt_vel_norm = nan(1, steps); % velocity norm after each ZUPT
+acc_log = zeros(3, steps); % Acceleration from propagated IMU data
+num_imu_samples = steps;
 zupt_count = 0;
 zupt_fail_count = 0;            % count ZUPT events not clamped to zero
 vel_blow_count = 0;             % track number of velocity blow-ups

--- a/MATLAB/Task_5_try_once.m
+++ b/MATLAB/Task_5_try_once.m
@@ -7,10 +7,13 @@ function rmse_pos = Task_5_try_once(cfg, vel_q_scale, vel_r)
     if nargin < 3, error('Task_5_try_once:args','cfg, vel_q_scale, vel_r required'); end
     % Use at most first 200k IMU steps for speed during tuning
     max_steps = 200000;
+    % Determine total IMU samples to avoid requesting more steps than exist
+    total_samples = size(readmatrix(cfg.imu_path), 1);
+    steps = min(max_steps, total_samples);
     try
         res = Task_5(cfg.imu_path, cfg.gnss_path, cfg.method, [], ...
             'vel_q_scale', vel_q_scale, 'vel_r', vel_r, ...
-            'trace_first_n', 0, 'max_steps', max_steps, 'dryrun', true);
+            'trace_first_n', 0, 'max_steps', steps, 'dryrun', true);
         if isstruct(res) && isfield(res,'rmse_pos')
             rmse_pos = res.rmse_pos;
         else


### PR DESCRIPTION
## Summary
- Compute available IMU sample count before running `Task_5` and pass a clamped `max_steps`
- Preallocate state history logs in `Task_5` using the same `steps` value to avoid size mismatches

## Testing
- `pytest -q` *(fails: ImportError: attempted relative import with no known parent package)*


------
https://chatgpt.com/codex/tasks/task_e_689b99ca1b8c832280e37c37243f39d3