### PR TITLE
refactor: improve interactive overlay import and fix quoting

### DIFF
--- a/PYTHON/src/plot_overlay.py
+++ b/PYTHON/src/plot_overlay.py
@@ -7,15 +7,32 @@ import matplotlib.pyplot as plt
 
 
 def _plot_overlay_interactive_safe(*args, **kwargs):
-    try:
+    """Safely import and call :func:`plot_overlay_interactive`.
+
+    Plotly and its optional dependencies (such as Kaleido for static export)
+    are not required for the rest of this project, so we avoid importing them at
+    module load time.  Instead, this helper lazily imports the interactive
+    plotting backend when needed and provides a clear error message if the
+    dependencies are missing.
+    """
+
+    try:  # pragma: no cover - import-time failure is environment specific
         from plot_overlay_interactive import (
             PLOTLY_AVAILABLE,
             plot_overlay_interactive,
         )
-    except Exception as e:
-        raise RuntimeError(f"Interactive plotting not available: {e}")
-    if not PLOTLY_AVAILABLE:
-        raise RuntimeError("Plotly not available.")
+    except Exception as e:  # pragma: no cover - graceful degradation
+        raise RuntimeError(
+            "Interactive plotting requires Plotly and its extras. "
+            "Install them with `pip install plotly kaleido`."
+        ) from e
+
+    if not PLOTLY_AVAILABLE:  # pragma: no cover - runtime check
+        raise RuntimeError(
+            "Plotly is not available. Install it with `pip install plotly` to "
+            "enable interactive plotting."
+        )
+
     return plot_overlay_interactive(*args, **kwargs)
 
 

--- a/PYTHON/src/plot_overlay_interactive.py
+++ b/PYTHON/src/plot_overlay_interactive.py
@@ -270,7 +270,7 @@ def plot_overlay_interactive(
     if save_static:
         try:
             # Save as PNG (requires kaleido)
-            png_file = html_file.with_suffix('.png')
+            png_file = html_file.with_suffix(".png")
             fig.write_image(str(png_file), width=1200, height=800, scale=2)
             print(f"Saved static PNG: {png_file}")
         except Exception as e:
@@ -278,7 +278,7 @@ def plot_overlay_interactive(
         
         try:
             # Save as PDF (requires kaleido)
-            pdf_file = html_file.with_suffix('.pdf')
+            pdf_file = html_file.with_suffix(".pdf")
             fig.write_image(str(pdf_file), width=1200, height=800, scale=2)
             print(f"Saved static PDF: {pdf_file}")
         except Exception as e:


### PR DESCRIPTION
## Summary
- ensure static exports use standard quotes in `plot_overlay_interactive`
- add lazy import helper with friendly errors for interactive overlay

## Testing
- `PYTHONPATH=PYTHON pytest -q` *(fails: FileNotFoundError: tests/data/simple_truth.txt not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c74aca35c83228c91a2cbcf68f212