### PR TITLE
feat: add optional dryrun flag to silence Task 5 logging

### DIFF
--- a/MATLAB/Task_5_try_once.m
+++ b/MATLAB/Task_5_try_once.m
@@ -1,7 +1,7 @@
 function rmse_pos = Task_5_try_once(cfg, vel_q_scale, vel_r)
 %TASK_5_TRY_ONCE Call Task_5 once with given Q/R and return RMSE position.
 %   RMSE_POS = TASK_5_TRY_ONCE(CFG, VEL_Q_SCALE, VEL_R) runs Task_5 with a
-%   limited step count and plotting disabled, returning the scalar RMSE of
+%   limited step count and plotting/console output disabled, returning the scalar RMSE of
 %   position error for autotuning.
 
     if nargin < 3, error('Task_5_try_once:args','cfg, vel_q_scale, vel_r required'); end
@@ -13,7 +13,7 @@ function rmse_pos = Task_5_try_once(cfg, vel_q_scale, vel_r)
     try
         res = Task_5(cfg.imu_path, cfg.gnss_path, cfg.method, [], ...
             'vel_q_scale', vel_q_scale, 'vel_r', vel_r, ...
-            'trace_first_n', 0, 'max_steps', steps, 'dryrun', true);
+            'trace_first_n', 0, 'max_steps', steps, 'dryrun', true); % dryrun suppresses plots/logging
         if isstruct(res) && isfield(res,'rmse_pos')
             rmse_pos = res.rmse_pos;
         else

--- a/MATLAB/task5_autotune.m
+++ b/MATLAB/task5_autotune.m
@@ -26,7 +26,8 @@ function [best_q, best_r, report] = task5_autotune(imu_path, gnss_path, method, 
                 fprintf('[Autotune] Trying vel_q_scale=%.3f  vel_r=%.3f ...\n', q, r);
             end
             try
-                res = Task_5(imu_path, gnss_path, method, [], 'vel_q_scale', q, 'vel_r', r, 'trace_first_n', 0, 'max_steps', max_steps);
+                res = Task_5(imu_path, gnss_path, method, [], 'vel_q_scale', q, 'vel_r', r, ...
+                    'trace_first_n', 0, 'max_steps', max_steps, 'dryrun', true);
                 rmse = res.rmse_pos;
                 results(k).vel_q_scale = q; %#ok<AGROW>
                 results(k).vel_r = r;      %#ok<AGROW>


### PR DESCRIPTION
## Summary
- Extend Task_5 with a `dryrun` flag that disables console output in addition to plots
- Silence tuning calls by passing `dryrun` in `Task_5_try_once` and `task5_autotune`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*


------
https://chatgpt.com/codex/tasks/task_e_689ba18614e88322b51c6a3239613aec