### PR TITLE
Fix ECEF vector rotation shape handling

### DIFF
--- a/PYTHON/src/utils/frames.py
+++ b/PYTHON/src/utils/frames.py
@@ -53,6 +53,25 @@ def R_ecef_to_ned(lat_rad: float, lon_rad: float) -> np.ndarray:
     return compute_C_ECEF_to_NED(lat_rad, lon_rad)
 
 
-def ecef_vec_to_ned(vec_ecef: Iterable[float], lat_rad: float, lon_rad: float) -> np.ndarray:
-    """Rotate an ECEF vector into the NED frame."""
-    return R_ecef_to_ned(lat_rad, lon_rad) @ np.asarray(vec_ecef).T
+def ecef_vec_to_ned(
+    vec_ecef: Iterable[float], lat_rad: float, lon_rad: float
+) -> np.ndarray:
+    """Rotate one or more ECEF vectors into the NED frame.
+
+    Parameters
+    ----------
+    vec_ecef : array_like
+        A single 3‑element vector or an array of shape ``(N, 3)`` containing
+        multiple ECEF vectors.  The returned array preserves this shape.
+    lat_rad, lon_rad : float
+        Geodetic latitude and longitude in **radians**.
+
+    Returns
+    -------
+    numpy.ndarray
+        The input vector(s) rotated into the NED frame with the same leading
+        dimensions as ``vec_ecef``.
+    """
+
+    vec = np.asarray(vec_ecef)
+    return vec @ R_ecef_to_ned(lat_rad, lon_rad).T

--- a/PYTHON/tests/test_ecef_vec_to_ned_shape.py
+++ b/PYTHON/tests/test_ecef_vec_to_ned_shape.py
@@ -1,0 +1,15 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from src.utils.frames import ecef_vec_to_ned
+
+
+def test_ecef_vec_to_ned_handles_multiple_samples():
+    lat = np.deg2rad(10.0)
+    lon = np.deg2rad(20.0)
+    vec = np.arange(15.0).reshape(5, 3)
+    ned = ecef_vec_to_ned(vec, lat, lon)
+    assert ned.shape == (5, 3)
+    t = np.linspace(0.0, 1.0, 5)
+    assert np.allclose(np.interp(t, t, ned[:, 0]), ned[:, 0])


### PR DESCRIPTION
## Summary
- Preserve input shape when converting ECEF vectors to NED to avoid interpolation errors
- Add regression test covering multiple-vector conversion

## Testing
- `PYTHONPATH=PYTHON pytest PYTHON/tests/test_ecef_vec_to_ned_shape.py PYTHON/tests/test_assemble_frames.py::test_assemble_frames_with_truth -q`


------
https://chatgpt.com/codex/tasks/task_e_689c1af9407c83228f4988aa3389f6c6