### PR TITLE
Refactor Task 6 plotting and enable lazy interactive import

### DIFF
--- a/PYTHON/src/run_triad_only.py
+++ b/PYTHON/src/run_triad_only.py
@@ -47,7 +47,10 @@ from tabulate import tabulate
 from evaluate_filter_results import run_evaluation_npz
 from run_all_methods import run_case, compute_C_NED_to_ECEF
 from utils import save_mat
-from task6_overlay_all_frames import run_task6_overlay_all_frames
+from task6_overlay_all_frames import (
+    run_task6_overlay_all_frames,
+    run_task6_compare_methods_all_frames,
+)
 
 # Import helper utilities from the utils package
 from utils.timeline import print_timeline
@@ -549,23 +552,53 @@ def main(argv: Iterable[str] | None = None) -> None:
     # ----------------------------
     truth_file = truth_path
     if truth_file.exists():
-        out_dir = os.path.join(str(results_dir), run_id, 'task6')
+        out_dir = os.path.join(str(results_dir), run_id_str, "task6")
         os.makedirs(out_dir, exist_ok=True)
-        lat_deg = math.degrees(ref_lat)
-        lon_deg = math.degrees(ref_lon)
-        triad_quat = quat[0] if 'quat' in locals() and quat is not None and len(quat) > 0 else np.array([1.0,0.0,0.0,0.0])
-        q_b2n = tuple(triad_quat.tolist())
-        kf_output_file = str(npz_path.with_suffix('.mat'))
+
+        # Reuse already-computed lat/lon from Task 1/4
+        lat_deg = float(math.degrees(ref_lat))
+        lon_deg = float(math.degrees(ref_lon))
+
+        # Prefer time-varying quaternion if available; fall back to TRIAD quat
+        triad_quat = (
+            quat[0]
+            if "quat" in locals() and quat is not None and len(quat) > 0
+            else np.array([1.0, 0.0, 0.0, 0.0])
+        )
+        q_b2n_const = tuple(triad_quat.tolist())
+
+        kf_output_file = str(npz_path.with_suffix(".mat"))
         with open(log_path, "a") as log:
             log.write("\nTASK 6: Overlay fused output with truth\n")
+
         run_task6_overlay_all_frames(
             est_file=kf_output_file,
             truth_file=str(truth_file.resolve()),
             output_dir=out_dir,
             lat_deg=lat_deg,
             lon_deg=lon_deg,
-            q_b2n=q_b2n,
+            gnss_file=str(gnss_path),
+            q_b2n_const=q_b2n_const,
         )
+
+        # Methods overlay (auto-discover peer files if present)
+        method_files = {}
+        triad_path = kf_output_file
+        davenport_path = triad_path.replace("TRIAD", "Davenport")
+        svd_path = triad_path.replace("TRIAD", "SVD")
+        for name, p in [("TRIAD", triad_path), ("Davenport", davenport_path), ("SVD", svd_path)]:
+            if os.path.isfile(p):
+                method_files[name] = p
+        if method_files:
+            run_task6_compare_methods_all_frames(
+                method_files=method_files,
+                truth_file=str(truth_file.resolve()),
+                output_dir=out_dir,
+                lat_deg=lat_deg,
+                lon_deg=lon_deg,
+                gnss_file=str(gnss_path),
+                q_b2n_const=q_b2n_const,
+            )
 
     # ----------------------------
     # Task 7: Evaluation

--- a/PYTHON/src/task6_overlay_all_frames.py
+++ b/PYTHON/src/task6_overlay_all_frames.py
@@ -1,313 +1,451 @@
-import os, json, math, numpy as np
-import scipy.io as sio
+"""Helpers for Task 6 overlay plots across multiple reference frames.
+
+The functions in this module operate purely on static matplotlib plots to
+avoid importing the heavier interactive plotting stack unless explicitly
+requested elsewhere.  They provide utilities to load estimator outputs and
+truth files, perform basic frame conversions and generate consistent overlay
+figures for NED, ECEF and BODY frames.
+"""
+
+from __future__ import annotations
+
+import json
+import os
 from pathlib import Path
+from typing import Dict, Tuple, Optional
+
+import numpy as np
+import pandas as pd
+import scipy.io as sio
 import matplotlib.pyplot as plt
-from typing import Tuple, Dict
 
 
-def _ensure_dir(p: Path):
-    p.mkdir(parents=True, exist_ok=True)
-
-
-def _to_np(a):
-    return np.asarray(a)
+# ---------------------------------------------------------------------------
+# Data loading helpers
+# ---------------------------------------------------------------------------
 
 
 def load_estimates(est_file: str) -> Dict[str, np.ndarray]:
+    """Load estimator output from ``.mat`` or ``.npz`` files.
+
+    The loader accepts a range of key names to cope with slightly differing
+    conventions.  Returned arrays are converted to :class:`numpy.ndarray`
+    instances.  Time is expected to be one-dimensional.
     """
