### PR TITLE
Add debug output for Task 4-6 plot saves

### DIFF
--- a/MATLAB/Task_4.m
+++ b/MATLAB/Task_4.m
@@ -721,6 +721,7 @@ function plot_comparison_in_frame(frame_name, t_gnss, t_imu, methods, C_B_N_meth
     end
     sgtitle(['GNSS vs. IMU Integration Comparison in ' frame_name ' Frame']);
     saveas(fig, filename);
+    fprintf('Task 4: saved %s comparison plot to %s\n', frame_name, filename);
     
     % --- Plot 2: All Data in ECEF Frame ---
     fig_ecef = figure('Name', 'All Data in ECEF Frame', 'Position', [150 150 1200 900], 'Visible', 'off');
@@ -759,7 +760,9 @@ function plot_comparison_in_frame(frame_name, t_gnss, t_imu, methods, C_B_N_meth
         end
         hold off; grid on; legend; title(['Acceleration ' dims_ecef{i}]); ylabel('m/s^2');
     end
-    saveas(fig_ecef, strrep(filename, '_ned.', '_ecef.'));
+    ecef_name = strrep(filename, '_ned.', '_ecef.');
+    saveas(fig_ecef, ecef_name);
+    fprintf('Task 4: saved ECEF comparison plot to %s\n', ecef_name);
     
     close(fig); close(fig_ecef);
 end
@@ -844,6 +847,8 @@ function plot_single_method(method, t_gnss, t_imu, C_B_N, p_gnss_ned, v_gnss_ned
     %   plotting policy.
 
     dims = {'North','East','Down'};
+    fprintf('Task 4 Subtask 4.13: method %s | GNSS samples=%d | IMU samples=%d\n', ...
+        method, numel(t_gnss), numel(t_imu));
     % Determine figure visibility from cfg
     visibleFlag = 'off';
     try
@@ -882,7 +887,7 @@ function plot_single_method(method, t_gnss, t_imu, C_B_N, p_gnss_ned, v_gnss_ned
     if cfg.plots.save_png
         print(fig,[fname '.png'],'-dpng');
     end
-    fprintf('Comparison plot in NED frame saved\n');
+    fprintf('Task 4: saved NED frame plot to %s (.pdf/.png)\n', fname);
     close(fig);
 
     % ----- ECEF frame -----
@@ -921,7 +926,7 @@ function plot_single_method(method, t_gnss, t_imu, C_B_N, p_gnss_ned, v_gnss_ned
     if cfg.plots.save_png
         print(fig,[fname '.png'],'-dpng');
     end
-    fprintf('All data in ECEF frame plot saved\n');
+    fprintf('Task 4: saved ECEF frame plot to %s (.pdf/.png)\n', fname);
     close(fig);
 
     % ----- Body frame -----
@@ -954,7 +959,7 @@ function plot_single_method(method, t_gnss, t_imu, C_B_N, p_gnss_ned, v_gnss_ned
     if cfg.plots.save_png
         print(fig,[fname '.png'],'-dpng');
     end
-    fprintf('All data in body frame plot saved\n');
+    fprintf('Task 4: saved body frame plot to %s (.pdf/.png)\n', fname);
     close(fig);
 
     % ----- Mixed frame (ECEF position/velocity + body acceleration) -----
@@ -977,8 +982,9 @@ function plot_single_method(method, t_gnss, t_imu, C_B_N, p_gnss_ned, v_gnss_ned
     fname = [base '_Task4_MixedFrame.pdf'];
     set(fig,'PaperPositionMode','auto');
     print(fig,fname,'-dpdf','-bestfit');
-    print(fig,strrep(fname,'.pdf','.png'),'-dpng');
-    fprintf('Mixed frames plot saved\n');
+    png_name = strrep(fname,'.pdf','.png');
+    print(fig,png_name,'-dpng');
+    fprintf('Task 4: saved mixed frame plot to %s and %s\n', fname, png_name);
     close(fig);
 end
 

--- a/MATLAB/Task_5.m
+++ b/MATLAB/Task_5.m
@@ -1118,6 +1118,7 @@ end % End of main function
             end
         catch
         end
+        fprintf('Task 5: NED frame plotting | samples=%d\n', size(pos_ned,2));
         figure('Name','Task5 NED Frame','Position',[100 100 1200 900], ...
             'Visible', visibleFlag);
         for k = 1:3
@@ -1144,6 +1145,7 @@ end % End of main function
         if cfg.plots.save_png
             print(gcf, [fname '.png'], '-dpng');
         end
+        fprintf('Task 5: saved NED frame plot to %s (.pdf/.png)\n', fname);
         close(gcf);
     end
 
@@ -1160,6 +1162,7 @@ end % End of main function
         pos_fused = (C_E_N' * pos_ned) + r0;
         vel_fused = C_E_N' * vel_ned;
         acc_fused = C_E_N' * acc_ned;
+        fprintf('Task 5: ECEF frame plotting | samples=%d\n', size(pos_ned,2));
         figure('Name','Task5 ECEF Frame','Position',[100 100 1200 900], ...
             'Visible', visibleFlag);
         for k = 1:3
@@ -1186,6 +1189,7 @@ end % End of main function
         if cfg.plots.save_png
             print(gcf, [fname '.png'], '-dpng');
         end
+        fprintf('Task 5: saved ECEF frame plot to %s (.pdf/.png)\n', fname);
         close(gcf);
     end
 
@@ -1200,6 +1204,7 @@ end % End of main function
         catch
         end
         N = size(pos_ned,2);
+        fprintf('Task 5: Body frame plotting | samples=%d\n', N);
         pos_body = zeros(3,N); vel_body = zeros(3,N); acc_body = zeros(3,N);
         for k = 1:N
             C_B_N = euler_to_rot(eul_log(:,k));
@@ -1243,6 +1248,7 @@ end % End of main function
         if cfg.plots.save_png
             print(gcf, [fname '.png'], '-dpng');
         end
+        fprintf('Task 5: saved body frame plot to %s (.pdf/.png)\n', fname);
         close(gcf);
     end
 
@@ -1294,5 +1300,6 @@ end % End of main function
         if cfg.plots.save_png
             print(gcf, [fname '.png'], '-dpng');
         end
+        fprintf('Task 5: saved ECEF truth plot to %s (.pdf/.png)\n', fname);
         close(gcf);
     end

--- a/MATLAB/Task_6.m
+++ b/MATLAB/Task_6.m
@@ -380,9 +380,10 @@ save_task_results(results, imu_name, gnss_name, method, 6);
 % =========================================================================
 try
     % NED comparison
-    t_g = S.gnss_time; 
-    pos_g = S.gnss_pos_ned; vel_g = S.gnss_vel_ned; 
+    t_g = S.gnss_time;
+    pos_g = S.gnss_pos_ned; vel_g = S.gnss_vel_ned;
     acc_g = [zeros(1,3); diff(vel_g)./diff(t_g)];
+    fprintf('Task 6: NED comparison plotting | GNSS samples=%d | est samples=%d\n', numel(t_g), numel(t_est));
     fig = figure('Name','Task6 NED Comparison','Position',[100 100 1200 900], 'Visible', visibleFlag);
     labels = {'North','East','Down'};
     for k = 1:3
@@ -391,10 +392,14 @@ try
         subplot(3,3,6+k); hold on; plot(t_g, acc_g(:,k),'k:'); plot(t_est, acc_ned(:,k),'b-'); grid on; title(['Acc ' labels{k}]);
     end
     set(fig,'PaperPositionMode','auto');
-    print(fig, fullfile(out_dir, sprintf('%s_task6_compare_NED.pdf', run_id)), '-dpdf', '-bestfit');
-    print(fig, fullfile(out_dir, sprintf('%s_task6_compare_NED.png', run_id)), '-dpng'); close(fig);
+    ned_base = fullfile(out_dir, sprintf('%s_task6_compare_NED', run_id));
+    print(fig, [ned_base '.pdf'], '-dpdf', '-bestfit');
+    print(fig, [ned_base '.png'], '-dpng');
+    fprintf('Task 6: saved NED comparison plots to %s.[pdf|png]\n', ned_base);
+    close(fig);
 
     % ECEF comparison
+    fprintf('Task 6: ECEF comparison plotting | samples=%d\n', numel(t_est));
     fig = figure('Name','Task6 ECEF Comparison','Position',[100 100 1200 900], 'Visible', visibleFlag);
     labelsE = {'X','Y','Z'};
     pos_f = pos_ecef; vel_f = vel_ecef; acc_f = acc_ecef; % from earlier
@@ -407,10 +412,14 @@ try
         subplot(3,3,6+k); hold on; plot(t_g, acc_ge(:,k),'k:'); plot(t_est, acc_f(:,k),'b-'); grid on; title(['Acc ' labelsE{k}]);
     end
     set(fig,'PaperPositionMode','auto');
-    print(fig, fullfile(out_dir, sprintf('%s_task6_compare_ECEF.pdf', run_id)), '-dpdf', '-bestfit');
-    print(fig, fullfile(out_dir, sprintf('%s_task6_compare_ECEF.png', run_id)), '-dpng'); close(fig);
+    ecef_base = fullfile(out_dir, sprintf('%s_task6_compare_ECEF', run_id));
+    print(fig, [ecef_base '.pdf'], '-dpdf', '-bestfit');
+    print(fig, [ecef_base '.png'], '-dpng');
+    fprintf('Task 6: saved ECEF comparison plots to %s.[pdf|png]\n', ecef_base);
+    close(fig);
 
     % Body comparison (includes raw IMU acceleration if available)
+    fprintf('Task 6: Body comparison plotting | samples=%d\n', numel(t_est));
     fig = figure('Name','Task6 Body Comparison','Position',[100 100 1200 900], 'Visible', visibleFlag);
     labelsB = {'X','Y','Z'};
     % GNSS -> body via euler
@@ -430,8 +439,11 @@ try
         grid on; title(['Acc ' labelsB{j}]);
     end
     set(fig,'PaperPositionMode','auto');
-    print(fig, fullfile(out_dir, sprintf('%s_task6_compare_BODY.pdf', run_id)), '-dpdf', '-bestfit');
-    print(fig, fullfile(out_dir, sprintf('%s_task6_compare_BODY.png', run_id)), '-dpng'); close(fig);
+    body_base = fullfile(out_dir, sprintf('%s_task6_compare_BODY', run_id));
+    print(fig, [body_base '.pdf'], '-dpdf', '-bestfit');
+    print(fig, [body_base '.png'], '-dpng');
+    fprintf('Task 6: saved body comparison plots to %s.[pdf|png]\n', body_base);
+    close(fig);
 catch ME
     warning('Task 6 comparison plots failed: %s', ME.message);
 end


### PR DESCRIPTION
## Summary
- add debug messages and path confirmations when saving Task 4 plots
- log sample counts and saved filenames for Task 5 NED/ECEF/body plots
- print comparison-plot save locations for Task 6 frames

## Testing
- `python -m pytest` *(fails: Interrupted: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689d6aecbca88322a354efb16614673c