### PR TITLE
feat: add dryrun flag to silence Task_5 output

### DIFF
--- a/MATLAB/Task_5_try_once.m
+++ b/MATLAB/Task_5_try_once.m
@@ -1,7 +1,7 @@
 function rmse_pos = Task_5_try_once(cfg, vel_q_scale, vel_r)
 %TASK_5_TRY_ONCE Call Task_5 once with given Q/R and return RMSE position.
 %   RMSE_POS = TASK_5_TRY_ONCE(CFG, VEL_Q_SCALE, VEL_R) runs Task_5 with a
-%   limited step count and plotting disabled, returning the scalar RMSE of
+%   limited step count and plotting/printing disabled, returning the scalar RMSE of
 %   position error for autotuning.
 
     if nargin < 3, error('Task_5_try_once:args','cfg, vel_q_scale, vel_r required'); end

--- a/MATLAB/task5_autotune.m
+++ b/MATLAB/task5_autotune.m
@@ -26,7 +26,7 @@ function [best_q, best_r, report] = task5_autotune(imu_path, gnss_path, method, 
                 fprintf('[Autotune] Trying vel_q_scale=%.3f  vel_r=%.3f ...\n', q, r);
             end
             try
-                res = Task_5(imu_path, gnss_path, method, [], 'vel_q_scale', q, 'vel_r', r, 'trace_first_n', 0, 'max_steps', max_steps);
+                res = Task_5(imu_path, gnss_path, method, [], 'vel_q_scale', q, 'vel_r', r, 'trace_first_n', 0, 'max_steps', max_steps, 'dryrun', true);
                 rmse = res.rmse_pos;
                 results(k).vel_q_scale = q; %#ok<AGROW>
                 results(k).vel_r = r;      %#ok<AGROW>


### PR DESCRIPTION
## Summary
- allow Task_5 to run in `dryrun` mode that suppresses console output
- silence Task_5 during parameter sweeps in autotune utilities
- document that Task_5_try_once disables plotting and printing while tuning

## Testing
- `pytest` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689ba1eea6c88322b8025317a6874529