### PR TITLE
Fix Task 6 plot saving and add Task 2 visualization

### DIFF
--- a/PYTHON/src/GNSS_IMU_Fusion.py
+++ b/PYTHON/src/GNSS_IMU_Fusion.py
@@ -182,7 +182,9 @@ def plot_task1_map(imu_file: str, gnss_file: str, method: str) -> None:
             )
 
     tag = f"{dataset_label}_{method}_task1_location_map"
-    fig.savefig(PY_RES_DIR / f"{tag}.png", dpi=300)
+    out_path = PY_RES_DIR / f"{tag}.png"
+    fig.savefig(out_path, dpi=300)
+    logging.info("Task 1 plot saved to %s", out_path)
     plt.close(fig)
 
 
@@ -356,6 +358,7 @@ def main():
         static_start=args.static_start,
         static_end=args.static_end,
         mag_file=args.mag_file,
+        tag=tag,
     )
     logging.info(f"Estimated IMU dt: {dt_imu:.6f} s")
     logging.info(f"Gravity vector (body): {g_body}")

--- a/PYTHON/src/plot_overlay_interactive.py
+++ b/PYTHON/src/plot_overlay_interactive.py
@@ -278,11 +278,13 @@ def plot_overlay_interactive(
         
         try:
             # Save as PDF (requires kaleido)
-            pdf_file = html_file.with_suffix('.png')
+            pdf_file = html_file.with_suffix('.pdf')
             fig.write_image(str(pdf_file), width=1200, height=800, scale=2)
             print(f"Saved static PDF: {pdf_file}")
         except Exception as e:
-            print(f"Note: Could not save PDF (install kaleido for static export): {e}")
+            print(
+                f"Note: Could not save PDF (install kaleido for static export): {e}"
+            )
 
 
 def create_comparison_dashboard(


### PR DESCRIPTION
## Summary
- ensure task 6 overlay saves a PDF by using the correct suffix
- log task 1 map path when saved
- generate and save a static interval plot during task 2 processing

## Testing
- `python -m py_compile PYTHON/src/plot_overlay_interactive.py`
- `python -m py_compile PYTHON/src/task6_plot_truth.py`
- `python PYTHON/src/run_triad_only.py --include-small --dataset X001_small --truth DATA/Truth/STATE_X001_small.txt` *(fails: KeyboardInterrupt after long run, but intermediate log confirms task 1 and task 2 plots saved)*


------
https://chatgpt.com/codex/tasks/task_e_689c49a6ccd08322a00a1f1ea35dcec1