### PR TITLE
Handle accelerometer outliers for Task 2

### DIFF
--- a/PYTHON/src/gnss_imu_fusion/init.py
+++ b/PYTHON/src/gnss_imu_fusion/init.py
@@ -122,17 +122,23 @@ def measure_body_vectors(
     gyro = butter_lowpass_filter(gyro)
     acc = butter_lowpass_filter(acc)
 
+    drop_n = int(1.0 / dt)
+    acc_trim = acc[drop_n:]
+    gyro_trim = gyro[drop_n:]
+
     if static_start is None:
         static_start, static_end = detect_static_interval(
-            acc,
-            gyro,
+            acc_trim,
+            gyro_trim,
             window_size=80,
             accel_var_thresh=0.01,
             gyro_var_thresh=1e-6,
             min_length=80,
         )
+        static_start += drop_n
+        static_end += drop_n
     else:
-        static_start = max(0, static_start)
+        static_start = max(drop_n, static_start)
         static_end = min(static_end or len(acc), len(acc))
     logging.info(
         "Static interval indices: %d to %d (%d samples)",

--- a/PYTHON/src/task2_plot.py
+++ b/PYTHON/src/task2_plot.py
@@ -46,7 +46,13 @@ def save_task2_summary_png(
     fig, axes = plt.subplots(2, 2, figsize=(10, 6))
 
     ax = axes[0, 0]
+    keep = t > 1.0
+    if np.any(keep):
+        p99 = np.nanpercentile(acc_norm[keep], 99.5)
+    else:
+        p99 = np.nanpercentile(acc_norm, 99.5)
     ax.plot(t, acc_norm)
+    ax.set_ylim(0, max(20, p99))
     ax.axvspan(t[static_start], t[static_end], color="red", alpha=0.3)
     ax.set_ylabel("|acc| [m/s²]")
     ax.set_title("Accelerometer norm")
@@ -130,7 +136,7 @@ def task2_measure_body_vectors(
     ax.set_xticklabels(labels, rotation=45, ha="right")
     ax.set_ylabel("Value")
     ax.set_title(
-        f"Task 2: Measured Vectors in Body Frame with Errors\nID: {plot_id}"
+        f"Task 2: Measured vectors in body frame\nID: {plot_id}"
     )
 
     for bar, val in zip(bars, values):


### PR DESCRIPTION
## Summary
- Clip accelerometer norm outliers for clearer Task 2 summary plots
- Drop initial corrupted samples before static interval detection
- Rename Task 2 vector bar chart for clarity

## Testing
- `PYTHONPATH=PYTHON pytest -q` *(fails: tests/data/simple_truth.txt not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ca5951cc48322adbc73773f44ba8f