### PR TITLE
Add flag for small dataset variants

### DIFF
--- a/PYTHON/src/paths.py
+++ b/PYTHON/src/paths.py
@@ -51,6 +51,52 @@ def ensure_results_dir() -> Path:
     return PY_RES_DIR
 
 
+def available_imu_files(include_small: bool = False) -> list[str]:
+    """Return a sorted list of IMU data files.
+
+    Parameters
+    ----------
+    include_small : bool, optional
+        If ``True``, include files with the ``_small`` suffix.
+    """
+
+    return sorted(
+        p.name
+        for p in IMU_DIR.glob("IMU_*.dat")
+        if include_small or "_small" not in p.stem
+    )
+
+
+def available_gnss_files(include_small: bool = False) -> list[str]:
+    """Return a sorted list of GNSS data files.
+
+    Parameters
+    ----------
+    include_small : bool, optional
+        If ``True``, include files with the ``_small`` suffix.
+    """
+
+    return sorted(
+        p.name
+        for p in GNSS_DIR.glob("GNSS_*.csv")
+        if include_small or "_small" not in p.stem
+    )
+
+
+def available_dataset_ids(include_small: bool = False) -> list[str]:
+    """Return dataset identifiers with available IMU or GNSS data.
+
+    Parameters
+    ----------
+    include_small : bool, optional
+        If ``True``, include datasets with the ``_small`` suffix.
+    """
+
+    imu_ids = {f[4:-4] for f in available_imu_files(include_small)}
+    gnss_ids = {f[5:-4] for f in available_gnss_files(include_small)}
+    return sorted(imu_ids | gnss_ids)
+
+
 # Backwards compatibility helper.  Older code imported ``ensure_py_results``
 # which simply ensured the directory existed without returning it.  Re-export
 # the new helper under that name so existing imports keep working.

--- a/PYTHON/src/run_all_methods.py
+++ b/PYTHON/src/run_all_methods.py
@@ -72,6 +72,12 @@ DEFAULT_DATASETS: Iterable[Tuple[str, str]] = [
     ("IMU_X003.dat", "GNSS_X002.csv"),  # dataset X003 shares GNSS_X002
 ]
 
+SMALL_DATASETS: Iterable[Tuple[str, str]] = [
+    ("IMU_X001_small.dat", "GNSS_X001_small.csv"),
+    ("IMU_X002_small.dat", "GNSS_X002_small.csv"),
+    ("IMU_X003_small.dat", "GNSS_X002_small.csv"),
+]
+
 DEFAULT_METHODS = ["TRIAD", "SVD", "Davenport"]
 
 SUMMARY_RE = re.compile(r"\[SUMMARY\]\s+(.*)")
@@ -128,6 +134,11 @@ def main(argv=None):
         help="YAML file specifying datasets and methods",
     )
     parser.add_argument(
+        "--include-small",
+        action="store_true",
+        help="Include *_small dataset variants",
+    )
+    parser.add_argument(
         "--no-plots",
         action="store_true",
         help="Skip plot generation for faster execution",
@@ -172,6 +183,8 @@ def main(argv=None):
         cases, methods = load_config(args.config)
     else:
         cases, methods = list(DEFAULT_DATASETS), list(DEFAULT_METHODS)
+        if args.include_small:
+            cases.extend(SMALL_DATASETS)
 
     logger.debug(f"Datasets: {cases}")
     logger.debug(f"Methods: {methods}")

--- a/PYTHON/src/run_triad_only.py
+++ b/PYTHON/src/run_triad_only.py
@@ -66,6 +66,7 @@ from paths import (
     truth_path as _truth_path_helper,
     ensure_results_dir as _ensure_results,
     python_results_dir as _py_results_dir,
+    available_dataset_ids as _available_dataset_ids,
 )
 
 SUMMARY_RE = re.compile(r"\[SUMMARY\]\s+(.*)")
@@ -158,9 +159,13 @@ def main(argv: Iterable[str] | None = None) -> None:
     )
     parser.add_argument(
         "--dataset",
-        choices=["X001", "X002", "X003"],
         default="X002",
-        help="Dataset ID to use (default X002)",
+        help="Dataset ID to use (default X002).",
+    )
+    parser.add_argument(
+        "--include-small",
+        action="store_true",
+        help="Include *_small datasets when listing available IDs.",
     )
     parser.add_argument("--imu", type=str, help="Path to IMU data file")
     parser.add_argument("--gnss", type=str, help="Path to GNSS data file")
@@ -192,6 +197,12 @@ def main(argv: Iterable[str] | None = None) -> None:
     parser.add_argument("--truth-rate", type=float, default=None, help="Hint truth sample rate [Hz]")
 
     args = parser.parse_args(argv)
+
+    valid_ids = _available_dataset_ids(include_small=args.include_small)
+    if args.dataset not in valid_ids:
+        parser.error(
+            f"Dataset {args.dataset} not found. Available datasets: {', '.join(valid_ids)}"
+        )
 
     if args.outdir:
         results_dir = Path(args.outdir)


### PR DESCRIPTION
## Summary
- allow `paths.available_dataset_ids` to optionally include `_small` datasets
- surface a `--include-small` flag in `run_triad_only.py`
- surface a `--include-small` flag in `run_all_methods.py`

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'src')*


------
https://chatgpt.com/codex/tasks/task_e_689c1b3681f883228c7be73fd9921705