### PR TITLE
Add explicit end for attitude_tools main function

### DIFF
--- a/MATLAB/utils/attitude_tools.m
+++ b/MATLAB/utils/attitude_tools.m
@@ -126,6 +126,8 @@ switch lower(action)
         error('Unknown action: %s', action);
 end
 
+end
+
 % --- helpers ---
 function [q, isRow] = ensureQuatShape(q)
     isRow = isrow(q) && numel(q)==4;


### PR DESCRIPTION
## Summary
- ensure attitude_tools.m terminates with an explicit `end` after the switch block
- confirm helper function retains its own `end`

## Testing
- `matlab -batch "run_triad_only"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cf1037c1483228b3e89bc2cfa9263