### PR TITLE
Add dryrun flag to silence Task_5 output

### DIFF
--- a/MATLAB/Task_5.m
+++ b/MATLAB/Task_5.m
@@ -19,6 +19,7 @@ function result = Task_5(imu_path, gnss_path, method, gnss_pos_ned, varargin)
 %       'vel_q_scale'      - scale for Q(4:6,4:6) velocity process noise [-]      (10.0)
 %       'vel_r'            - R(4:6,4:6) velocity measurement variance   [m^2/s^2] (0.25)
 %       'scale_factor'     - accelerometer scale factor                 [-]      (required)
+%       'dryrun'           - skip plots and console output              [flag]   (false)
 
 addpath(fullfile(fileparts(mfilename('fullpath')), 'src', 'utils'));
 
@@ -78,7 +79,7 @@ end
     addParameter(p, 'trace_first_n', 0);       % [steps] capture first N KF steps
     addParameter(p, 'max_steps', inf);         % [steps] limit processing for tuning
     addParameter(p, 'scale_factor', []);       % [-]
-    addParameter(p, 'dryrun', false);          % [flag] skip plots when tuning
+    addParameter(p, 'dryrun', false);          % [flag] skip plots and console output when tuning
     parse(p, varargin{:});
     accel_noise     = p.Results.accel_noise;
     vel_proc_noise  = p.Results.vel_proc_noise;
@@ -93,6 +94,12 @@ end
     max_steps       = p.Results.max_steps;
     scale_factor    = p.Results.scale_factor;
     dryrun          = p.Results.dryrun;
+
+    if dryrun
+        logf = @(varargin) [];
+    else
+        logf = @fprintf;
+    end
 
 
     if ~isfile(gnss_path)
@@ -116,8 +123,8 @@ end
     else
         log_tag = [' (' method ')'];
     end
-    fprintf('\nTask 5: Sensor Fusion with Kalman Filter\n');
-    fprintf('Subtask 5.1: Configuring logging.\n');
+    logf('\nTask 5: Sensor Fusion with Kalman Filter\n');
+    logf('Subtask 5.1: Configuring logging.\n');
 
     % Load attitude estimate from Task 3 results
     results_file = fullfile(results_dir, sprintf('Task3_results_%s.mat', pair_tag));
@@ -139,7 +146,7 @@ end
         assignin('base','C_B_N_ref', C_B_N);
     end
 
-    fprintf('Subtask 5.3: Loading GNSS and IMU data.\n');
+    logf('Subtask 5.3: Loading GNSS and IMU data.\n');
     % Load GNSS data to obtain time and velocity
     gnss_tbl = readtable(gnss_path);
     gnss_time = zero_base_time(gnss_tbl.Posix_Time);
@@ -251,11 +258,11 @@ end
         C_n_b = C_B_N';
         g_ned_bias = [0; 0; 9.794];
         accel_bias = mean_acc_body + C_n_b * g_ned_bias;
-        fprintf('Computed accel bias in Task 5: [%f, %f, %f]\n', accel_bias);
+        logf('Computed accel bias in Task 5: [%f, %f, %f]\n', accel_bias);
     catch
         warning('Task 5: accel bias recomputation failed; using Task 2 bias');
     end
-    fprintf('Method %s: Scale factor: %.4f\n', method, scale_factor);
+    logf('Method %s: Scale factor: %.4f\n', method, scale_factor);
 
     % Apply bias correction to IMU data
     gyro_body_raw = gyro_body_raw - gyro_bias';
@@ -266,7 +273,7 @@ end
 %% ========================================================================
 % Subtask 5.1-5.5: Configure and Initialize 15-State Filter
 % =========================================================================
-fprintf('\nSubtask 5.1-5.5: Configuring and Initializing 15-State Kalman Filter.\n');
+logf('\nSubtask 5.1-5.5: Configuring and Initializing 15-State Kalman Filter.\n');
 results4 = fullfile(results_dir, sprintf('Task4_results_%s.mat', pair_tag));
 if nargin < 4 || isempty(gnss_pos_ned)
     if evalin('base','exist(''task4_results'',''var'')')
@@ -308,7 +315,7 @@ catch
     R = zeros(6);
     R(1:3,1:3) = eye(3) * pos_meas_noise^2;
     R(4:6,4:6) = eye(3) * 0.25;
