### PR TITLE
Tune velocity noise handling and clarify ZUPT thresholds

### DIFF
--- a/PYTHON/src/GNSS_IMU_Fusion.py
+++ b/PYTHON/src/GNSS_IMU_Fusion.py
@@ -153,7 +153,7 @@ def main():
     parser.add_argument(
         "--vel-q-scale",
         type=float,
-        default=10.0,
+        default=1.0,
         help=(
             "Scale applied to velocity process noise block Q[3:6,3:6] "
             "(base 0.01 m^2/s^2)"
@@ -162,7 +162,7 @@ def main():
     parser.add_argument(
         "--vel-r",
         type=float,
-        default=0.25,
+        default=1.0,
         help=(
             "Diagonal variance for GNSS velocity measurements R[3:6,3:6] "
             "[m^2/s^2]"

--- a/PYTHON/src/fusion_single.py
+++ b/PYTHON/src/fusion_single.py
@@ -78,8 +78,12 @@ def main():
                         help='Additional process noise for velocity states')
     parser.add_argument('--pos_meas_noise', type=float, default=1.0,
                         help='Measurement noise for GNSS position')
-    parser.add_argument('--vel_meas_noise', type=float, default=1.0,
-                        help='Measurement noise for GNSS velocity')
+    parser.add_argument(
+        '--vel_meas_noise',
+        type=float,
+        default=3.0,
+        help='Measurement noise for GNSS velocity (std dev, m/s)',
+    )
     parser.add_argument('--static_window', type=int, default=400)
     parser.add_argument('--smoother', action='store_true')
     args = parser.parse_args()

--- a/PYTHON/src/gnss_imu_fusion/kalman.py
+++ b/PYTHON/src/gnss_imu_fusion/kalman.py
@@ -33,7 +33,9 @@ class GNSSIMUKalman:
         pos_proc_noise: float = 0.0,
         vel_proc_noise: float = 0.0,
         pos_meas_noise: float = 1.0,
-        vel_meas_noise: float = 1.0,
+        # Default GNSS velocity measurement noise standard deviation [m/s]
+        # Increased from 1.0 to 3.0 to down-weight noisy GNSS speed updates
+        vel_meas_noise: float = 3.0,
     ) -> None:
         self.gnss_weight = gnss_weight
         self.accel_noise = accel_noise

--- a/PYTHON/src/utils_legacy.py
+++ b/PYTHON/src/utils_legacy.py
@@ -80,14 +80,20 @@ def ensure_dependencies(requirements: Optional[pathlib.Path] = None) -> None:
         ])
 
 
-def detect_static_interval(accel_data, gyro_data, window_size=200,
-                           accel_var_thresh=0.01, gyro_var_thresh=1e-6,
-                           min_length=100):
+def detect_static_interval(
+    accel_data,
+    gyro_data,
+    window_size=200,
+    accel_var_thresh=0.01,
+    gyro_var_thresh=1e-6,
+    min_length=100,
+):
     """Find the longest static segment in the data using variance thresholding.
 
-    The search spans the entire dataset to locate the longest interval
-    where both accelerometer and gyroscope variances remain below the
-    specified thresholds.
+    The search spans the entire dataset to locate the longest interval where
+    both accelerometer and gyroscope variances remain below the specified
+    thresholds. The defaults are calibrated so zero-velocity updates fire
+    during genuine stationary periods without being overly sensitive to noise.
 
     Parameters
     ----------
@@ -143,8 +149,10 @@ def detect_static_interval(accel_data, gyro_data, window_size=200,
 
 def is_static(accel_win, gyro_win, accel_var_thresh=0.01, gyro_var_thresh=1e-6):
     """Check if the current IMU window is static."""
-    return (np.max(np.var(accel_win, axis=0)) < accel_var_thresh and
-            np.max(np.var(gyro_win, axis=0)) < gyro_var_thresh)
+    return (
+        np.max(np.var(accel_win, axis=0)) < accel_var_thresh
+        and np.max(np.var(gyro_win, axis=0)) < gyro_var_thresh
+    )
 
 # Additional utilities for logging and thresholding
 

--- a/docs/MATLAB/Task5_MATLAB.md
+++ b/docs/MATLAB/Task5_MATLAB.md
@@ -14,7 +14,7 @@ Default parameters:
 | `vel_proc_noise`    | `0.0` |
 | `pos_proc_noise`    | `0.0` |
 | `pos_meas_noise`    | `1.0` |
-| `vel_meas_noise`    | `1.0` |
+| `vel_meas_noise`    | `3.0` |
 | `accel_bias_noise`  | `1e-5` |
 | `gyro_bias_noise`   | `1e-5` |
 


### PR DESCRIPTION
## Summary
- Raise GNSS velocity measurement noise defaults and reduce velocity process noise scaling
- Expose higher GNSS velocity noise in `fusion_single` CLI
- Document zero-velocity thresholds and their role in `utils_legacy`
- Update MATLAB task documentation to reflect new velocity noise

## Testing
- `pytest PYTHON/tests/test_kalman_gravity.py PYTHON/tests/test_static_detection.py -q` with `PYTHONPATH=.`
- `PYTHONPATH=. python src/GNSS_IMU_Fusion.py --imu-file IMU_X001_small.dat --gnss-file GNSS_X001_small.csv --no-plots`

------
https://chatgpt.com/codex/tasks/task_e_689c74b0e3ac832282cf37514647e7c9