### PR TITLE
Fix Task2 plots to use consistent timing and raw accelerometer data

### DIFF
--- a/PYTHON/src/gnss_imu_fusion/init.py
+++ b/PYTHON/src/gnss_imu_fusion/init.py
@@ -113,7 +113,8 @@ def measure_body_vectors(
     acc = data[:, 5:8]
 
     if len(time) > 1:
-        dt = float(np.mean(np.diff(time[:100])))
+        dt_candidates = np.diff(time[: min(400, len(time))])
+        dt = float(np.mean(dt_candidates[dt_candidates > 0]))
     else:
         dt = 1.0 / 400.0
     gyro /= dt
@@ -191,7 +192,7 @@ def measure_body_vectors(
 
     # Plot accelerometer and gyroscope norms with static interval highlighted
     try:
-        t = time - time[0]
+        t = np.arange(len(time)) * dt
         acc_norm = np.linalg.norm(acc, axis=1)
         gyro_norm = np.linalg.norm(gyro, axis=1)
         fig, ax = plt.subplots(2, 1, figsize=(10, 6), sharex=True)

--- a/PYTHON/src/task2_plot.py
+++ b/PYTHON/src/task2_plot.py
@@ -30,7 +30,16 @@ def save_task2_summary_png(
     time = imu_data[:, 1]
     gyro = imu_data[:, 2:5]
     acc = imu_data[:, 5:8]
-    t = time - time[0]
+
+    if len(time) > 1:
+        dt_candidates = np.diff(time[: min(400, len(time))])
+        dt = float(np.mean(dt_candidates[dt_candidates > 0]))
+    else:
+        dt = 1.0 / 400.0
+
+    t = np.arange(len(time)) * dt
+    gyro = gyro / dt
+    acc = acc / dt
     acc_norm = np.linalg.norm(acc, axis=1)
     gyro_norm = np.linalg.norm(gyro, axis=1)
 
@@ -81,8 +90,14 @@ def task2_measure_body_vectors(
         acc_cols = ["accel_x", "accel_y", "accel_z"]
         gyro_cols = ["gyro_x", "gyro_y", "gyro_z"]
         static_df = imu_data.iloc[start:end]
-        acc = static_df[acc_cols].to_numpy()
-        gyro = static_df[gyro_cols].to_numpy()
+        time = imu_data["time"].to_numpy()
+        if len(time) > 1:
+            dt_candidates = np.diff(time[: min(400, len(time))])
+            dt = float(np.mean(dt_candidates[dt_candidates > 0]))
+        else:
+            dt = 1.0 / 400.0
+        acc = static_df[acc_cols].to_numpy() / dt
+        gyro = static_df[gyro_cols].to_numpy() / dt
         g_body = -np.mean(acc, axis=0)
         omega_ie_body = np.mean(gyro, axis=0)
         acc_err = np.std(acc, axis=0)


### PR DESCRIPTION
## Summary
- Compute sample times and scale IMU data to rad/s and m/s^2 so static interval shading and accelerometer norm are correct
- Scale static-interval vectors before plotting to show actual gravity and Earth rotation values
- Use uniform time axis when plotting static interval in task2 pipeline

## Testing
- `PYTHONPATH=PYTHON pytest` *(fails: FileNotFoundError: tests/data/simple_truth.txt not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c9b8978008322a44f81510dd21d91