### PR TITLE
Switch frame comparison outputs to PNG

### DIFF
--- a/MATLAB/task5_plot_comparison.m
+++ b/MATLAB/task5_plot_comparison.m
@@ -6,7 +6,7 @@ function task5_plot_comparison(run_id)
 %   information ``ref_lat``, ``ref_lon``, ``ref_r0`` and ``C_B_N_ref`` must
 %   also be present.  The function writes four figures to
 %   ``results/RUN_ID/`` with filenames following the pattern
-%   ``<RUN_ID>_task5_<FRAME>_comparison.{pdf,png}``.
+%   ``<RUN_ID>_task5_<FRAME>_comparison.png``.
 %
 %   Example:
 %       task5_plot_comparison('IMU_X001_GNSS_X001')

--- a/PYTHON/src/cfg/default_cfg.py
+++ b/PYTHON/src/cfg/default_cfg.py
@@ -16,7 +16,6 @@ def default_cfg() -> dict:
         "paths": paths,
         "plots": {
             "popup_figures": False,
-            "save_pdf": True,
             "save_png": True,
         },
     }

--- a/PYTHON/src/utils/default_cfg.m
+++ b/PYTHON/src/utils/default_cfg.m
@@ -5,5 +5,5 @@ function cfg = default_cfg()
 %   configuration.
 
 cfg = struct();
-cfg.plots = struct('popup_figures', false, 'save_pdf', true, 'save_png', true);
+cfg.plots = struct('popup_figures', false, 'save_png', true);
 end

--- a/PYTHON/src/utils/plot_frame_comparison.m
+++ b/PYTHON/src/utils/plot_frame_comparison.m
@@ -48,11 +48,8 @@ else
         hold off;
     end
 end
-% Save PDF & PNG
+% Save PNG
 fname = [out_prefix '_' frame_name '_comparison'];
-if cfg.plots.save_pdf
-    saveas(gcf, [fname '.pdf'], 'pdf');
-end
 if cfg.plots.save_png
     saveas(gcf, [fname '.png'], 'png');
 end

--- a/PYTHON/src/utils/plot_initial_orientation.m
+++ b/PYTHON/src/utils/plot_initial_orientation.m
@@ -1,6 +1,6 @@
 function plot_initial_orientation(out_dir, R_bn)
 %PLOT_INITIAL_ORIENTATION Generate a simple 3-D axis plot of orientation.
-%   PLOT_INITIAL_ORIENTATION(DIR, R_BN) saves a PDF figure showing the NED
+%   PLOT_INITIAL_ORIENTATION(DIR, R_BN) saves a PNG figure showing the NED
 %   axes transformed by R_BN.
 
     figure('Visible','off');
@@ -15,7 +15,7 @@ function plot_initial_orientation(out_dir, R_bn)
     xlabel('X'); ylabel('Y'); zlabel('Z');
     legend({'N','E','D','b_x','b_y','b_z'},'Location','best');
     title('Initial Orientation');
-    pdf_file = fullfile(out_dir, 'initial_orientation.pdf');
-    print('-dpdf', pdf_file);
+    png_file = fullfile(out_dir, 'initial_orientation.png');
+    print('-dpng', png_file);
     close(gcf);
 end

--- a/README.md
+++ b/README.md
@@ -266,8 +266,8 @@ Typical result PDFs:
 - `<tag>_task1_location_map.pdf` – initial location map
 - `task3_errors_comparison.pdf` – attitude initialization error comparison
 - `task3_quaternions_comparison.pdf` – quaternion components for initialization
-- `task4_comparison_ned.pdf` – GNSS vs IMU in NED frame
-- `task4_mixed_frames.pdf` – GNSS/IMU data in mixed frames
+- `task4_comparison_ned.png` – GNSS vs IMU in NED frame
+- `task4_mixed_frames.png` – GNSS/IMU data in mixed frames
 - `task4_all_ned.pdf` – integrated data in NED frame
 - `task4_all_ecef.pdf` – integrated data in ECEF frame
 - `task4_all_body.pdf` – integrated data in body frame