-    fprintf('Auto-tune failed; using default Q/R\n');
+    logf('Auto-tune failed; using default Q/R\n');
 end
 H = [eye(6), zeros(6,9)];
 
@@ -350,14 +357,14 @@ q_b_n = rot_to_quaternion(C_B_N); % Initial attitude quaternion
                 'File %s does not contain g_NED. Using default gravity.', task1_file);
             g_NED = [0; 0; constants.GRAVITY];
         end
-        fprintf('Loaded gravity from %s\n', task1_file);
+        logf('Loaded gravity from %s\n', task1_file);
     else
         warning('Task_5:MissingTask1', ...
             'Task 1 output not found; using constants.GRAVITY.');
         g_NED = [0; 0; constants.GRAVITY];
     end
 
-    fprintf('Gravity vector applied: [%.8f %.8f %.8f]\n', g_NED);
+    logf('Gravity vector applied: [%.8f %.8f %.8f]\n', g_NED);
 
     % -- Compute Wahba Errors using all Task 3 rotation matrices --
     if isfield(task3_results,'methods') && ~isempty(task3_results.methods)
@@ -404,7 +411,7 @@ else
     steps = total_samples;
 end
 x_log = zeros(15, steps);
-fprintf('Task 5: x_log initialized with size %dx%d\n', size(x_log));
+logf('Task 5: x_log initialized with size %dx%d\n', size(x_log));
 euler_log = zeros(3, steps);
 zupt_log = zeros(1, steps);
 zupt_vel_norm = nan(1, steps); % velocity norm after each ZUPT
@@ -416,13 +423,13 @@ vel_blow_count = 0;             % track number of velocity blow-ups
 accel_std_thresh = 0.05;        % [m/s^2]
 gyro_std_thresh  = 0.005;       % [rad/s]
 vel_thresh       = 0.1;         % [m/s]
-fprintf('-> 15-State filter initialized.\n');
-fprintf('Subtask 5.4: Integrating IMU data for each method.\n');
+logf('-> 15-State filter initialized.\n');
+logf('Subtask 5.4: Integrating IMU data for each method.\n');
 
 %% ========================================================================
 % Subtask 5.6: Kalman Filter for Sensor Fusion
 % =========================================================================
-fprintf('\nSubtask 5.6: Running Kalman Filter for sensor fusion for each method.\n');
+logf('\nSubtask 5.6: Running Kalman Filter for sensor fusion for each method.\n');
 
 % Interpolate GNSS measurements to IMU timestamps
 gnss_pos_interp = zeros(num_imu_samples,3);
@@ -441,7 +448,7 @@ task5_gnss_interp_ned_plot(gnss_time, gnss_pos_ned, gnss_vel_ned, imu_time, ...
     gnss_pos_interp, gnss_vel_interp, run_id, results_dir, cfg);
 
 % --- Main Filter Loop ---
-fprintf('-> Starting filter loop over %d IMU samples...\n', num_imu_samples);
+logf('-> Starting filter loop over %d IMU samples...\n', num_imu_samples);
 in_static = false; % debounce flag for ZUPT
 % Optional trace buffers for first N steps
 trace_n = max(0, min(trace_first_n, num_imu_samples));
@@ -463,7 +470,7 @@ for i = 1:num_imu_samples
     gnss_vel_i = gnss_vel_interp(i,:)';
 
     if mod(i, 1e5) == 0
