### PR TITLE
Stop saving Task1 HTML map

### DIFF
--- a/PYTHON/src/GNSS_IMU_Fusion.py
+++ b/PYTHON/src/GNSS_IMU_Fusion.py
@@ -285,9 +285,9 @@ def main():
         from task1_worldmap_png import save_task1_worldmap_png
         try:
             png_path = save_task1_worldmap_png(gnss_file, run_id, out_dir)
-            print(f"Task 1: saved world map PNG -> {png_path}")
+            print(f"Task 1: saved location map PNG -> {png_path}")
         except Exception as ex:
-            print(f"Task 1: world map PNG failed: {ex}")
+            print(f"Task 1: location map PNG failed: {ex}")
     else:
         logging.info("Skipping plot generation (--no-plots)")
 
@@ -1868,7 +1868,7 @@ def main():
 
     # Create plot summary
     summary = {
-        f"{run_id}_task1_worldmap.png": "Task 1 world map",
+        f"{run_id}_task1_location_map.png": "Task 1 location map",
         f"{tag}_task3_errors_comparison.pdf": "Attitude initialization error comparison",
         f"{tag}_task3_quaternions_comparison.pdf": "Quaternion components for initialization",
         f"{tag}_task4_comparison_ned.pdf": "GNSS vs IMU data in NED frame",

--- a/PYTHON/src/task1_worldmap_png.py
+++ b/PYTHON/src/task1_worldmap_png.py
@@ -115,7 +115,7 @@ def save_task1_worldmap_png(gnss_file: str, run_id: str, out_dir="PYTHON/results
     """Create one rectangular world map PNG with colored Earth, GNSS point, labels."""
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
-    out_png = out_dir / f"{run_id}_task1_worldmap.png"
+    out_png = out_dir / f"{run_id}_task1_location_map.png"
 
     # 1) Get lat/lon sequence, compute representative location
     latlon = _gnss_to_latlon_deg(gnss_file)
@@ -167,5 +167,5 @@ def save_task1_worldmap_png(gnss_file: str, run_id: str, out_dir="PYTHON/results
     fig.tight_layout()
     fig.savefig(out_png, dpi=150)
     plt.close(fig)
-    print(f"[Task1] Saved world map -> {out_png}")
+    print(f"[Task1] Saved location map -> {out_png}")
     return str(out_png)


### PR DESCRIPTION
## Summary
- Rename Task 1 world map output to `<run_id>_task1_location_map.png`.
- Update fusion script to log only the PNG location map and drop HTML references.

## Testing
- `pytest` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689c74ade9b8832280bf5fe14ed01cc5