### PR TITLE
Improve Task6 overlay robustness

### DIFF
--- a/PYTHON/src/task6_plot_truth.py
+++ b/PYTHON/src/task6_plot_truth.py
@@ -34,6 +34,9 @@ def main():
     out_dir = (Path('PYTHON')/ 'results' / run_id / 'task6').resolve()
     out_dir.mkdir(parents=True, exist_ok=True)
 
+    time_hint = est_path.with_name(f"{run_id}_task5_time.mat")
+    time_hint_path = str(time_hint) if time_hint.is_file() else None
+
     # Parse qbody
     q_const = None
     if args.qbody:
@@ -64,7 +67,8 @@ def main():
             output_dir=str(out_dir),
             lat_deg=args.lat, lon_deg=args.lon,
             gnss_file=args.gnss_file,
-            q_b2n_const=q_const
+            q_b2n_const=q_const,
+            time_hint_path=time_hint_path,
         )
         saved.update(saved_single if isinstance(saved_single, dict) else {})
     except Exception as ex:
@@ -97,7 +101,8 @@ def main():
                 output_dir=str(out_dir),
                 lat_deg=args.lat, lon_deg=args.lon,
                 gnss_file=args.gnss_file,
-                q_b2n_const=q_const
+                q_b2n_const=q_const,
+                time_hint_path=time_hint_path,
             )
             if isinstance(saved_multi, dict):
                 saved.update(saved_multi)


### PR DESCRIPTION
## Summary
- make Task6 time handling robust across estimator outputs, time files, and runmeta fallback
- add diagnostics, manifest, and safer frame-by-frame plotting with static PNG output
- pass optional time hints from task6_plot_truth to overlay helpers

## Testing
- `PYTHONPATH=. pytest tests/test_naming.py tests/test_task6_length_handling.py -q`
- `python PYTHON/src/task6_plot_truth.py --est-file tmp/est.mat --truth-file tmp/truth.csv --lat 0 --lon 0 --run-id dummy`


------
https://chatgpt.com/codex/tasks/task_e_689ceee856c08322b94869fb81baee5c