### PR TITLE
Place Task 3 quaternion legend at top right

### DIFF
--- a/PYTHON/GNSS_IMU_Fusion_Single_script.py
+++ b/PYTHON/GNSS_IMU_Fusion_Single_script.py
@@ -618,8 +618,8 @@ if q_truth is not None:
     ax.set_xticklabels(labels)
     ax.set_ylabel("Quaternion Component")
     ax.set_title("Task 3: Quaternion Comparison")
-    ax.legend()
-    plt.tight_layout()
+    ax.legend(loc="upper left", bbox_to_anchor=(1, 1))
+    fig.tight_layout()
     plt.savefig(RES_DIR / f"{TAG}_task3_errors_comparison.png")
     if INTERACTIVE:
         plt.show()

--- a/PYTHON/src/GNSS_IMU_Fusion.py
+++ b/PYTHON/src/GNSS_IMU_Fusion.py
@@ -160,8 +160,8 @@ def task3_plot_quaternions_and_errors(
     ax.set_ylabel("Quaternion Value")
     ax.set_ylim(-1, 1)
     ax.set_title("Task 3: Quaternion Components by Method and Case")
-    ax.legend(loc="best")
-    plt.tight_layout()
+    ax.legend(loc="upper left", bbox_to_anchor=(1, 1))
+    fig.tight_layout()
 
     quat_path = Path(output_dir) / f"{RUN_ID}_task3_quaternions_{timestamp}.png"
     plt.savefig(quat_path, dpi=200, bbox_inches="tight")


### PR DESCRIPTION
## Summary
- Position quaternion component plot legend outside the axes at the top-right so the bars can use full plotting area.
- Apply the same legend placement to the standalone Task 3 quaternion comparison plot.

## Testing
- `make test` *(fails: Multiple top-level packages discovered in a flat-layout)*

------
https://chatgpt.com/codex/tasks/task_e_689ca5bce8188322b0a0899386fff3da