### PR TITLE
Guard MATLAB autotune outputs behind verbosity flag

### DIFF
--- a/MATLAB/task5_autotune.m
+++ b/MATLAB/task5_autotune.m
@@ -47,7 +47,9 @@ function [best_q, best_r, report] = task5_autotune(imu_path, gnss_path, method, 
     T = struct2table(results);
     report = struct('table', T, 'best_rmse', best_rmse, ...
         'best_rmse_q', best_q, 'best_rmse_r', best_r);
-    disp(T);
-    fprintf('[Autotune] Best vel_q_scale=%.3f  vel_r=%.3f  RMSE=%.3f\n', ...
-        best_q, best_r, best_rmse);
+    if verbose
+        disp(T);
+        fprintf('[Autotune] Best vel_q_scale=%.3f  vel_r=%.3f  RMSE=%.3f\n', ...
+            best_q, best_r, best_rmse);
+    end
 end


### PR DESCRIPTION
## Summary
- Only display tuning table and summary when `verbose` is true in `task5_autotune`

## Testing
- `matlab -batch "task5_autotune('dummy','dummy','method',5,0.25,false)"` *(command not found: matlab)*
- `octave --eval "task5_autotune('dummy','dummy','method',5,0.25,false)"` *(command not found: octave)*

------
https://chatgpt.com/codex/tasks/task_e_689ba4035b40832287b3bc9da6d413f8