### PR TITLE
Use package import for frames module

### DIFF
--- a/PYTHON/src/utils/frames.py
+++ b/PYTHON/src/utils/frames.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import numpy as np
 from typing import Iterable, Tuple
 
-from .ecef_llh import lla_to_ecef
+from utils.ecef_llh import lla_to_ecef
+from utils import compute_C_ECEF_to_NED
 
 
 def _rotation_ecef_to_ned(lat_deg: float, lon_deg: float) -> np.ndarray:
@@ -39,3 +40,19 @@ def ned_to_ecef(n: Iterable[float], e: Iterable[float], d: Iterable[float],
     R = _rotation_ecef_to_ned(lat0, lon0)
     ecef = np.linalg.inv(R) @ np.vstack((n, e, d))
     return ecef[0] + x0, ecef[1] + y0, ecef[2] + z0
+
+
+def R_ecef_to_ned(lat_rad: float, lon_rad: float) -> np.ndarray:
+    """Rotation matrix from ECEF to NED.
+
+    Parameters
+    ----------
+    lat_rad, lon_rad : float
+        Geodetic latitude and longitude in **radians**.
+    """
+    return compute_C_ECEF_to_NED(lat_rad, lon_rad)
+
+
+def ecef_vec_to_ned(vec_ecef: Iterable[float], lat_rad: float, lon_rad: float) -> np.ndarray:
+    """Rotate an ECEF vector into the NED frame."""
+    return R_ecef_to_ned(lat_rad, lon_rad) @ np.asarray(vec_ecef).T

--- a/PYTHON/src/validate_with_truth.py
+++ b/PYTHON/src/validate_with_truth.py
@@ -11,13 +11,7 @@ import matplotlib.pyplot as plt
 from tabulate import tabulate
 
 from utils import compute_C_ECEF_to_NED, ecef_to_geodetic, zero_base_time
-import importlib.util
-from pathlib import Path as _Path
-
-_frames_path = _Path(__file__).resolve().parent / "utils" / "frames.py"
-_spec = importlib.util.spec_from_file_location("_frames", _frames_path)
-_frames = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(_frames)
+from utils import frames as _frames
 R_ecef_to_ned = _frames.R_ecef_to_ned
 ecef_vec_to_ned = _frames.ecef_vec_to_ned
 from plot_overlay import plot_overlay

--- a/PYTHON/tests/test_frames.py
+++ b/PYTHON/tests/test_frames.py
@@ -1,13 +1,7 @@
-import importlib.util
-from pathlib import Path
+from utils import frames as _frames
 import numpy as np
 
-spec = importlib.util.spec_from_file_location(
-    "_frames", Path(__file__).resolve().parents[1] / "src" / "utils" / "frames.py"
-)
-frames = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(frames)
-R_ecef_to_ned = frames.R_ecef_to_ned
+R_ecef_to_ned = _frames.R_ecef_to_ned
 
 
 def test_ecef_to_ned_equator_prime_meridian():


### PR DESCRIPTION
## Summary
- Replace `importlib` module loading with standard `utils.frames` import
- Switch `utils.frames` to absolute imports and expose rotation helpers
- Update tests to import `utils.frames` directly

## Testing
- `python PYTHON/src/task6_plot_truth.py --help`
- `python -m pytest tests/test_frames.py`
- `python -m pytest tests/test_validate_with_truth.py::test_load_estimate_time_s`
- `python -m pytest tests/test_task6_length_handling.py::test_truncate_to_shorter_length`


------
https://chatgpt.com/codex/tasks/task_e_689bb9853db48322bedd2fee163a4a98