### PR TITLE
feat: add verbose autotune summary

### DIFF
--- a/MATLAB/task5_autotune.m
+++ b/MATLAB/task5_autotune.m
@@ -1,4 +1,4 @@
-function [best_q, best_r, report] = task5_autotune(imu_path, gnss_path, method, grid_q, grid_r)
+function [best_q, best_r, report] = task5_autotune(imu_path, gnss_path, method, grid_q, grid_r, verbose)
 %TASK5_AUTOTUNE Grid-search vel_q_scale and vel_r to minimise RMSE_pos.
 %   [BEST_Q, BEST_R, REPORT] = TASK5_AUTOTUNE(IMU_PATH, GNSS_PATH, METHOD,
 %   GRID_Q, GRID_R) runs Task_5 over the Cartesian product of GRID_Q and
@@ -9,6 +9,7 @@ function [best_q, best_r, report] = task5_autotune(imu_path, gnss_path, method, 
 
     if nargin < 4 || isempty(grid_q), grid_q = [5, 10, 20, 40]; end
     if nargin < 5 || isempty(grid_r), grid_r = [0.25, 0.5, 1.0]; end
+    if nargin < 6 || isempty(verbose), verbose = false; end
 
     results = [];
     k = 1;
@@ -17,7 +18,9 @@ function [best_q, best_r, report] = task5_autotune(imu_path, gnss_path, method, 
     max_steps = 120000;  % ~5 minutes of IMU at 400 Hz
     for q = grid_q
         for r = grid_r
-            fprintf('[Autotune] Trying vel_q_scale=%.3f  vel_r=%.3f ...\n', q, r);
+            if verbose
+                fprintf('[Autotune] Trying vel_q_scale=%.3f  vel_r=%.3f ...\n', q, r);
+            end
             try
                 res = Task_5(imu_path, gnss_path, method, [], 'vel_q_scale', q, 'vel_r', r, 'trace_first_n', 0, 'max_steps', max_steps);
                 rmse = res.rmse_pos;
@@ -40,4 +43,6 @@ function [best_q, best_r, report] = task5_autotune(imu_path, gnss_path, method, 
     report = struct('table', T, 'best_rmse', best_rmse, ...
         'best_rmse_q', best_q, 'best_rmse_r', best_r);
     disp(T);
+    fprintf('[Autotune] Best vel_q_scale=%.3f  vel_r=%.3f  RMSE=%.3f\n', ...
+        best_q, best_r, best_rmse);
 end


### PR DESCRIPTION
## Summary
- add `verbose` parameter to task5_autotune to control logging
- print only final table and best q/r unless verbose is true
- report best tuning results with a single summary message

## Testing
- `make test` *(fails: Multiple top-level packages discovered in a flat-layout)*

------
https://chatgpt.com/codex/tasks/task_e_689b99cce5188322b610f6bb0b81a1fe