### PR TITLE
feat: add MATLAB figure saving

### DIFF
--- a/MATLAB/save_plot.m
+++ b/MATLAB/save_plot.m
@@ -1,13 +1,19 @@
-function save_plot(fig, imu_name, gnss_name, method, task)
-%SAVE_PLOT Save figure as PDF and PNG in the results directory.
-%   SAVE_PLOT(FIG, IMU_NAME, GNSS_NAME, METHOD, TASK) writes FIG to the
-%   repository 'results' folder using the naming convention:
-%   IMU_NAME_GNSS_NAME_METHOD_taskTASK_results.pdf and .png.
-%   This mirrors the Python pipeline output structure.
+function save_plot(fig, imu_name, gnss_name, method, task, save_pdf, save_png)
+%SAVE_PLOT  Save figure in the results directory.
+%   SAVE_PLOT(FIG, IMU_NAME, GNSS_NAME, METHOD, TASK, SAVE_PDF, SAVE_PNG)
+%   writes FIG to the repository 'results' folder using the naming
+%   convention IMU_NAME_GNSS_NAME_METHOD_taskTASK_results.*.  When both
+%   SAVE_PDF and SAVE_PNG are false, the figure is saved using
+%   :func:`save_plot_fig` instead.
+%
+%   SAVE_PDF and SAVE_PNG are optional and default to true.
 %
 %   Example:
 %       save_plot(fig, 'IMU_X002', 'GNSS_X002', 'TRIAD', 5)
-%   saves results/IMU_X002_GNSS_X002_TRIAD_task5_results.pdf.
+%   saves results/IMU_X002_GNSS_X002_TRIAD_task5_results.pdf and .png.
+
+    if nargin < 6 || isempty(save_pdf); save_pdf = true; end
+    if nargin < 7 || isempty(save_png); save_png = true; end
 
     results_dir = get_results_dir();
     if ~exist(results_dir, 'dir')
@@ -16,9 +22,30 @@ function save_plot(fig, imu_name, gnss_name, method, task)
     base = sprintf('%s_%s_%s_task%d_results', imu_name, gnss_name, method, task);
     pdf_path = fullfile(results_dir, [base '.pdf']);
     png_path = fullfile(results_dir, [base '.png']);
+    fig_path = fullfile(results_dir, [base '.fig']);
 
     set(fig, 'PaperPosition', [0 0 8 6]);
-    print(fig, pdf_path, '-dpdf', '-bestfit');
-    exportgraphics(fig, png_path, 'Resolution', 300);
-    fprintf('Saved plot to %s and %s\n', pdf_path, png_path);
+
+    did_save = false;
+    if save_pdf
+        print(fig, pdf_path, '-dpdf', '-bestfit');
+        did_save = true;
+    end
+    if save_png
+        exportgraphics(fig, png_path, 'Resolution', 300);
+        did_save = true;
+    end
+
+    if ~did_save
+        save_plot_fig(fig, fig_path);
+        fprintf('Saved plot to %s\n', fig_path);
+    else
+        if save_pdf && save_png
+            fprintf('Saved plot to %s and %s\n', pdf_path, png_path);
+        elseif save_pdf
+            fprintf('Saved plot to %s\n', pdf_path);
+        else
+            fprintf('Saved plot to %s\n', png_path);
+        end
+    end
 end

--- a/MATLAB/save_plot_fig.m
+++ b/MATLAB/save_plot_fig.m
@@ -1,5 +1,15 @@
-function save_plot_fig(~, ~)
-%SAVE_PLOT_FIG  Placeholder for saving plots in MATLAB .fig format.
-%   Mirrors the Python ``save_plot_fig`` helper but is not implemented yet.
-error('save_plot_fig not yet implemented');
+function save_plot_fig(fig, filename)
+%SAVE_PLOT_FIG  Save figure in MATLAB ``.fig`` format.
+%   SAVE_PLOT_FIG(FIG, FILENAME) writes the given figure to *FILENAME*
+%   using MATLAB's :func:`savefig` so it can be reopened later.  This
+%   mirrors the Python ``save_plot_fig`` helper.
+
+    if nargin < 1 || isempty(fig)
+        fig = gcf; %#ok<GFLD> default to current figure if none provided
+    end
+    if nargin < 2 || isempty(filename)
+        error('A filename must be provided');
+    end
+
+    savefig(fig, filename);
 end


### PR DESCRIPTION
## Summary
- implement MATLAB `save_plot_fig` using MATLAB's `savefig`
- extend `save_plot` to support optional PDF/PNG saving and fallback to `.fig`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_689b9acefe9c8322a5c40e64e3ae634b