### PR TITLE
Skip zero latitude/longitude when plotting GNSS location

### DIFF
--- a/PYTHON/src/task1_worldmap_png.py
+++ b/PYTHON/src/task1_worldmap_png.py
@@ -81,7 +81,12 @@ def _gnss_to_latlon_deg(gnss_file: str) -> np.ndarray:
                 try:
                     lat = float(row["Latitude_deg"])
                     lon = float(row["Longitude_deg"])
-                    if np.isfinite(lat) and np.isfinite(lon):
+                    # Ignore obviously invalid zero-filled coordinates
+                    if (
+                        np.isfinite(lat)
+                        and np.isfinite(lon)
+                        and (abs(lat) > 1e-9 or abs(lon) > 1e-9)
+                    ):
                         latlon.append([lat, lon])
                 except Exception:
                     continue


### PR DESCRIPTION
## Summary
- Avoid using zero-filled Latitude/Longitude fields by falling back to ECEF-derived coordinates
- Filter out zero-valued GNSS points when building world map plots

## Testing
- `PYTHONPATH=PYTHON pytest PYTHON/tests/test_ecef_to_geodetic.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689c95ac8db0832288d96d00d8d8c805