### PR TITLE
Improve Task6 overlay data extraction and debugging

### DIFF
--- a/PYTHON/src/task6_plot_truth.py
+++ b/PYTHON/src/task6_plot_truth.py
@@ -27,6 +27,7 @@ def main():
     ap.add_argument('--svd-file', default=None)
     ap.add_argument('--no-interactive', action='store_true', help='disable any interactive imports')
     ap.add_argument('--output', default=None, help='(ignored) kept for backward compat')
+    ap.add_argument('--debug-task6', action='store_true', help='enable verbose Task 6 debugging')
     args = ap.parse_args()
 
     est_path = Path(args.est_file).resolve()
@@ -69,6 +70,7 @@ def main():
             gnss_file=args.gnss_file,
             q_b2n_const=q_const,
             time_hint_path=time_hint_path,
+            debug=args.debug_task6,
         )
         saved.update(saved_single if isinstance(saved_single, dict) else {})
     except Exception as ex:
@@ -103,6 +105,7 @@ def main():
                 gnss_file=args.gnss_file,
                 q_b2n_const=q_const,
                 time_hint_path=time_hint_path,
+                debug=args.debug_task6,
             )
             if isinstance(saved_multi, dict):
                 saved.update(saved_multi)


### PR DESCRIPTION
## Summary
- Add robust `extract_vec3` and `extract_scalar` helpers for Task 6 to handle MATLAB shapes, key variations, and resampling.
- Synthesize missing frames, derive acceleration from velocity, and provide detailed debug reporting with `--debug-task6` flag.
- Extend CLI to expose debug flag and forward it to overlay helpers.

## Testing
- `PYTHONPATH=PYTHON pytest PYTHON/tests/test_validate_with_truth.py::test_assemble_frames_small_truth -q`


------
https://chatgpt.com/codex/tasks/task_e_689d681fdf3083229f2a2ef2cf2775b6