### PR TITLE
Add diagnostic MATLAB plot saving and optional exports

### DIFF
--- a/MATLAB/Task_2.m
+++ b/MATLAB/Task_2.m
@@ -151,12 +151,14 @@ function body_data = Task_2(imu_path, gnss_path, method)
     base = sprintf('%s_%s_%s_task2_static', imu_id, gnss_id, method_tag);
     fig_path = fullfile(results_dir, [base '.fig']);
     save_plot_fig(fig_static, fig_path);
-    if isfield(cfg.plots,'save_pdf') && cfg.plots.save_pdf
+    save_pdf = isfield(cfg,'plots') && isfield(cfg.plots,'save_pdf') && cfg.plots.save_pdf;
+    save_png = isfield(cfg,'plots') && isfield(cfg.plots,'save_png') && cfg.plots.save_png;
+    if save_pdf
         pdf_path = fullfile(results_dir, [base '.pdf']);
         set(fig_static, 'PaperPosition', [0 0 8 6]);
         print(fig_static, pdf_path, '-dpdf', '-bestfit');
     end
-    if isfield(cfg.plots,'save_png') && cfg.plots.save_png
+    if save_png
         png_path = fullfile(results_dir, [base '.png']);
         exportgraphics(fig_static, png_path, 'Resolution', 300);
     end

--- a/MATLAB/Task_3.m
+++ b/MATLAB/Task_3.m
@@ -92,12 +92,14 @@ title('Attitude difference vs TRIAD');
 base = sprintf('%s_%s_%s_task3_attitude', imu_id, gnss_id, method);
 fig_path = fullfile(results_dir, [base '.fig']);
 save_plot_fig(fig_cmp, fig_path);
-if isfield(cfg.plots,'save_pdf') && cfg.plots.save_pdf
+save_pdf = isfield(cfg,'plots') && isfield(cfg.plots,'save_pdf') && cfg.plots.save_pdf;
+save_png = isfield(cfg,'plots') && isfield(cfg.plots,'save_png') && cfg.plots.save_png;
+if save_pdf
     pdf_path = fullfile(results_dir, [base '.pdf']);
     set(fig_cmp, 'PaperPosition', [0 0 8 6]);
     print(fig_cmp, pdf_path, '-dpdf', '-bestfit');
 end
-if isfield(cfg.plots,'save_png') && cfg.plots.save_png
+if save_png
     png_path = fullfile(results_dir, [base '.png']);
     exportgraphics(fig_cmp, png_path, 'Resolution', 300);
 end

--- a/MATLAB/save_plot_fig.m
+++ b/MATLAB/save_plot_fig.m
@@ -1,3 +1,22 @@
 function save_plot_fig(fig, filename)
+%SAVE_PLOT_FIG  Save a MATLAB figure to .fig ensuring parent directory exists.
+%   SAVE_PLOT_FIG(FIG, FILENAME) writes the figure handle FIG to the
+%   specified FILENAME using MATLAB's ``savefig``.  If the directory of
+%   FILENAME does not exist it is created automatically.  The caller is
+%   responsible for providing the full path including ``.fig`` extension.
 
+    if nargin < 2 || isempty(filename)
+        results_dir = get_results_dir();
+        if ~exist(results_dir, 'dir')
+            mkdir(results_dir);
+        end
+        filename = fullfile(results_dir, 'figure.fig');
+    else
+        [out_dir, ~, ~] = fileparts(filename);
+        if ~isempty(out_dir) && ~exist(out_dir, 'dir')
+            mkdir(out_dir);
+        end
+    end
+
+    savefig(fig, filename);
 end


### PR DESCRIPTION
## Summary
- Implement `save_plot_fig` helper to persist figures and ensure directories exist
- Add optional PDF/PNG export logic in Task 2 and Task 3 using configuration flags
- Save static interval and attitude comparison diagnostic figures for easier debugging

## Testing
- `PYTHONPATH=PYTHON pytest PYTHON/tests/test_validate_3sigma.py -q` *(fails: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_689b9de3d7a48322aca74905d958f672