### PR TITLE
Refine task 5 & 6 plot labeling

### DIFF
--- a/PYTHON/src/GNSS_IMU_Fusion.py
+++ b/PYTHON/src/GNSS_IMU_Fusion.py
@@ -1868,7 +1868,12 @@ def main():
         for j in range(3):
             ax = ax_ned_all[i, j]
             if i == 0:
-                ax.plot(t_rel_gnss, gnss_pos_ned[:, j], "k-", label="Measured GNSS")
+                ax.plot(
+                    t_rel_gnss,
+                    gnss_pos_ned[:, j],
+                    "k-",
+                    label="Derived GNSS (ECEF→NED)",
+                )
                 ax.plot(
                     t_rel_ilu,
                     fused_pos[method][:, j],
@@ -1880,7 +1885,12 @@ def main():
                     ax.plot(t_rel_ilu, truth_pos_ned_i[:, j], "m-", label="Truth")
                 ax.set_title(f"Position {dirs_ned[j]}")
             elif i == 1:
-                ax.plot(t_rel_gnss, gnss_vel_ned[:, j], "k-", label="Measured GNSS")
+                ax.plot(
+                    t_rel_gnss,
+                    gnss_vel_ned[:, j],
+                    "k-",
+                    label="Derived GNSS (ECEF→NED)",
+                )
                 ax.plot(
                     t_rel_ilu,
                     fused_vel[method][:, j],
@@ -1892,7 +1902,12 @@ def main():
                     ax.plot(t_rel_ilu, truth_vel_ned_i[:, j], "m-", label="Truth")
                 ax.set_title(f"Velocity V{dirs_ned[j]}")
             else:
-                ax.plot(t_rel_gnss, gnss_acc_ned[:, j], "k-", label="Measured GNSS")
+                ax.plot(
+                    t_rel_gnss,
+                    gnss_acc_ned[:, j],
+                    "k-",
+                    label="Derived GNSS (ECEF→NED)",
+                )
                 ax.plot(
                     t_rel_ilu,
                     fused_acc[method][:, j],
@@ -1904,7 +1919,9 @@ def main():
             ax.set_xlabel("Time (s)")
             ax.set_ylabel("Value")
             ax.legend(loc="best")
-    fig_ned_all.suptitle(f"Task 5 – {method} – NED Frame (Fused vs. Measured GNSS)")
+    fig_ned_all.suptitle(
+        f"Task 5 – {method} – NED Frame (Fused vs. Derived GNSS)"
+    )
     fig_ned_all.tight_layout(rect=[0, 0, 1, 0.95])
     if not args.no_plots:
         plt.savefig(f"results/{tag}_task5_all_ned.png", dpi=200, bbox_inches="tight")
@@ -1930,7 +1947,12 @@ def main():
         for j in range(3):
             ax = ax_ecef_all[i, j]
             if i == 0:
-                ax.plot(t_rel_gnss, gnss_pos_ecef[:, j], "k-", label="Measured GNSS")
+                ax.plot(
+                    t_rel_gnss,
+                    gnss_pos_ecef[:, j],
+                    "k-",
+                    label="Measured GNSS Position",
+                )
                 ax.plot(
                     t_rel_ilu,
                     pos_ecef[:, j],
@@ -1942,7 +1964,12 @@ def main():
                     ax.plot(t_rel_ilu, truth_pos_ecef_i[:, j], "m-", label="Truth")
                 ax.set_title(f"Position {dirs_ecef[j]}_ECEF")
             elif i == 1:
-                ax.plot(t_rel_gnss, gnss_vel_ecef[:, j], "k-", label="Measured GNSS")
+                ax.plot(
+                    t_rel_gnss,
+                    gnss_vel_ecef[:, j],
+                    "k-",
+                    label="Measured GNSS Velocity",
+                )
                 ax.plot(
                     t_rel_ilu,
                     vel_ecef[:, j],
@@ -1954,7 +1981,12 @@ def main():
                     ax.plot(t_rel_ilu, truth_vel_ecef_i[:, j], "m-", label="Truth")
                 ax.set_title(f"Velocity V{dirs_ecef[j]}_ECEF")
             else:
-                ax.plot(t_rel_gnss, gnss_acc_ecef[:, j], "k-", label="Derived GNSS")
+                ax.plot(
+                    t_rel_gnss,
+                    gnss_acc_ecef[:, j],
+                    "k-",
+                    label="Derived GNSS Acceleration",
+                )
                 ax.plot(
                     t_rel_ilu,
                     acc_ecef[:, j],
@@ -1966,7 +1998,9 @@ def main():
             ax.set_xlabel("Time (s)")
             ax.set_ylabel("Value")
             ax.legend(loc="best")
-    fig_ecef_all.suptitle(f"Task 5 – {method} – ECEF Frame (Fused vs. Measured GNSS)")
+    fig_ecef_all.suptitle(
+        f"Task 5 – {method} – ECEF Frame (Fused vs. Measured GNSS; Acc Derived)"
+    )
     fig_ecef_all.tight_layout(rect=[0, 0, 1, 0.95])
     if not args.no_plots:
         plt.savefig(f"results/{tag}_task5_all_ecef.png", dpi=200, bbox_inches="tight")
@@ -1990,7 +2024,12 @@ def main():
         for j in range(3):
             ax = ax_body_all[i, j]
             if i == 0:
-                ax.plot(t_rel_gnss, gnss_pos_body[:, j], "k-", label="Measured GNSS")
+                ax.plot(
+                    t_rel_gnss,
+                    gnss_pos_body[:, j],
+                    "k-",
+                    label="Derived GNSS",
+                )
                 ax.plot(
                     t_rel_ilu,
                     pos_body[:, j],
@@ -2002,7 +2041,12 @@ def main():
                     ax.plot(t_rel_ilu, truth_pos_body[:, j], "m-", label="Truth")
                 ax.set_title(f"Position r{dirs_body[j]}_body")
             elif i == 1:
-                ax.plot(t_rel_gnss, gnss_vel_body[:, j], "k-", label="Measured GNSS")
+                ax.plot(
+                    t_rel_gnss,
+                    gnss_vel_body[:, j],
+                    "k-",
+                    label="Derived GNSS",
+                )
                 ax.plot(
                     t_rel_ilu,
                     vel_body[:, j],
@@ -2014,7 +2058,12 @@ def main():
                     ax.plot(t_rel_ilu, truth_vel_body[:, j], "m-", label="Truth")
                 ax.set_title(f"Velocity v{dirs_body[j]}_body")
             else:
-                ax.plot(t_rel_gnss, gnss_acc_body[:, j], "k-", label="Derived GNSS")
+                ax.plot(
+                    t_rel_gnss,
+                    gnss_acc_body[:, j],
+                    "k-",
+                    label="Derived GNSS Acceleration",
+                )
                 ax.plot(
                     t_rel_ilu,
                     acc_body[:, j],
@@ -2026,7 +2075,9 @@ def main():
             ax.set_xlabel("Time (s)")
             ax.set_ylabel("Value")
             ax.legend(loc="best")
-    fig_body_all.suptitle(f"Task 5 – {method} – Body Frame (Fused vs. Measured GNSS)")
+    fig_body_all.suptitle(
+        f"Task 5 – {method} – Body Frame (Fused vs. Derived GNSS)"
+    )
     fig_body_all.tight_layout(rect=[0, 0, 1, 0.95])
     if not args.no_plots:
         plt.savefig(f"results/{tag}_task5_all_body.png", dpi=200, bbox_inches="tight")

--- a/PYTHON/src/task6_overlay_all_frames.py
+++ b/PYTHON/src/task6_overlay_all_frames.py
@@ -309,7 +309,12 @@ def plot_overlay_3x3(
         for i in range(3):  # rows: components
             ax = axes[i, j]
             if est is not None:
-                ax.plot(time, est[:, i], label="Estimated" if (i == 0 and j == 0) else None, linewidth=1.2)
+                ax.plot(
+                    time,
+                    est[:, i],
+                    label="Fused" if (i == 0 and j == 0) else None,
+                    linewidth=1.2,
+                )
             if tru is not None:
                 ax.plot(
                     time,
@@ -328,7 +333,7 @@ def plot_overlay_3x3(
     axes[0, 2].set_title("Acceleration")
     handles, labels = axes[0, 0].get_legend_handles_labels()
     if handles:
-        fig.legend(handles, labels, ncol=3, loc="upper center")
+        fig.legend(handles, labels, ncol=2, loc="upper center")
     fig.suptitle(title)
     fig.tight_layout(rect=[0, 0, 1, 0.92])
     fig.savefig(outfile, dpi=150)
@@ -354,7 +359,12 @@ def plot_methods_overlay_3x3(
             for name, trip in methods_triplets.items():
                 est = trip[j]
                 if est is not None:
-                    ax.plot(time, est[:, i], label=name if (i == 0 and j == 0) else None, linewidth=1.2)
+                    ax.plot(
+                        time,
+                        est[:, i],
+                        label=(f"Fused {name}" if (i == 0 and j == 0) else None),
+                        linewidth=1.2,
+                    )
             if tru is not None:
                 ax.plot(
                     time,


### PR DESCRIPTION
## Summary
- Clarify Task 5 NED comparison by labeling GNSS data as derived ECEF→NED and updating ECEF/body frames to differentiate measured positions/velocities from derived accelerations
- Mark fused curves explicitly in Task 6 overlay plots and adjust legends accordingly

## Testing
- `PYTHONPATH=. pytest -q` *(failed: missing STATE_X001.txt and GNSS_X001_small.csv)*

------
https://chatgpt.com/codex/tasks/task_e_689cb55c51ec83229425d602e661092e