-    Load estimator output from .mat or .npz
-    Expected keys (if present):
-      t, time, pos_ned, vel_ned, acc_ned, pos_ecef, vel_ecef, acc_ecef,
-      pos_body, vel_body, acc_body
-    Return dict with as many of these as found. Arrays shape (N,3); time (N,).
-    """
+
     p = Path(est_file)
-    if p.suffix == '.npz':
-        d = dict(np.load(p))
+    if p.suffix == ".npz":
+        data = dict(np.load(p))
     else:
-        d = {k: v for k, v in sio.loadmat(p, squeeze_me=True).items() if not k.startswith('__')}
+        data = {
+            k: v
+            for k, v in sio.loadmat(p, squeeze_me=True).items()
+            if not k.startswith("__")
+        }
+
     def pick(*names):
         for n in names:
-            if n in d:
-                x = _to_np(d[n])
-                return x
+            if n in data:
+                return np.asarray(data[n])
         return None
-    time = pick('t','time','Time','TIME','time_s','t_est')
-    out = {
-        'time': time,
-        'pos_ned': pick('pos_ned','posNED','position_ned','pos_ned_m'),
-        'vel_ned': pick('vel_ned','velNED','velocity_ned','vel_ned_ms'),
-        'acc_ned': pick('acc_ned','accNED','acceleration_ned','acc_ned_ms'),
-        'pos_ecef': pick('pos_ecef','posECEF','position_ecef','pos_ecef_m'),
-        'vel_ecef': pick('vel_ecef','velECEF','velocity_ecef','vel_ecef_ms'),
-        'acc_ecef': pick('acc_ecef','accECEF','acceleration_ecef','acc_ecef_ms'),
-        'pos_body': pick('pos_body','posBODY','pos_body_m'),
-        'vel_body': pick('vel_body','velBODY','vel_body_ms'),
-        'acc_body': pick('acc_body','accBODY','acc_body_ms'),
+
+    out: Dict[str, np.ndarray] = {
+        "time": pick("time", "t"),
+        "pos_ned": pick("pos_ned"),
+        "vel_ned": pick("vel_ned"),
+        "acc_ned": pick("acc_ned"),
+        "pos_ecef": pick("pos_ecef"),
+        "vel_ecef": pick("vel_ecef"),
+        "acc_ecef": pick("acc_ecef"),
+        "pos_body": pick("pos_body"),
+        "vel_body": pick("vel_body"),
+        "acc_body": pick("acc_body"),
+        "q_b2n": pick("q_b2n", "quat_b2n"),
     }
     return out
 
 
-def load_truth_truthfile(truth_file: str) -> Dict[str, np.ndarray]:
-    """
-    Parse STATE_Xxxx.txt; support whitespace/csv with headers containing:
-      time, pos_ecef_X/Y/Z, vel_ecef_X/Y/Z  (case-insensitive)
-      optionally *_ned_* columns.
-    Return dict with 'time', and as many of pos/vel in ECEF/NED as present.
-    """
-    import pandas as pd, numpy as np
+def load_truth(truth_file: str) -> Dict[str, np.ndarray]:
+    """Parse truth files ``STATE_X*.txt`` (CSV or whitespace separated)."""
+
+    out: Dict[str, np.ndarray] = {}
     try:
-        df = pd.read_csv(truth_file, sep=None, engine='python')
+        df = pd.read_csv(truth_file, sep=None, engine="python")
         cols = {c.lower(): c for c in df.columns}
-        def grab(prefix, frame):
-            key = {}
-            for k in ['x','y','z','n','e','d']:
-                for name in [f'{prefix}_{k}', f'{frame}_{k}', f'{prefix}_{frame}_{k}']:
-                    if name in cols:
-                        key[k] = cols[name]
-                        break
-            return key
-        out = {}
-        tcol = None
-        for cand in ['time','t','posix_time','sec','seconds']:
-            if cand in cols: tcol = cols[cand]; break
-        out['time'] = df[tcol].to_numpy() if tcol else np.arange(len(df))
-        ecef_map = {'x':None,'y':None,'z':None}
-        for k, pat in {'x':['pos_ecef_x','ecef_x','x_ecef','x_ecef_m','x'],'y':['pos_ecef_y','ecef_y','y_ecef','y_ecef_m','y'],'z':['pos_ecef_z','ecef_z','z_ecef','z_ecef_m','z']}.items():
-            for c in pat:
-                if c in cols: ecef_map[k]=cols[c]; break
-        if all(ecef_map.values()):
-            out['pos_ecef'] = df[[ecef_map['x'],ecef_map['y'],ecef_map['z']]].to_numpy()
-        vel_map = {'x':None,'y':None,'z':None}
-        for k, pat in {'x':['vel_ecef_x','vx_ecef','ecef_vx','vx','vx_ecef_mps'],'y':['vel_ecef_y','vy_ecef','ecef_vy','vy','vy_ecef_mps'],'z':['vel_ecef_z','vz_ecef','ecef_vz','vz','vz_ecef_mps']}.items():
-            for c in pat:
-                if c in cols: vel_map[k]=cols[c]; break
-        if all(vel_map.values()):
-            out['vel_ecef'] = df[[vel_map['x'],vel_map['y'],vel_map['z']]].to_numpy()
-        ned_map = {'n':None,'e':None,'d':None}
-        for k, pat in {'n':['pos_n','ned_n','north'],'e':['pos_e','ned_e','east'],'d':['pos_d','ned_d','down']}.items():
-            for c in pat:
-                if c in cols: ned_map[k]=cols[c]; break
-        if all(ned_map.values()):
-            out['pos_ned'] = df[[ned_map['n'],ned_map['e'],ned_map['d']]].to_numpy()
+
+        def trip(prefix: str, keys: Tuple[str, str, str]) -> Optional[np.ndarray]:
+            names = [f"{prefix}_{k}" for k in keys]
+            if all(n in cols for n in names):
+                return df[[cols[n] for n in names]].to_numpy()
+            return None
+
+        tcol = cols.get("time") or cols.get("t")
+        out["time"] = df[tcol].to_numpy() if tcol else np.arange(len(df))
+        out["pos_ecef"] = trip("pos_ecef", ("x", "y", "z"))
+        out["vel_ecef"] = trip("vel_ecef", ("x", "y", "z"))
+        out["pos_ned"] = trip("pos_ned", ("n", "e", "d"))
+        out["vel_ned"] = trip("vel_ned", ("n", "e", "d"))
         return out
     except Exception:
-        pass
-    arr = np.loadtxt(truth_file, comments='#')
-    out = {'time': arr[:,1]}
-    if arr.shape[1] >= 8:
-        out['pos_ecef'] = arr[:,2:5]
-        out['vel_ecef'] = arr[:,5:8]
-    return out
-
-# --- Frame helpers ---
-def R_ecef_to_ned(lat_rad: float, lon_rad: float) -> np.ndarray:
-    sL, cL = np.sin(lat_rad), np.cos(lat_rad)
-    sO, cO = np.sin(lon_rad), np.cos(lon_rad)
-    # NED-from-ECEF (3x3)
-    return np.array([[-sL*cO, -sL*sO,  cL],
-                     [   -sO,     cO, 0.0],
-                     [-cL*cO, -cL*sO, -sL]])
+        arr = np.loadtxt(truth_file)
+        out["time"] = arr[:, 0]
+        if arr.shape[1] >= 7:
+            out["pos_ecef"] = arr[:, 1:4]
+            out["vel_ecef"] = arr[:, 4:7]
+        return out
 
 
-def quat_to_dcm(qw,qx,qy,qz):
-    # body->NED DCM from quaternion (qw,qx,qy,qz)
-    q0,q1,q2,q3 = qw,qx,qy,qz
-    R = np.array([
-        [1-2*(q2*q2+q3*q3), 2*(q1*q2 - q0*q3), 2*(q1*q3 + q0*q2)],
-        [2*(q1*q2 + q0*q3), 1-2*(q1*q1+q3*q3), 2*(q2*q3 - q0*q1)],
-        [2*(q1*q3 - q0*q2), 2*(q2*q3 + q0*q1), 1-2*(q1*q1+q2*q2)]
-    ])
-    return R
+def load_lat_lon_from_gnss(gnss_csv: str | None) -> Tuple[Optional[float], Optional[float]]:
+    """Return average latitude/longitude from a GNSS CSV file."""
+
+    if not gnss_csv:
+        return None, None
+    try:
+        df = pd.read_csv(gnss_csv)
+        lat = df["Latitude_deg"].mean() if "Latitude_deg" in df.columns else None
+        lon = df["Longitude_deg"].mean() if "Longitude_deg" in df.columns else None
+        return float(lat) if lat is not None else None, float(lon) if lon is not None else None
+    except Exception:  # pragma: no cover - best effort
+        return None, None
 
 
-def ned_to_body(v_ned: np.ndarray, q_b2n: Tuple[float,float,float,float]) -> np.ndarray:
-    Rb2n = quat_to_dcm(*q_b2n)
-    Rn2b = Rb2n.T
-    return (Rn2b @ v_ned.T).T
+# ---------------------------------------------------------------------------
+# Frame helpers
+# ---------------------------------------------------------------------------
 
 
-def ecef_to_ned_vec(v_ecef: np.ndarray, lat_rad: float, lon_rad: float) -> np.ndarray:
-    R = R_ecef_to_ned(lat_rad, lon_rad)
+def R_ecef_to_ned(lat_deg: float, lon_deg: float) -> np.ndarray:
+    lat = np.deg2rad(lat_deg)
+    lon = np.deg2rad(lon_deg)
+    sL, cL = np.sin(lat), np.cos(lat)
+    sO, cO = np.sin(lon), np.cos(lon)
+    return np.array(
+        [
+            [-sL * cO, -sL * sO, cL],
+            [-sO, cO, 0.0],
+            [-cL * cO, -cL * sO, -sL],
+        ]
+    )
+
+
+def ecef_to_ned_vec(v_ecef: np.ndarray, lat_deg: float, lon_deg: float) -> np.ndarray:
+    R = R_ecef_to_ned(lat_deg, lon_deg)
     return (R @ v_ecef.T).T
 
 
-def ned_to_ecef_vec(v_ned: np.ndarray, lat_rad: float, lon_rad: float) -> np.ndarray:
-    R = R_ecef_to_ned(lat_rad, lon_rad)
+def ned_to_ecef_vec(v_ned: np.ndarray, lat_deg: float, lon_deg: float) -> np.ndarray:
+    R = R_ecef_to_ned(lat_deg, lon_deg)
     return (R.T @ v_ned.T).T
 
 
-def interp_to(t_src, X_src, t_dst):
-    # piecewise linear per column
-    X_src = np.asarray(X_src)
-    out = np.zeros((len(t_dst), X_src.shape[1]))
-    for i in range(X_src.shape[1]):
-        out[:,i] = np.interp(t_dst, t_src, X_src[:,i])
+def quat_to_dcm(qw: float, qx: float, qy: float, qz: float) -> np.ndarray:
+    """Quaternion (body->NED) to direction cosine matrix."""
+
+    q0, q1, q2, q3 = qw, qx, qy, qz
+    return np.array(
+        [
+            [1 - 2 * (q2 * q2 + q3 * q3), 2 * (q1 * q2 - q0 * q3), 2 * (q1 * q3 + q0 * q2)],
+            [2 * (q1 * q2 + q0 * q3), 1 - 2 * (q1 * q1 + q3 * q3), 2 * (q2 * q3 - q0 * q1)],
+            [2 * (q1 * q3 - q0 * q2), 2 * (q2 * q3 + q0 * q1), 1 - 2 * (q1 * q1 + q2 * q2)],
+        ]
+    )
+
+
+def ned_to_body(v_ned: np.ndarray, q_b2n: np.ndarray | Tuple[float, float, float, float]) -> np.ndarray:
+    """Rotate NED vectors into the body frame.
+
+    ``q_b2n`` may be a constant quaternion or an array of shape (N,4) providing a
+    quaternion per sample.  In both cases the returned array matches the shape of
+    ``v_ned``.
+    """
+
+    v = np.asarray(v_ned)
+    q = np.asarray(q_b2n)
+    if q.ndim == 1:
+        Rb2n = quat_to_dcm(*q)
+        Rn2b = Rb2n.T
+        return (Rn2b @ v.T).T
+    out = np.zeros_like(v)
+    for i in range(len(v)):
+        Rb2n = quat_to_dcm(*q[i])
+        out[i] = Rb2n.T @ v[i]
     return out
 
 
-def plot_overlay_3x3(time, est_xyz, truth_xyz, title, ylabels, outfile):
-    import matplotlib.pyplot as plt
-    fig, axes = plt.subplots(3,3, figsize=(16,10), sharex=True)
-    comps = ['X','Y','Z']
-    for r,yl in enumerate(ylabels):
-        est_block = est_xyz[r] if est_xyz[r] is not None else np.zeros((len(time),3))
-        truth_block = truth_xyz[r] if truth_xyz[r] is not None else np.zeros((len(time),3))
-        for c in range(3):
-            ax = axes[r,c]
-            ax.plot(time, est_block[:,c], label='Estimated', linewidth=1.2)
-            ax.plot(time, truth_block[:,c], linestyle='--', label='Truth', linewidth=1.0)
-            ax.set_ylabel(f'{yl} {comps[c]}')
-            if r==0: ax.set_title(['Position','Velocity','Acceleration'][c] if False else comps[c])
-            if r==2: ax.set_xlabel('Time [s]')
-            ax.grid(True, alpha=0.3)
-    # Better titles
-    axes[0,0].set_title('Position')
-    axes[0,1].set_title('Velocity')
-    axes[0,2].set_title('Acceleration')
-    handles, labels = axes[0,0].get_legend_handles_labels()
-    fig.legend(handles, labels, ncol=2, loc='upper center')
+# ---------------------------------------------------------------------------
+# Misc helpers
+# ---------------------------------------------------------------------------
+
+
+def interp_to(t_src: np.ndarray, X_src: np.ndarray, t_dst: np.ndarray) -> np.ndarray:
+    """Piecewise-linear interpolation column-wise."""
+
+    X_src = np.asarray(X_src)
+    out = np.zeros((len(t_dst), X_src.shape[1]))
+    for i in range(X_src.shape[1]):
+        out[:, i] = np.interp(t_dst, t_src, X_src[:, i])
+    return out
+
+
+def plot_overlay_3x3(
+    time: np.ndarray,
+    est_triplet: Tuple[Optional[np.ndarray], Optional[np.ndarray], Optional[np.ndarray]],
+    tru_triplet: Tuple[Optional[np.ndarray], Optional[np.ndarray], Optional[np.ndarray]],
+    title: str,
+    outfile: str | Path,
+) -> None:
+    """Create a 3x3 overlay figure comparing estimate and truth."""
+
+    comps = ["X", "Y", "Z"]
+    ylabels = ["Position [m]", "Velocity [m/s]", "Acceleration [m/s²]"]
+    fig, axes = plt.subplots(3, 3, figsize=(12, 9), sharex=True)
+    for j in range(3):  # columns: pos/vel/acc
+        est = est_triplet[j]
+        tru = tru_triplet[j]
+        for i in range(3):  # rows: components
+            ax = axes[i, j]
+            if est is not None:
+                ax.plot(time, est[:, i], label="Estimated" if (i == 0 and j == 0) else None, linewidth=1.2)
+            if tru is not None:
+                ax.plot(
+                    time,
+                    tru[:, i],
+                    linestyle="--",
+                    label="Truth" if (i == 0 and j == 0) else None,
+                    linewidth=1.0,
+                )
+            if j == 0:
+                ax.set_ylabel(f"{comps[i]} {ylabels[j]}")
+            if i == 2:
+                ax.set_xlabel("Time [s]")
+            ax.grid(alpha=0.3)
+    axes[0, 0].set_title("Position")
+    axes[0, 1].set_title("Velocity")
+    axes[0, 2].set_title("Acceleration")
+    handles, labels = axes[0, 0].get_legend_handles_labels()
+    if handles:
+        fig.legend(handles, labels, ncol=3, loc="upper center")
     fig.suptitle(title)
-    fig.tight_layout(rect=[0,0,1,0.95])
+    fig.tight_layout(rect=[0, 0, 1, 0.92])
     fig.savefig(outfile, dpi=150)
     plt.close(fig)
 
 
-def run_task6_overlay_all_frames(est_file: str, truth_file: str, output_dir: str,
-                                 lat_deg: float = None, lon_deg: float = None,
-                                 q_b2n: Tuple[float,float,float,float] = None):
-    """
-    - est_file: kf output .mat/.npz with at least NED series
-    - truth_file: STATE file with ECEF and/or NED
-    - lat/lon: if None, read from GNSS_X*.csv later (caller provides); otherwise use.
-    - q_b2n: constant body->NED quaternion from Task 3 (if None, assume [1,0,0,0]).
-    Saves three PNGs:
-      {run}/task6/{run}_task6_overlay_NED.png
-      {run}/task6/{run}_task6_overlay_ECEF.png
-      {run}/task6/{run}_task6_overlay_BODY.png
-    """
-    from pathlib import Path
-    outp = Path(output_dir); _ensure_dir(outp)
+def plot_methods_overlay_3x3(
+    time: np.ndarray,
+    methods_triplets: Dict[str, Tuple[Optional[np.ndarray], Optional[np.ndarray], Optional[np.ndarray]]],
+    tru_triplet: Tuple[Optional[np.ndarray], Optional[np.ndarray], Optional[np.ndarray]],
+    title: str,
+    outfile: str | Path,
+) -> None:
+    """Plot multiple methods against truth in a 3x3 grid."""
+
+    comps = ["X", "Y", "Z"]
+    ylabels = ["Position [m]", "Velocity [m/s]", "Acceleration [m/s²]"]
+    fig, axes = plt.subplots(3, 3, figsize=(12, 9), sharex=True)
+    for j in range(3):
+        tru = tru_triplet[j]
+        for i in range(3):
+            ax = axes[i, j]
+            for name, trip in methods_triplets.items():
+                est = trip[j]
+                if est is not None:
+                    ax.plot(time, est[:, i], label=name if (i == 0 and j == 0) else None, linewidth=1.2)
+            if tru is not None:
+                ax.plot(
+                    time,
+                    tru[:, i],
+                    linestyle="--",
+                    label="Truth" if (i == 0 and j == 0) else None,
+                    linewidth=1.0,
+                )
+            if j == 0:
+                ax.set_ylabel(f"{comps[i]} {ylabels[j]}")
+            if i == 2:
+                ax.set_xlabel("Time [s]")
+            ax.grid(alpha=0.3)
+    axes[0, 0].set_title("Position")
+    axes[0, 1].set_title("Velocity")
+    axes[0, 2].set_title("Acceleration")
+    handles, labels = axes[0, 0].get_legend_handles_labels()
+    if handles:
+        fig.legend(handles, labels, ncol=4, loc="upper center")
+    fig.suptitle(title)
+    fig.tight_layout(rect=[0, 0, 1, 0.92])
+    fig.savefig(outfile, dpi=150)
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# High-level runners
+# ---------------------------------------------------------------------------
+
+
+def _build_frames(data: Dict[str, np.ndarray], lat_deg: float | None, lon_deg: float | None, q_b2n: np.ndarray | Tuple[float, float, float, float] | None) -> Dict[str, Tuple[Optional[np.ndarray], Optional[np.ndarray], Optional[np.ndarray]]]:
+    """Construct NED, ECEF and BODY triplets from raw data."""
+
+    lat = lat_deg
+    lon = lon_deg
+    pos_ned = data.get("pos_ned")
+    vel_ned = data.get("vel_ned")
+    acc_ned = data.get("acc_ned")
+
+    if pos_ned is None and lat is not None and data.get("pos_ecef") is not None:
+        pos_ned = ecef_to_ned_vec(data["pos_ecef"], lat, lon)
+    if vel_ned is None and lat is not None and data.get("vel_ecef") is not None:
+        vel_ned = ecef_to_ned_vec(data["vel_ecef"], lat, lon)
+    if acc_ned is None and lat is not None and data.get("acc_ecef") is not None:
+        acc_ned = ecef_to_ned_vec(data["acc_ecef"], lat, lon)
+
+    pos_ecef = data.get("pos_ecef")
+    vel_ecef = data.get("vel_ecef")
+    acc_ecef = data.get("acc_ecef")
+    if pos_ecef is None and lat is not None and pos_ned is not None:
+        pos_ecef = ned_to_ecef_vec(pos_ned, lat, lon)
+    if vel_ecef is None and lat is not None and vel_ned is not None:
+        vel_ecef = ned_to_ecef_vec(vel_ned, lat, lon)
+    if acc_ecef is None and lat is not None and acc_ned is not None:
+        acc_ecef = ned_to_ecef_vec(acc_ned, lat, lon)
+
+    q = data.get("q_b2n")
+    if q is None:
+        q = q_b2n
+    if q is None:
+        q = (1.0, 0.0, 0.0, 0.0)
+    body = (
+        ned_to_body(pos_ned, q) if pos_ned is not None else None,
+        ned_to_body(vel_ned, q) if vel_ned is not None else None,
+        ned_to_body(acc_ned, q) if acc_ned is not None else None,
+    )
+
+    return {
+        "NED": (pos_ned, vel_ned, acc_ned),
+        "ECEF": (pos_ecef, vel_ecef, acc_ecef),
+        "BODY": body,
+    }
+
+
+def run_task6_overlay_all_frames(
+    est_file: str,
+    truth_file: str,
+    output_dir: str,
+    lat_deg: float | None = None,
+    lon_deg: float | None = None,
+    gnss_file: str | None = None,
+    q_b2n_const: Tuple[float, float, float, float] | None = None,
+) -> None:
+    """Generate single-method overlays for all frames."""
+
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    if (lat_deg is None or lon_deg is None) and gnss_file:
+        g_lat, g_lon = load_lat_lon_from_gnss(gnss_file)
+        lat_deg = lat_deg if lat_deg is not None else g_lat
+        lon_deg = lon_deg if lon_deg is not None else g_lon
 
     est = load_estimates(est_file)
-    tru = load_truth_truthfile(truth_file)
+    tru = load_truth(truth_file)
+    t = est.get("time")
+    if t is None:
+        raise ValueError("Estimator output lacks time array")
 
-    t = est.get('time')
-    if t is None: raise ValueError('Estimator output lacks time array.')
-    # Build NED for both
-    # Estimated: prefer provided; else convert from ECEF if present
-    pos_ned_est = est.get('pos_ned')
-    vel_ned_est = est.get('vel_ned')
-    acc_ned_est = est.get('acc_ned')
+    q = est.get("q_b2n") or q_b2n_const
+    frames_est = _build_frames(est, lat_deg, lon_deg, q)
+    frames_tru = _build_frames(tru, lat_deg, lon_deg, q)
+    t_truth = tru.get("time", t)
+    for trip in frames_tru.values():
+        for i in range(3):
+            if trip[i] is not None:
+                trip[i] = interp_to(t_truth, trip[i], t)
 
-    # If NED missing but ECEF present and lat/lon given, convert:
-    if (pos_ned_est is None or vel_ned_est is None) and est.get('pos_ecef') is not None and lat_deg is not None:
-        lat = np.deg2rad(lat_deg); lon = np.deg2rad(lon_deg)
-        if pos_ned_est is None: pos_ned_est = ecef_to_ned_vec(est['pos_ecef'], lat, lon)
-        if vel_ned_est is None and est.get('vel_ecef') is not None:
-            vel_ned_est = ecef_to_ned_vec(est['vel_ecef'], lat, lon)
-        if acc_ned_est is None and est.get('acc_ecef') is not None:
-            acc_ned_est = ecef_to_ned_vec(est['acc_ecef'], lat, lon)
+    manifest: Dict[str, str] = {}
+    for name in ["NED", "ECEF", "BODY"]:
+        est_trip = frames_est[name]
+        tru_trip = frames_tru[name]
+        if est_trip[0] is None or tru_trip[0] is None:
+            continue
+        out = out_dir / f"task6_overlay_{name}.png"
+        plot_overlay_3x3(t, est_trip, tru_trip, f"Task 6: Overlay ({name})", out)
+        manifest[f"task6_overlay_{name}"] = str(out.resolve())
 
-    # Truth: prefer NED; else from ECEF with lat/lon
-    pos_ned_tru = tru.get('pos_ned')
-    vel_ned_tru = tru.get('vel_ned')
-    acc_ned_tru = tru.get('acc_ned')  # optional; often missing
-    if pos_ned_tru is None and tru.get('pos_ecef') is not None and lat_deg is not None:
-        lat = np.deg2rad(lat_deg); lon = np.deg2rad(lon_deg)
-        pos_ned_tru = ecef_to_ned_vec(tru['pos_ecef'], lat, lon)
-        if tru.get('vel_ecef') is not None:
-            vel_ned_tru = ecef_to_ned_vec(tru['vel_ecef'], lat, lon)
+    manifest_path = out_dir / "task6_overlay_manifest.json"
+    with manifest_path.open("w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2)
 
-    # Interpolate truth to estimator timebase
-    t_tru = tru.get('time')
-    if t_tru is None: t_tru = t
-    if pos_ned_tru is not None:
-        pos_ned_tru = interp_to(t_tru, pos_ned_tru, t)
-    if vel_ned_tru is not None:
-        vel_ned_tru = interp_to(t_tru, vel_ned_tru, t)
-    if acc_ned_tru is not None:
-        acc_ned_tru = interp_to(t_tru, acc_ned_tru, t)
-    pos_ecef_tru = tru.get('pos_ecef')
-    vel_ecef_tru = tru.get('vel_ecef')
-    acc_ecef_tru = tru.get('acc_ecef')
-    if pos_ecef_tru is not None:
-        pos_ecef_tru = interp_to(t_tru, pos_ecef_tru, t)
-    if vel_ecef_tru is not None:
-        vel_ecef_tru = interp_to(t_tru, vel_ecef_tru, t)
-    if acc_ecef_tru is not None:
-        acc_ecef_tru = interp_to(t_tru, acc_ecef_tru, t)
 
-    # BODY frame using constant q_b2n (from Task 3 TRIAD by default)
-    if q_b2n is None: q_b2n = (1.0,0.0,0.0,0.0)
-    def to_body(Pn, Vn, An):
-        Pb = ned_to_body(Pn, q_b2n) if Pn is not None else None
-        Vb = ned_to_body(Vn, q_b2n) if Vn is not None else None
-        Ab = ned_to_body(An, q_b2n) if An is not None else None
-        return Pb, Vb, Ab
+def run_task6_compare_methods_all_frames(
+    method_files: Dict[str, str],
+    truth_file: str,
+    output_dir: str,
+    lat_deg: float | None = None,
+    lon_deg: float | None = None,
+    gnss_file: str | None = None,
+    q_b2n_const: Tuple[float, float, float, float] | None = None,
+) -> None:
+    """Overlay multiple methods against truth for all frames."""
 
-    # ECEF frame: if not provided, convert from NED using lat/lon
-    def ensure_ecef(Pn, Vn, An):
-        if Pn is None: return None, None, None
-        lat = np.deg2rad(lat_deg); lon = np.deg2rad(lon_deg)
-        Pe = ned_to_ecef_vec(Pn, lat, lon)
-        Ve = ned_to_ecef_vec(Vn, lat, lon) if Vn is not None else None
-        Ae = ned_to_ecef_vec(An, lat, lon) if An is not None else None
-        return Pe, Ve, Ae
+    if not method_files:
+        return
 
-    # --- Build per-frame triplets (pos, vel, acc) for est and truth ---
-    # NED
-    NED_est = (pos_ned_est, vel_ned_est, acc_ned_est)
-    NED_tru = (pos_ned_tru, vel_ned_tru, acc_ned_tru)
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
 
-    # BODY
-    BODY_est = to_body(*NED_est)
-    BODY_tru = to_body(*NED_tru)
+    if (lat_deg is None or lon_deg is None) and gnss_file:
+        g_lat, g_lon = load_lat_lon_from_gnss(gnss_file)
+        lat_deg = lat_deg if lat_deg is not None else g_lat
+        lon_deg = lon_deg if lon_deg is not None else g_lon
 
-    # ECEF
-    if lat_deg is None or lon_deg is None:
-        raise ValueError('lat_deg/lon_deg required to produce ECEF overlays when only NED is available.')
-    ECEF_est = (est.get('pos_ecef'), est.get('vel_ecef'), est.get('acc_ecef'))
-    ECEF_tru = (pos_ecef_tru, vel_ecef_tru, acc_ecef_tru)
-    if ECEF_est[0] is None and NED_est[0] is not None:
-        ECEF_est = ensure_ecef(*NED_est)
-    if ECEF_tru[0] is None and NED_tru[0] is not None:
-        ECEF_tru = ensure_ecef(*NED_tru)
+    truth = load_truth(truth_file)
 
-    # --- Plot ---
-    # Wrap in lists for plotting helper: [pos, vel, acc]
-    def pack(trip):
-        return [trip[0], trip[1], trip[2]]
+    # Choose the first method as timebase
+    first_path = next(iter(method_files.values()))
+    base = load_estimates(first_path)
+    t_base = base.get("time")
+    if t_base is None:
+        raise ValueError("Estimator output lacks time array")
 
-    # NED
-    if NED_est[0] is not None and NED_tru[0] is not None:
-        plot_overlay_3x3(
-            t,
-            [NED_est[0], NED_est[1], NED_est[2]],
-            [NED_tru[0], NED_tru[1], NED_tru[2]],
-            title='Task 6: Overlay (NED)',
-            ylabels=['Pos [m]','Vel [m/s]','Acc [m/s²]'],
-            outfile=str(Path(output_dir)/'task6_overlay_NED.png')
+    q_base = base.get("q_b2n") or q_b2n_const
+    frames_truth = _build_frames(truth, lat_deg, lon_deg, q_base)
+    t_truth = truth.get("time", t_base)
+    for trip in frames_truth.values():
+        for i in range(3):
+            if trip[i] is not None:
+                trip[i] = interp_to(t_truth, trip[i], t_base)
+
+    methods_frames: Dict[str, Dict[str, Tuple[Optional[np.ndarray], Optional[np.ndarray], Optional[np.ndarray]]]] = {}
+    for name, path in method_files.items():
+        est = load_estimates(path)
+        t_est = est.get("time")
+        if t_est is None:
+            continue
+        q_m = est.get("q_b2n") or q_base
+        frames = _build_frames(est, lat_deg, lon_deg, q_m)
+        for trip in frames.values():
+            for i in range(3):
+                if trip[i] is not None:
+                    trip[i] = interp_to(t_est, trip[i], t_base)
+        methods_frames[name] = frames
+
+    manifest_path = out_dir / "task6_overlay_manifest.json"
+    manifest = {}
+    if manifest_path.exists():
+        manifest = json.loads(manifest_path.read_text())
+
+    for frame in ["NED", "ECEF", "BODY"]:
+        methods_triplets = {m: f[frame] for m, f in methods_frames.items() if f[frame][0] is not None}
+        if not methods_triplets:
+            continue
+        out = out_dir / f"task6_methods_overlay_{frame}.png"
+        plot_methods_overlay_3x3(
+            t_base,
+            methods_triplets,
+            frames_truth[frame],
+            f"Task 6: Methods Overlay ({frame})",
+            out,
         )
-    # ECEF
-    if ECEF_est[0] is not None and ECEF_tru[0] is not None:
-        plot_overlay_3x3(
-            t,
-            [ECEF_est[0], ECEF_est[1], ECEF_est[2]],
-            [ECEF_tru[0], ECEF_tru[1], ECEF_tru[2]],
-            title='Task 6: Overlay (ECEF)',
-            ylabels=['Pos [m]','Vel [m/s]','Acc [m/s²]'],
-            outfile=str(Path(output_dir)/'task6_overlay_ECEF.png')
-        )
-    # BODY
-    if BODY_est[0] is not None and BODY_tru[0] is not None:
-        plot_overlay_3x3(
-            t,
-            [BODY_est[0], BODY_est[1], BODY_est[2]],
-            [BODY_tru[0], BODY_tru[1], BODY_tru[2]],
-            title='Task 6: Overlay (BODY)',
-            ylabels=['Pos [m]','Vel [m/s]','Acc [m/s²]'],
-            outfile=str(Path(output_dir)/'task6_overlay_BODY.png')
-        )
+        manifest[f"task6_methods_overlay_{frame}"] = str(out.resolve())
 
-    return True
+    with manifest_path.open("w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2)
+

--- a/PYTHON/src/task6_plot_truth.py
+++ b/PYTHON/src/task6_plot_truth.py
@@ -3,11 +3,9 @@
 
 import argparse
 from pathlib import Path
-from typing import Tuple
+from typing import Dict, Tuple, Optional
 
-from task6_overlay_all_frames import run_task6_overlay_all_frames
-
-try:
+try:  # pragma: no cover - optional helper
     from utils.run_id import run_id as build_run_id
 except Exception:  # pragma: no cover
     build_run_id = None  # type: ignore
@@ -16,7 +14,7 @@ except Exception:  # pragma: no cover
 def parse_qbody(qstr: str | None) -> Tuple[float, float, float, float] | None:
     if not qstr:
         return None
-    parts = [float(p) for p in qstr.split(',')]
+    parts = [float(p) for p in qstr.split(",")]
     if len(parts) != 4:
         raise ValueError("--qbody must provide four comma-separated values")
     return tuple(parts)  # type: ignore
@@ -26,25 +24,35 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Task 6 overlay helper")
     parser.add_argument("--est-file", required=True, help="KF output .mat/.npz file")
     parser.add_argument("--truth-file", required=True, help="STATE_X file")
+    parser.add_argument("--gnss-file", help="GNSS CSV for lat/lon fallback")
     parser.add_argument("--lat", type=float, help="Latitude in degrees")
     parser.add_argument("--lon", type=float, help="Longitude in degrees")
     parser.add_argument("--qbody", type=str, help="Body->NED quaternion qw,qx,qy,qz")
+    parser.add_argument("--triad-file", help="TRIAD estimator output for comparison")
+    parser.add_argument("--davenport-file", help="Davenport estimator output")
+    parser.add_argument("--svd-file", help="SVD estimator output")
+    parser.add_argument("--run-id", help="Override run identifier")
     args = parser.parse_args()
 
     est_path = Path(args.est_file)
-    run_id_str = None
-    if build_run_id is not None:
+    run_id_str: Optional[str] = args.run_id
+    if run_id_str is None and build_run_id is not None:
         try:
             run_id_str = build_run_id(est_path.stem)
         except Exception:
             run_id_str = None
     if run_id_str is None:
-        run_id_str = est_path.stem.replace('_kf_output', '')
+        run_id_str = est_path.stem
 
     output_dir = Path("results") / run_id_str / "task6"
     output_dir.mkdir(parents=True, exist_ok=True)
 
     qbody_tuple = parse_qbody(args.qbody)
+
+    from task6_overlay_all_frames import (
+        run_task6_overlay_all_frames,
+        run_task6_compare_methods_all_frames,
+    )
 
     run_task6_overlay_all_frames(
         est_file=str(est_path),
@@ -52,12 +60,46 @@ def main() -> None:
         output_dir=str(output_dir),
         lat_deg=args.lat,
         lon_deg=args.lon,
-        q_b2n=qbody_tuple,
+        gnss_file=args.gnss_file,
+        q_b2n_const=qbody_tuple,
     )
+
+    # Build method file mapping
+    method_files: Dict[str, str] = {}
+    if args.triad_file:
+        method_files["TRIAD"] = args.triad_file
+    if args.davenport_file:
+        method_files["Davenport"] = args.davenport_file
+    if args.svd_file:
+        method_files["SVD"] = args.svd_file
+
+    if not method_files:
+        triad_path = Path(args.est_file)
+        davenport_path = triad_path.with_name(triad_path.name.replace("TRIAD", "Davenport"))
+        svd_path = triad_path.with_name(triad_path.name.replace("TRIAD", "SVD"))
+        for name, p in [("TRIAD", triad_path), ("Davenport", davenport_path), ("SVD", svd_path)]:
+            if p.exists():
+                method_files[name] = str(p)
+
+    if method_files:
+        run_task6_compare_methods_all_frames(
+            method_files=method_files,
+            truth_file=args.truth_file,
+            output_dir=str(output_dir),
+            lat_deg=args.lat,
+            lon_deg=args.lon,
+            gnss_file=args.gnss_file,
+            q_b2n_const=qbody_tuple,
+        )
 
     print(output_dir / "task6_overlay_NED.png")
     print(output_dir / "task6_overlay_ECEF.png")
     print(output_dir / "task6_overlay_BODY.png")
+    if method_files:
+        print(output_dir / "task6_methods_overlay_NED.png")
+        print(output_dir / "task6_methods_overlay_ECEF.png")
+        print(output_dir / "task6_methods_overlay_BODY.png")
+    print(output_dir / "task6_overlay_manifest.json")
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- Lazily import interactive plotting to avoid crashes when Plotly isn't installed
- Add comprehensive Task 6 frame overlay helpers and CLI wrapper
- Hook Task 6 overlays directly into run_triad_only

## Testing
- `python -m py_compile PYTHON/src/plot_overlay.py PYTHON/src/task6_overlay_all_frames.py PYTHON/src/task6_plot_truth.py PYTHON/src/run_triad_only.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'src')*


------
https://chatgpt.com/codex/tasks/task_e_689c36b04c508322ab0b750790581ad0