### PR TITLE
Use dataset-specific truth file in TRIAD runner

### DIFF
--- a/PYTHON/src/run_triad_only.py
+++ b/PYTHON/src/run_triad_only.py
@@ -236,11 +236,11 @@ def main(argv: Iterable[str] | None = None) -> None:
     if args.truth:
         truth_path = Path(args.truth)
     else:
-        truth_path = _truth_path_helper("STATE_X001.txt")
-    if not truth_path.exists():
-        alt = resolve_truth_path()
-        if alt:
-            truth_path = Path(alt)
+        truth_path = _truth_path_helper(f"STATE_{args.dataset}.txt")
+        if not truth_path.exists():
+            alt = resolve_truth_path()
+            if alt:
+                truth_path = Path(alt)
     logger.info(
         "Resolved input files: imu=%s gnss=%s truth=%s", imu_path, gnss_path, truth_path
     )


### PR DESCRIPTION
## Summary
- resolve truth path based on dataset in `run_triad_only.py`
- only fall back to generic resolver when dataset-specific file is missing

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_689c1b3371608322b426bc9598654f70