### PR TITLE
feat: enhance task6 truth overlay and output flattening

### DIFF
--- a/PYTHON/src/GNSS_IMU_Fusion.py
+++ b/PYTHON/src/GNSS_IMU_Fusion.py
@@ -164,13 +164,14 @@ def task3_plot_quaternions_and_errors(
 
     quat_path = Path(output_dir) / f"{RUN_ID}_task3_quaternions_{timestamp}.png"
     plt.savefig(quat_path, dpi=200, bbox_inches="tight")
-    print(f"Quaternion comparison plot saved: {quat_path}")
+    print(f"[Task3] Quaternion comparison plot saved: {quat_path} bytes={os.path.getsize(quat_path)}")
     plt.close(fig)
 
     # Attitude error comparison ------------------------------------------
     epsilon = 1e-6
     grav_vals = [max(epsilon, errors_dict[m]["grav"]) for m in methods]
     earth_vals = [max(epsilon, errors_dict[m]["earth"]) for m in methods]
+    print(f"[Task3] grav_err_deg={grav_vals} earth_err_deg={earth_vals}")
     if any(v <= epsilon for v in grav_vals + earth_vals):
         print("Near-zero errors detected; plot may appear empty")
 
@@ -188,8 +189,10 @@ def task3_plot_quaternions_and_errors(
     plt.tight_layout()
 
     err_path = Path(output_dir) / f"{RUN_ID}_task3_errors_{timestamp}.png"
+    if not grav_vals or not earth_vals or (np.allclose(grav_vals, 0) and np.allclose(earth_vals, 0)):
+        raise ValueError("Task3 arrays all zero or empty")
     plt.savefig(err_path, dpi=200, bbox_inches="tight")
-    print(f"Error comparison plot saved: {err_path}")
+    print(f"[Task3] Error comparison plot saved: {err_path} bytes={os.path.getsize(err_path)}")
     plt.close(fig)
 
 

--- a/PYTHON/src/task2_plot.py
+++ b/PYTHON/src/task2_plot.py
@@ -7,6 +7,7 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import uuid
+import os
 
 
 def save_task2_summary_png(
@@ -76,6 +77,7 @@ def save_task2_summary_png(
     out_png = out_dir / f"{run_id}_task2_summary.png"
     fig.savefig(out_png, dpi=300)
     plt.close(fig)
+    print(f"[Task2] Summary -> {out_png} bytes={os.path.getsize(out_png)}")
     return out_png
 
 
@@ -153,5 +155,5 @@ def task2_measure_body_vectors(
     out_png = out_dir / "IMU_X002_GNSS_X002_TRIAD_task2_vectors.png"
     fig.savefig(out_png, dpi=300)
     plt.close(fig)
-    print(f"Task 2: saved plot -> {out_png}")
+    print(f"[Task2] saved plot -> {out_png} bytes={os.path.getsize(out_png)}")
     return out_png

--- a/PYTHON/src/utils/read_truth_txt.py
+++ b/PYTHON/src/utils/read_truth_txt.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+import numpy as np
+
+
+def read_truth_txt(path: str | Path):
+    """Return ``t_truth``, ``pos_ecef`` and ``vel_ecef`` arrays from STATE_X text file.
+
+    The truth files have columns::
+        count  time  X_ECEF_m  Y_ECEF_m  Z_ECEF_m  VX_ECEF_mps  VY_ECEF_mps  VZ_ECEF_mps ...
+    ``vel`` columns are optional; if missing, zeros are returned with a warning.
+    """
+    p = Path(path)
+    arr = np.loadtxt(p, comments="#")
+    if arr.ndim == 1:
+        arr = arr.reshape(1, -1)
+    if arr.size == 0:
+        return np.array([]), np.zeros((0, 3)), np.zeros((0, 3))
+    if arr.shape[1] < 5:
+        raise ValueError(f"Truth file {p} has insufficient columns: {arr.shape[1]}")
+    t_truth = arr[:, 1].astype(float)
+    pos_ecef = arr[:, 2:5].astype(float)
+    if arr.shape[1] >= 8:
+        vel_ecef = arr[:, 5:8].astype(float)
+    else:
+        vel_ecef = np.zeros_like(pos_ecef)
+        print(f"[Task6][WARN] {p} lacks velocity columns; using zeros")
+    return t_truth, pos_ecef, vel_ecef
+
+
+__all__ = ["read_truth_txt"]


### PR DESCRIPTION
## Summary
- Add robust truth reader and detailed debug logs for Task 6 overlay, with interpolation and reference frame conversion
- Ensure Task 6 plots and compare-method overlays save sizes and flatten to results root
- Provide Task 1 map export diagnostics, Task 2 figure size prints, Task 3 quaternion/error debug, and result manifest generation

## Testing
- `pytest -q` *(fails: No module named 'src')*
- `PYTHONPATH=PYTHON/src pytest PYTHON/tests/test_task6_length_handling.py::test_truth_interp -q` *(fails: No module named 'task6_overlay_plot')*

------
https://chatgpt.com/codex/tasks/task_e_689d71ee2b3083228eb5ec6e4080fcc0