--- a/Report/task4_integration.md
+++ b/Report/task4_integration.md
@@ -7,7 +7,7 @@ Biases are estimated during the static interval, e.g. for X001 the accelerometer
 Figures comparing the IMU trajectory against GNSS are saved as
 
 ```
-results/run_triad_only/<tag>_task4_comparison_ned.pdf
+results/run_triad_only/<tag>_task4_comparison_ned.png
 results/run_triad_only/<tag>_task4_all_ned.pdf
 results/run_triad_only/<tag>_task4_all_ecef.pdf
 results/run_triad_only/<tag>_task4_all_body.pdf

--- a/docs/MATLAB/Task4_MATLAB.md
+++ b/docs/MATLAB/Task4_MATLAB.md
@@ -35,7 +35,7 @@ GNSS ECEF → NED → comparison plots
 
 ### 4.13 Validate and Plot
 - Plot GNSS, raw IMU and integrated IMU data in NED, body and ECEF frames.
-- Save the PDFs as `results/<tag>_task4_*.pdf` and list them in `plot_summary.md`.
+- Save the PNGs as `results/<tag>_task4_*.png` and list them in `plot_summary.md`.
 - Use the [standardized legend terms](../PlottingChecklist.md#standardized-legend-terms) when naming GNSS, IMU and fused series.
 - When the `STATE_X001.txt` reference trajectory is available you can run the Python
   script `src/validate_with_truth.py` or call the MATLAB helper

--- a/docs/Python/Task4_Python.md
+++ b/docs/Python/Task4_Python.md
@@ -35,7 +35,7 @@ GNSS ECEF → NED → comparison plots
 
 ### 4.13 Validate and Plot
 - Create comparison plots in NED, body and ECEF frames.
-- Save the PDFs to `results/<tag>_task4_*.pdf` and record them in `plot_summary.md`.
+- Save the PNGs to `results/<tag>_task4_*.png` and record them in `plot_summary.md`.
 - Consult the [standardized legend terms](../PlottingChecklist.md#standardized-legend-terms) when labelling GNSS, IMU and fused traces.
 
 ## Result

--- a/docs/TRIAD_Task4_Wiki.md
+++ b/docs/TRIAD_Task4_Wiki.md
@@ -35,7 +35,7 @@ GNSS ECEF → NED → comparison plots
 
 ### 4.13 Validate and Plot
 - Create comparison plots in NED, body and ECEF frames showing GNSS, raw IMU and integrated IMU data.
-- Save the PDFs to `results/<tag>_task4_*.pdf` and list them in `plot_summary.md`.
+- Save the PNGs to `results/<tag>_task4_*.png` and list them in `plot_summary.md`.
 - Consult the [standardized legend terms](PlottingChecklist.md#standardized-legend-terms) when naming GNSS, IMU and fused traces.
 
 ## Result

--- a/plot_summary.md
+++ b/plot_summary.md
@@ -1,8 +1,8 @@
 - **X001_TRIAD_task1_location_map.pdf**: Initial location on Earth map
 - **X001_TRIAD_task3_errors_comparison.pdf**: Attitude initialization error comparison
 - **X001_TRIAD_task3_quaternions_comparison.pdf**: Quaternion components for initialization
-- **X001_TRIAD_task4_comparison_ned.pdf**: GNSS vs IMU data in NED frame
-- **X001_TRIAD_task4_mixed_frames.pdf**: GNSS/IMU data in mixed frames
+- **X001_TRIAD_task4_comparison_ned.png**: GNSS vs IMU data in NED frame
+- **X001_TRIAD_task4_mixed_frames.png**: GNSS/IMU data in mixed frames
 - **X001_TRIAD_task4_all_ned.pdf**: Integrated data in NED frame
 - **X001_TRIAD_task4_all_ecef.pdf**: Integrated data in ECEF frame
 - **X001_TRIAD_task4_all_body.pdf**: Integrated data in body frame


### PR DESCRIPTION
## Summary
- Save initial orientation plot as PNG instead of PDF
- Drop PDF branch in `plot_frame_comparison` and default configs
- Update Task 4 documentation and scripts to reference PNG comparison plots

## Testing
- `pytest` *(fails: 28 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689bbedde8848322b7d557b84c4e2d90