### PR TITLE
Disable PDF/PNG plot saving by default

### DIFF
--- a/MATLAB/Task_5.m
+++ b/MATLAB/Task_5.m
@@ -697,7 +697,8 @@ if ~isempty(zupt_indices)
     xlabel('Time (s)'); ylabel('|v| after ZUPT [m/s]');
     title('Velocity magnitude following each ZUPT');
     legend('|v|');
-    save_plot(fig_zupt, imu_name, gnss_name, [method '_ZUPT'], 5);
+    save_plot(fig_zupt, imu_name, gnss_name, [method '_ZUPT'], 5, ...
+              cfg.plots.save_pdf, cfg.plots.save_png);
 end
 
 plot_task5_mixed_frame(imu_time, x_log(1:3,:), x_log(4:6,:), ...

--- a/MATLAB/run_triad_all.m
+++ b/MATLAB/run_triad_all.m
@@ -26,7 +26,7 @@ for i = 1:numel(datasets)
     cfg.imu_file = ds.imu;
     cfg.gnss_file = ds.gnss;
     cfg.truth_file = truth_file;
-    cfg.plots = struct('popup_figures', false, 'save_pdf', true, 'save_png', true);
+    cfg.plots = struct('popup_figures', false, 'save_pdf', false, 'save_png', false);
 
     fprintf('\n[TRIAD] ===== Dataset %s =====\n', ds.id);
     tStart = tic();

--- a/MATLAB/run_triad_batch.m
+++ b/MATLAB/run_triad_batch.m
@@ -12,7 +12,7 @@ cfg.method = 'TRIAD';
 cfg.imu_file = 'IMU_X002.dat';
 cfg.gnss_file = 'GNSS_X002.csv';
 cfg.truth_file = 'STATE_X001.txt';
-cfg.plots = struct('popup_figures', false, 'save_pdf', true, 'save_png', true);
+cfg.plots = struct('popup_figures', false, 'save_pdf', false, 'save_png', false);
 
 try
     tStart = tic();

--- a/MATLAB/run_triad_only.m
+++ b/MATLAB/run_triad_only.m
@@ -35,8 +35,8 @@ if ~isfield(cfg,'plots') || ~isstruct(cfg.plots)
     cfg.plots = struct();
 end
 if ~isfield(cfg.plots,'popup_figures'), cfg.plots.popup_figures = true; end
-if ~isfield(cfg.plots,'save_pdf'),      cfg.plots.save_pdf      = true;  end
-if ~isfield(cfg.plots,'save_png'),      cfg.plots.save_png      = true;  end
+if ~isfield(cfg.plots,'save_pdf'),      cfg.plots.save_pdf      = false; end
+if ~isfield(cfg.plots,'save_png'),      cfg.plots.save_png      = false; end
 % KF tuning defaults (safe if default_cfg not reloaded)
 if ~isfield(cfg,'vel_q_scale'), cfg.vel_q_scale = 10.0; end
 if ~isfield(cfg,'vel_r'),       cfg.vel_r       = 0.25; end

--- a/MATLAB/save_plot.m
+++ b/MATLAB/save_plot.m
@@ -6,14 +6,14 @@ function save_plot(fig, imu_name, gnss_name, method, task, save_pdf, save_png)
 %   SAVE_PDF and SAVE_PNG are false, the figure is saved using
 %   :func:`save_plot_fig` instead.
 %
-%   SAVE_PDF and SAVE_PNG are optional and default to true.
+%   SAVE_PDF and SAVE_PNG are optional and default to false.
 %
 %   Example:
 %       save_plot(fig, 'IMU_X002', 'GNSS_X002', 'TRIAD', 5)
 %   saves results/IMU_X002_GNSS_X002_TRIAD_task5_results.pdf and .png.
 
-    if nargin < 6 || isempty(save_pdf); save_pdf = true; end
-    if nargin < 7 || isempty(save_png); save_png = true; end
+    if nargin < 6 || isempty(save_pdf); save_pdf = false; end
+    if nargin < 7 || isempty(save_png); save_png = false; end
 
     results_dir = get_results_dir();
     if ~exist(results_dir, 'dir')

--- a/MATLAB/src/utils/default_cfg.m
+++ b/MATLAB/src/utils/default_cfg.m
@@ -9,8 +9,8 @@ cfg.truth_file = '';
 
 cfg.plots = struct();
 cfg.plots.popup_figures = true;      % pop up figures by default
-cfg.plots.save_pdf      = true;      % save as PDF
-cfg.plots.save_png      = true;      % save as PNG
+cfg.plots.save_pdf      = false;     % save as PDF
+cfg.plots.save_png      = false;     % save as PNG
 
 cfg.strict = true;   % tasks should error on missing inputs
 

--- a/MATLAB/task4_gnss_imu_integration.m
+++ b/MATLAB/task4_gnss_imu_integration.m
@@ -1,4 +1,4 @@
-function task4_gnss_imu_integration(gnss_data, imu_data, task1_results, task2_results, task3_results, results_dir, dt)
+function task4_gnss_imu_integration(gnss_data, imu_data, task1_results, task2_results, task3_results, results_dir, dt, cfg)
 %TASK4_GNSS_IMU_INTEGRATION  Integrate IMU data and compare with GNSS.
 %   TASK4_GNSS_IMU_INTEGRATION(GNSS_DATA, IMU_DATA, TASK1_RESULTS,
 %   TASK2_RESULTS, TASK3_RESULTS, RESULTS_DIR, DT) performs the Task 4
@@ -21,8 +21,16 @@ function task4_gnss_imu_integration(gnss_data, imu_data, task1_results, task2_re
 %                                  'Task2_IMU_biases.mat', 'Task3_results_IMU_X002_GNSS_X002.mat', ...
 %                                  get_results_dir(), 0.0025);
 
+addpath(fullfile(fileparts(mfilename('fullpath')), 'src', 'utils'));
 if nargin < 7 || isempty(dt)
     dt = 0.0025; % default sample period
+end
+if nargin < 8 || isempty(cfg)
+    try
+        cfg = evalin('caller','cfg');
+    catch
+        cfg = default_cfg();
+    end
 end
 
 %% Load previous task outputs
@@ -84,7 +92,7 @@ for i=1:3
     grid on; xlabel('Sample'); ylabel('m');
     if i==1, title('North Position'); elseif i==2, title('East Position'); else, title('Down Position'); end
 end
-save_plot(fig, 'IMU', 'GNSS', 'TRIAD', 4);
+save_plot(fig, 'IMU', 'GNSS', 'TRIAD', 4, cfg.plots.save_pdf, cfg.plots.save_png);
 
 %% Save results
 out_file = fullfile(results_dir,'Task4_results_IMU_GNSS.mat');


### PR DESCRIPTION
## Summary
- stop saving PDF/PNG plots by default in `run_triad_only` and default config
- propagate plotting flags through Task 5 and helper utilities
- allow `task4_gnss_imu_integration` to respect plot flags and update batch scripts

## Testing
- `pytest PYTHON/tests/test_compute_biases.py -q` *(fails: ModuleNotFoundError: No module named 'src')*


------
https://chatgpt.com/codex/tasks/task_e_689b9d2f9bec83229848d0243ac4dce2