### PR TITLE
Bypass Task 5 plotting and saves during dry runs

### DIFF
--- a/MATLAB/Task_5_try_once.m
+++ b/MATLAB/Task_5_try_once.m
@@ -22,8 +22,17 @@ function rmse_pos = Task_5_try_once(cfg, vel_q_scale, vel_r)
     end
     fclose(fid);
     steps = min(max_steps, total_samples);
+    % Clone cfg locally and disable all plotting/saving for tuning runs
+    cfg_local = cfg;
+    if ~isfield(cfg_local, 'plots') || ~isstruct(cfg_local.plots)
+        cfg_local.plots = struct();
+    end
+    cfg_local.plots.popup_figures = false;
+    cfg_local.plots.save_pdf = false;
+    cfg_local.plots.save_png = false;
+    cfg = cfg_local; %#ok<NASGU> ensure Task_5 sees modified cfg
     try
-        res = Task_5(cfg.imu_path, cfg.gnss_path, cfg.method, [], ...
+        res = Task_5(cfg_local.imu_path, cfg_local.gnss_path, cfg_local.method, [], ...
             'vel_q_scale', vel_q_scale, 'vel_r', vel_r, ...
             'trace_first_n', 0, 'max_steps', steps, 'dryrun', true); % dryrun suppresses plots/logging
         if isstruct(res) && isfield(res,'rmse_pos')


### PR DESCRIPTION
## Summary
- Clone configuration in `Task_5_try_once` and disable plotting/saving before invoking `Task_5`
- Force `Task_5` to hide figures on `dryrun` and wrap all plot/save routines so they are skipped

## Testing
- `pip install -e .[tests]` *(failed: Multiple top-level packages discovered in a flat-layout)*
- `PYTHONPATH=PYTHON pytest PYTHON/tests/test_utils.py::test_zero_base_time -q`
- `PYTHONPATH=PYTHON pytest -q` *(failed: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_689bb44b9d588322aa98edb2d6797fa8