### PR TITLE
Use line counting for Task_5_try_once IMU size detection

### DIFF
--- a/MATLAB/Task_5_try_once.m
+++ b/MATLAB/Task_5_try_once.m
@@ -8,7 +8,19 @@ function rmse_pos = Task_5_try_once(cfg, vel_q_scale, vel_r)
     % Use at most first 200k IMU steps for speed during tuning
     max_steps = 200000;
     % Determine total IMU samples to avoid requesting more steps than exist
-    total_samples = size(readmatrix(cfg.imu_path), 1);
+    fid = fopen(cfg.imu_path, 'r');
+    if fid == -1
+        error('Task_5_try_once:file', 'Could not open IMU file %s', cfg.imu_path);
+    end
+    total_samples = 0;
+    while ~feof(fid)
+        line = fgetl(fid);
+        if ~ischar(line)
+            break;
+        end
+        total_samples = total_samples + 1;
+    end
+    fclose(fid);
     steps = min(max_steps, total_samples);
     try
         res = Task_5(cfg.imu_path, cfg.gnss_path, cfg.method, [], ...


### PR DESCRIPTION
## Summary
- Replace `readmatrix` with `fopen`/`fgetl` loop to count IMU samples without loading full dataset
- Keep step limiting logic for autotuning

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src')*
- `python - <<'PY' ...` counted lines and verified row counts match `numpy.loadtxt` for both small and large datasets
- `/usr/bin/time -f 'elapsed=%E mem=%MKB' python - <<'PY' ...` shows line counting uses 8.9MB vs 64MB and starts faster (0.44s vs 1.16s)


------
https://chatgpt.com/codex/tasks/task_e_689ba405834c832298bb8ab216af325c