-        fprintf('[DBG-KF] k=%d   posN=%.1f  velN=%.2f  accN=%.2f\n', ...
+        logf('[DBG-KF] k=%d   posN=%.1f  velN=%.2f  accN=%.2f\n', ...
             i, x(1), x(4), a_ned(1));
     end
     % --- 1. State Propagation (Prediction) ---
@@ -485,7 +492,7 @@ for i = 1:num_imu_samples
     % acceleration via a = f + g (parity with Python pipeline).
     a_ned = C_B_N * corrected_accel + g_NED;
     if mod(i, 1e5) == 0
-        fprintf('[DBG-KF] k=%d   posN=%.1f  velN=%.2f  accN=%.2f\n', ...
+        logf('[DBG-KF] k=%d   posN=%.1f  velN=%.2f  accN=%.2f\n', ...
             i, x(1), x(4), a_ned(1));
     end
     if i > 1
@@ -496,7 +503,7 @@ for i = 1:num_imu_samples
             vel_new = prev_vel;
             pos_new = x(1:3);
             vel_blow_count = vel_blow_count + 1;
-            fprintf('Velocity blow-up at k=%d; zeroed delta_v\n', i);
+            logf('Velocity blow-up at k=%d; zeroed delta_v\n', i);
         else
             pos_new = x(1:3) + 0.5 * (vel_new + prev_vel) * dt_imu;
         end
@@ -570,35 +577,35 @@ for i = 1:num_imu_samples
         zupt_vel_norm(i) = norm(x(4:6));
         if zupt_vel_norm(i) > vel_thresh
             zupt_fail_count = zupt_fail_count + 1;
-            fprintf('ZUPT clamp failure at k=%d (norm=%.3f)\n', i, zupt_vel_norm(i));
+            logf('ZUPT clamp failure at k=%d (norm=%.3f)\n', i, zupt_vel_norm(i));
         end
         x(4:6) = 0;
     end
     if mod(i,100000) == 0
-        fprintf('ZUPT applied %d times so far\n', zupt_count);
+        logf('ZUPT applied %d times so far\n', zupt_count);
     end
 
     % --- Log State and Attitude ---
     x_log(:, i) = x;
     euler_log(:, i) = quat_to_euler(q_b_n);
     if mod(i, 100000) == 0
-        fprintf('Task 5: Stored state at sample %d/%d\n', i, num_imu_samples);
+        logf('Task 5: Stored state at sample %d/%d\n', i, num_imu_samples);
     end
 end
-fprintf('Method %s: IMU data integrated.\n', method);
-fprintf('Method %s: Kalman Filter completed. ZUPTcnt=%d\n', method, zupt_count);
-fprintf('Method %s: velocity blow-up events=%d\n', method, vel_blow_count);
-fprintf('Method %s: ZUPT clamp failures=%d\n', method, zupt_fail_count);
+logf('Method %s: IMU data integrated.\n', method);
+logf('Method %s: Kalman Filter completed. ZUPTcnt=%d\n', method, zupt_count);
+logf('Method %s: velocity blow-up events=%d\n', method, vel_blow_count);
+logf('Method %s: ZUPT clamp failures=%d\n', method, zupt_fail_count);
 
 %% ========================================================================
 % Subtask 5.7: Handle Event at 5000s
 % =========================================================================
-fprintf('\nSubtask 5.7: No event handling needed as time < 5000s.\n');
+logf('\nSubtask 5.7: No event handling needed as time < 5000s.\n');
 
 %% ========================================================================
 % Subtask 5.8: Plotting Results
 % =========================================================================
-fprintf('\nSubtask 5.8.2: Plotting results for %s.\n', method);
+logf('\nSubtask 5.8.2: Plotting results for %s.\n', method);
 
 % Ensure array sizes match for plotting
 if numel(imu_time) ~= size(x_log,2)
@@ -643,7 +650,7 @@ for i = 1:3
     plot(gnss_time, gnss_pos_ned(:,i), 'k:', 'LineWidth', 1, 'DisplayName', 'GNSS (Raw)');
     plot(imu_time, x_log(i,:), 'b-', 'LineWidth', 1.5, 'DisplayName', 'Fused (KF)');
     hold off; grid on; legend; ylabel('[m]'); title(['Position ' labels{i}]);
-    fprintf('Subtask 5.8.2: Plotted %s position %s: First = %.4f, Last = %.4f\n', ...
+    logf('Subtask 5.8.2: Plotted %s position %s: First = %.4f, Last = %.4f\n', ...
         method, labels{i}, x_log(i,1), x_log(i,end));
 
     % Velocity
@@ -655,7 +662,7 @@ for i = 1:3
         plot(imu_time(zupt_indices), x_log(i+3,zupt_indices), 'ro', 'MarkerSize', 3, 'DisplayName', 'ZUPT');
     end
     hold off; grid on; legend; ylabel('[m/s]'); title(['Velocity ' labels{i}]);
-    fprintf('Subtask 5.8.2: Plotted %s velocity %s: First = %.4f, Last = %.4f\n', ...
+    logf('Subtask 5.8.2: Plotted %s velocity %s: First = %.4f, Last = %.4f\n', ...
         method, labels{i}, x_log(i+3,1), x_log(i+3,end));
 
     % Acceleration
@@ -663,7 +670,7 @@ for i = 1:3
     plot(gnss_time, gnss_accel_ned(:,i), 'k:', 'LineWidth', 1, 'DisplayName', 'GNSS (Derived)');
     plot(imu_time, acc_log(i,:), 'b-', 'LineWidth', 1.5, 'DisplayName', 'Fused (KF)');
     hold off; grid on; legend; ylabel('[m/s^2]'); title(['Acceleration ' labels{i}]);
-    fprintf('Subtask 5.8.2: Plotted %s acceleration %s: First = %.4f, Last = %.4f\n', ...
+    logf('Subtask 5.8.2: Plotted %s acceleration %s: First = %.4f, Last = %.4f\n', ...
         method, labels{i}, acc_log(i,1), acc_log(i,end));
 end
 xlabel('Time (s)');
@@ -671,7 +678,7 @@ sgtitle('Kalman Filter Results vs. GNSS');
 % out_pdf = fullfile(results_dir, sprintf('%s_task5_results_%s.pdf', tag, method));
 % set(fig,'PaperPositionMode','auto');
 % print(fig, out_pdf, '-dpdf', '-bestfit');
-% fprintf('Subtask 5.8.2: %s plot saved as ''%s''\n', method, out_pdf);
+% logf('Subtask 5.8.2: %s plot saved as ''%s''\n', method, out_pdf);
 % exportgraphics(fig, all_file, 'Append', true);
 
 % --- Plot 4: Attitude (Euler Angles) ---
@@ -686,7 +693,7 @@ xlabel('Time (s)'); sgtitle('Attitude Estimate Over Time');
 % att_file = fullfile(results_dir, sprintf('%s_Task5_Attitude.pdf', tag));
 % set(gcf,'PaperPositionMode','auto');
 % print(gcf, att_file, '-dpdf', '-bestfit');
-% fprintf('Saved plot: %s\n', att_file);
+% logf('Saved plot: %s\n', att_file);
 
 % --- Plot 5: Velocity Magnitude After ZUPTs ---
 zupt_indices = find(zupt_log);
@@ -703,23 +710,23 @@ end
 
 plot_task5_mixed_frame(imu_time, x_log(1:3,:), x_log(4:6,:), ...
     acc_log, euler_log, C_ECEF_to_NED, ref_r0, g_NED, run_id, method, results_dir, all_file, cfg);
-fprintf('Fused mixed frames plot saved\n');
+logf('Fused mixed frames plot saved\n');
 
-fprintf('Plotting all data in NED frame.\n');
+logf('Plotting all data in NED frame.\n');
 plot_task5_ned_frame(imu_time, x_log(1:3,:), x_log(4:6,:), acc_log, ...
     gnss_time, gnss_pos_ned, gnss_vel_ned, gnss_accel_ned, method, run_id, cfg);
 
-fprintf('Plotting all data in ECEF frame.\n');
+logf('Plotting all data in ECEF frame.\n');
 plot_task5_ecef_frame(imu_time, x_log(1:3,:), x_log(4:6,:), acc_log, ...
     gnss_time, gnss_pos_ecef, gnss_vel_ecef, gnss_accel_ecef, C_ECEF_to_NED, ref_r0, method, run_id, cfg);
 
-fprintf('Plotting all data in body frame.\n');
+logf('Plotting all data in body frame.\n');
 plot_task5_body_frame(imu_time, x_log(1:3,:), x_log(4:6,:), acc_log, acc_body_raw, euler_log, ...
     gnss_time, gnss_pos_ned, gnss_vel_ned, gnss_accel_ned, method, g_NED, run_id, cfg);
 
 state_file = fullfile(fileparts(imu_path), sprintf('STATE_%s.txt', imu_name));
 if exist(state_file, 'file')
-    fprintf('Plotting fused ECEF trajectory with truth overlay.\n');
+    logf('Plotting fused ECEF trajectory with truth overlay.\n');
     plot_task5_ecef_truth(imu_time, x_log(1:3,:), x_log(4:6,:), acc_log, ...
         state_file, C_ECEF_to_NED, ref_r0, method, run_id, cfg);
 end
@@ -753,9 +760,9 @@ max_resid_vel = max(vecnorm(res_vel,2,2));
 min_resid_vel = min(vecnorm(res_vel,2,2));
 
 % Print a concise summary matching the Python pipeline
-fprintf('Position: North=%.4f, East=%.4f, Down=%.4f\n', ...
+logf('Position: North=%.4f, East=%.4f, Down=%.4f\n', ...
         x_log(1,end), x_log(2,end), x_log(3,end));
-fprintf('RMSE_pos: %.4f\n', rmse_pos);
+logf('RMSE_pos: %.4f\n', rmse_pos);
 
 % --- Plot: Position Residuals ---
 figure('Name', 'KF Results: Position Residuals', 'Position', [150 150 1200 600]);
@@ -769,7 +776,7 @@ xlabel('Time (s)'); sgtitle('Position Residuals (KF - GNSS)');
 % err_file = fullfile(results_dir, sprintf('%s_Task5_ErrorAnalysis.pdf', tag));
 % set(gcf,'PaperPositionMode','auto');
 % print(gcf, err_file, '-dpdf', '-bestfit');
-% fprintf('Saved plot: %s\n', err_file);
+% logf('Saved plot: %s\n', err_file);
 % exportgraphics(gcf, all_file, 'Append', true);
 summary_line = sprintf(['[SUMMARY] method=%s imu=%s gnss=%s rmse_pos=%8.2fm ' ...
     'final_pos=%8.2fm rms_vel=%8.2fm/s final_vel=%8.2fm/s ' ...
@@ -780,12 +787,12 @@ summary_line = sprintf(['[SUMMARY] method=%s imu=%s gnss=%s rmse_pos=%8.2fm ' ..
     final_pos_err, rmse_vel, final_vel, rms_resid_pos, max_resid_pos, ...
     rms_resid_vel, max_resid_vel, norm(accel_bias), norm(gyro_bias), grav_err_mean, grav_err_max, ...
     omega_err_mean, omega_err_max, zupt_count);
-fprintf('%s\n', summary_line);
-fprintf('[SUMMARY] method=%s rmse_pos=%.2f m final_pos=%.2f m ', ...
+logf('%s\n', summary_line);
+logf('[SUMMARY] method=%s rmse_pos=%.2f m final_pos=%.2f m ', ...
         method, rmse_pos, final_pos_err);
-fprintf('rmse_vel=%.2f m/s final_vel=%.2f m/s\n', rmse_vel, final_vel);
+logf('rmse_vel=%.2f m/s final_vel=%.2f m/s\n', rmse_vel, final_vel);
 fid = fopen(fullfile(results_dir, [run_id '_summary.txt']), 'w');
-fprintf(fid, '%s\n', summary_line);
+logf(fid, '%s\n', summary_line);
 fclose(fid);
 
 % Store summary metrics and biases for later analysis
@@ -806,7 +813,7 @@ end
 
 summary_file = fullfile(results_dir, 'IMU_GNSS_summary.txt');
 fid_sum = fopen(summary_file, 'a');
-fprintf(fid_sum, '%s\n', summary_line);
+logf(fid_sum, '%s\n', summary_line);
 fclose(fid_sum);
 
 % Persist core results for unit tests and further analysis
@@ -814,7 +821,7 @@ fclose(fid_sum);
 time      = imu_time; %#ok<NASGU>  used by Task_6
 gnss_time = gnss_time; %#ok<NASGU>
 t_est = (0:size(x_log,2)-1)' * dt_imu; %#ok<NASGU>
-fprintf('Saved t_est with length %d\n', length(t_est));
+logf('Saved t_est with length %d\n', length(t_est));
 dt = dt_imu; %#ok<NASGU> IMU sample interval
 imu_rate_hz = 1 / dt_imu; %#ok<NASGU> IMU sampling rate
 
@@ -838,15 +845,15 @@ save(results_file, 'gnss_pos_ned', 'gnss_vel_ned', 'gnss_accel_ned', ...
 % by storing the fused position under the generic ``pos`` field as well.
 pos = pos_ned; %#ok<NASGU>
 save(results_file, 'x_log', 'pos', '-append');
-fprintf('State history (x_log) saved to %s\n', results_file);
+logf('State history (x_log) saved to %s\n', results_file);
 if isfile(results_file)
-    fprintf('Results saved to %s\n', results_file);
+    logf('Results saved to %s\n', results_file);
 else
     warning('Missing %s', results_file);
 end
 try
     check = load(results_file, 'x_log');
-    fprintf('Task 5: Verified x_log saved, size: %dx%d\n', size(check.x_log));
+    logf('Task 5: Verified x_log saved, size: %dx%d\n', size(check.x_log));
 catch
     warning('Task 5: Failed to verify x_log save in %s', results_file);
 end
@@ -854,7 +861,7 @@ end
 % Export estimator time vector for compatibility with Python pipeline
 time_file = fullfile(results_dir, sprintf('%s_task5_time.mat', run_id));
 save(time_file, 't_est', 'dt', 'x_log');
-fprintf('Task 5: Saved time vector to %s\n', time_file);
+logf('Task 5: Saved time vector to %s\n', time_file);
 
     method_struct = struct('gnss_pos_ned', gnss_pos_ned, 'gnss_vel_ned', gnss_vel_ned, ...
         'gnss_accel_ned', gnss_accel_ned, 'gnss_pos_ecef', gnss_pos_ecef, ...

--- a/MATLAB/Task_5_try_once.m
+++ b/MATLAB/Task_5_try_once.m
@@ -1,8 +1,8 @@
 function rmse_pos = Task_5_try_once(cfg, vel_q_scale, vel_r)
 %TASK_5_TRY_ONCE Call Task_5 once with given Q/R and return RMSE position.
 %   RMSE_POS = TASK_5_TRY_ONCE(CFG, VEL_Q_SCALE, VEL_R) runs Task_5 with a
-%   limited step count and plotting disabled, returning the scalar RMSE of
-%   position error for autotuning.
+%   limited step count and plotting/printing disabled (dryrun=true),
+%   returning the scalar RMSE of position error for autotuning.
 
     if nargin < 3, error('Task_5_try_once:args','cfg, vel_q_scale, vel_r required'); end
     % Use at most first 200k IMU steps for speed during tuning

--- a/MATLAB/task5_autotune.m
+++ b/MATLAB/task5_autotune.m
@@ -5,7 +5,8 @@ function [best_q, best_r, report] = task5_autotune(imu_path, gnss_path, method, 
 %   GRID_R and selects the pair that minimises RMSE_pos (computed against
 %   GNSS). REPORT contains fields {table, best_rmse, best_rmse_q,
 %   best_rmse_r}. This function can be slow on large datasets; consider
-%   running with a reduced time span if needed.
+%   running with a reduced time span if needed. Task_5 is invoked with
+%   dryrun=true to suppress plots and console output during the sweep.
 
     if nargin < 4 || isempty(grid_q), grid_q = [5, 10, 20, 40]; end
     if nargin < 5 || isempty(grid_r), grid_r = [0.25, 0.5, 1.0]; end
@@ -26,7 +27,7 @@ function [best_q, best_r, report] = task5_autotune(imu_path, gnss_path, method, 
                 fprintf('[Autotune] Trying vel_q_scale=%.3f  vel_r=%.3f ...\n', q, r);
             end
             try
-                res = Task_5(imu_path, gnss_path, method, [], 'vel_q_scale', q, 'vel_r', r, 'trace_first_n', 0, 'max_steps', max_steps);
+                res = Task_5(imu_path, gnss_path, method, [], 'vel_q_scale', q, 'vel_r', r, 'trace_first_n', 0, 'max_steps', max_steps, 'dryrun', true);
                 rmse = res.rmse_pos;
                 results(k).vel_q_scale = q; %#ok<AGROW>
                 results(k).vel_r = r;      %#ok<AGROW>


### PR DESCRIPTION
## Summary
- Extend Task_5 with a `dryrun` option that suppresses plotting and console output
- Use a `logf` helper to wrap all former `fprintf` calls
- Ensure autotune helpers call Task_5 with `dryrun=true`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*
- `pip install -e .[tests]` *(fails: Multiple top-level packages discovered in a flat-layout)*

------
https://chatgpt.com/codex/tasks/task_e_689b9f8e629c83229f22e41616e8d00a