### PR TITLE
feat: add PNG saver with size check

### DIFF
--- a/MATLAB/plot_xyz_timeseries.m
+++ b/MATLAB/plot_xyz_timeseries.m
@@ -1,13 +1,14 @@
 function plot_xyz_timeseries(tF, pF, vF, aF, tG, pG, vG, aG, figTitle, outPrefix, axisLabels, method)
-%PLOT_XYZ_TIMESERIES  Plot fused and GNSS timeseries in a 3x3 grid.
+%PLOT_XYZ_TIMESERIES  Plot fused and GNSS time series in a 3x3 grid.
 %   plot_xyz_timeseries(TF, PF, VF, AF, TG, PG, VG, AG, TITLE, PREFIX, LABELS, METHOD)
 %   mirrors the Python helper used for Task 5 plots. ``PF``, ``VF`` and ``AF``
 %   are ``3xN`` arrays containing position, velocity and acceleration from the
 %   Kalman filter. GNSS measurements ``PG``, ``VG`` and ``AG`` are optional but
-%   when provided are drawn as black dashed lines for comparison. ``METHOD`` is
+%   when provided are drawn as dashed black lines for comparison. ``METHOD`` is
 %   inserted into the legend to clearly identify the fused data source.
 %   ``axisLabels`` defaults to ``{'X','Y','Z'}``.  Figures are saved to
-%   ``PREFIX_fixed.pdf`` and ``PREFIX_fixed.png``.
+%   ``PREFIX_fixed.png`` using ``save_png_checked`` which verifies successful
+%   creation.
 
     if nargin < 11 || isempty(axisLabels)
         axisLabels = {'X','Y','Z'};
@@ -31,7 +32,7 @@ function plot_xyz_timeseries(tF, pF, vF, aF, tG, pG, vG, aG, figTitle, outPrefix
     yAcc = [-limAcc limAcc];
 
     % ----- 3. Layout ---------------------------------------------------------
-    fig = figure('Name', figTitle, 'Units','pixels', 'Position',[80 80 1100 800]);
+    fig = figure('Name', figTitle, 'Units','pixels', 'Position',[100 100 1800 1200]);
     tl  = tiledlayout(3,3,'TileSpacing','compact','Padding','compact'); %#ok<NASGU>
 
     rowNames  = {'Position','Velocity','Acceleration'};
@@ -39,29 +40,36 @@ function plot_xyz_timeseries(tF, pF, vF, aF, tG, pG, vG, aG, figTitle, outPrefix
     fusedSet  = {pF, vF, aF};
     gnssSet   = {pG, vG, aG};
     ylims     = {yPos, yVel, yAcc};
-
+    hf0 = []; hg0 = [];
     for r = 1:3
         for c = 1:3
-            nexttile
+            nexttile;
             % Fused data ------------------------------------------------------
-            plot(tF, fusedSet{r}(c,:), 'b-', 'LineWidth', 1.0); hold on
+            hf = plot(tF, fusedSet{r}(c,:), 'b-', 'LineWidth', 1.5); hold on
             % GNSS overlay ---------------------------------------------------
             if ~isempty(gnssSet{r})
-                plot(tG, gnssSet{r}(c,:), 'k:', 'LineWidth', 1.0);
-                if ~isempty(method)
-                    legend({sprintf('Fused (GNSS+IMU, %s)', method), 'Measured GNSS'}, 'Location','best');
-                else
-                    legend({'Fused (GNSS+IMU)','Measured GNSS'}, 'Location','best');
-                end
+                hg = plot(tG, gnssSet{r}(c,:), 'k--', 'LineWidth', 1.5);
+            else
+                hg = gobjects(0);
             end
+            if isempty(hf0); hf0 = hf; end
+            if isempty(hg0) && ~isempty(hg); hg0 = hg; end
             grid on; ylim(ylims{r});
-            xlabel('Time [s]'); ylabel(units{r});
+            xlabel('Time [s]');
+            ylabel(sprintf('%s %s', rowNames{r}, units{r}));
             title(sprintf('%s %s', rowNames{r}, axisLabels{c}));
         end
     end
+    if isempty(hg0)
+        legend(tl, hf0, sprintf('Fused%s', ternary(~isempty(method), [' (' method ')'], '')), ...
+            'Orientation','horizontal','Location','northoutside');
+    else
+        legend(tl, [hf0 hg0], {sprintf('Fused%s', ternary(~isempty(method), [' (' method ')'], '')), 'GNSS'}, ...
+            'Orientation','horizontal','Location','northoutside');
+    end
     sgtitle(figTitle,'FontWeight','bold');
+    set(findall(fig,'-property','FontSize'),'FontSize',12);
 
     % ----- 4. Save -----------------------------------------------------------
-    saveas(fig, [outPrefix, '_fixed.png']);
-    saveas(fig, [outPrefix, '_fixed.pdf']);
+    save_png_checked(fig, [outPrefix, '_fixed.png']);
 end

--- a/MATLAB/utils/save_png_checked.m
+++ b/MATLAB/utils/save_png_checked.m
@@ -1,0 +1,45 @@
+function save_png_checked(fig, filename)
+%SAVE_PNG_CHECKED Save figure as PNG with fixed size and verify output.
+%   SAVE_PNG_CHECKED(FIG, FILENAME) writes FIG to FILENAME as a PNG using
+%   1800x1200 pixels at 200 DPI in landscape orientation. The function
+%   asserts that the file is created and larger than 5 KB.
+%
+%   Example:
+%       save_png_checked(gcf, 'MATLAB/results/demo.png');
+%
+%   The function creates parent directories if necessary.
+
+    if nargin < 1 || isempty(fig)
+        fig = gcf;
+    end
+    if nargin < 2 || isempty(filename)
+        error('save_png_checked:MissingFile', 'Filename is required');
+    end
+    [out_dir, ~, ext] = fileparts(filename);
+    if isempty(ext)
+        filename = [filename '.png'];
+        ext = '.png';
+    end
+    if ~strcmpi(ext, '.png')
+        error('save_png_checked:Extension', 'Filename must end with .png');
+    end
+    if ~exist(out_dir, 'dir')
+        mkdir(out_dir);
+    end
+
+    % Configure figure dimensions
+    set(fig, 'Units', 'pixels');
+    set(fig, 'Position', [100 100 1800 1200]);
+    set(fig, 'PaperOrientation', 'landscape');
+    set(fig, 'PaperUnits', 'inches', 'PaperPosition', [0 0 9 6]);
+
+    % Save using print for consistent dpi
+    print(fig, filename, '-dpng', '-r200');
+
+    info = dir(filename);
+    assert(~isempty(info), 'save_png_checked:FileMissing', ...
+        'Failed to create %s', filename);
+    assert(info.bytes > 5*1024, 'save_png_checked:FileTooSmall', ...
+        'File %s is only %d bytes', filename, info.bytes);
+    fprintf('Saved %s (%d bytes)\n', filename, info.bytes);
+end

--- a/PYTHON/src/utils/plot_frame_comparison.m
+++ b/PYTHON/src/utils/plot_frame_comparison.m
@@ -5,7 +5,8 @@ function plot_frame_comparison(t, data_sets, labels, frame_name, out_prefix, cfg
 %   labels      : cell array of legend strings
 %   frame_name  : 'NED','ECEF','BODY','Mixed'
 %   out_prefix  : full path prefix, e.g. results/.../RUNID_taskX
-%   cfg         : struct with plotting policy
+%   cfg         : struct with plotting policy. PNG output is saved via
+%                 ``save_png_checked`` ensuring 1800×1200 px at 200 DPI.
 
 if nargin < 6 || isempty(cfg)
     cfg = default_cfg();
@@ -19,39 +20,67 @@ try
 catch
 end
 
-% Create figure
-figure('Visible', visibleFlag);
+% Create figure with required dimensions
+fig = figure('Visible', visibleFlag, 'Units','pixels', 'Position',[100 100 1800 1200]);
+
 if strcmpi(frame_name,'Mixed')
     % single axes
     hold on; grid on;
     for i = 1:numel(data_sets)
         D = data_sets{i};
         % assume D is 3×N
-        plot(t, D(1,:), '-'); plot(t, D(2,:), '--'); plot(t, D(3,:), ':');
+        plot(t, D(1,:), '-', 'LineWidth', 1.5);
+        plot(t, D(2,:), '--', 'LineWidth', 1.5);
+        plot(t, D(3,:), ':', 'LineWidth', 1.5);
     end
-    legend(labels,'Location','best');
-    xlabel('Time (s)'); ylabel(sprintf('%s axes',frame_name));
+    legend(labels,'Location','northoutside','Orientation','horizontal');
+    xlabel('Time [s]'); ylabel(sprintf('%s axes',frame_name));
     title([frame_name ' Comparison']);
     hold off;
 else
     % three stacked subplots
+    axisLabels = get_axis_labels(frame_name);
+    lines = gobjects(numel(data_sets),1);
     for ax = 1:3
         subplot(3,1,ax); hold on; grid on;
         for i = 1:numel(data_sets)
             D = data_sets{i};
-            plot(t, D(ax,:), 'DisplayName', labels{i});
+            h = plot(t, D(ax,:), 'LineWidth', 1.5, 'DisplayName', labels{i});
+            if ax == 1
+                lines(i) = h;
+            end
         end
-        ylabel(sprintf('%s_%d',frame_name,ax));
-        if ax==1, title([frame_name ' Comparison']); end
-        if ax==3, xlabel('Time (s)'); end
-        if ax==1, legend('show','Location','best'); end
-        hold off;
+        ylabel(sprintf('%s [m]', axisLabels{ax}));
+        if ax==1
+            title([frame_name ' Comparison']);
+        end
+        if ax==3
+            xlabel('Time [s]');
+        end
     end
+    legend(lines, labels, 'Orientation','horizontal','Location','northoutside');
 end
+
+set(findall(fig,'-property','FontSize'),'FontSize',12);
+
 % Save PNG
-fname = [out_prefix '_' frame_name '_comparison'];
+fname = sprintf('%s_%s.png', out_prefix, lower(frame_name));
 if cfg.plots.save_png
-    saveas(gcf, [fname '.png'], 'png');
+    save_png_checked(fig, fname);
 end
-close;
+close(fig);
+end
+
+function labels = get_axis_labels(frame_name)
+%GET_AXIS_LABELS Return axis labels for frames
+switch upper(frame_name)
+    case 'NED'
+        labels = {'North','East','Down'};
+    case 'ECEF'
+        labels = {'X','Y','Z'};
+    case 'BODY'
+        labels = {'X','Y','Z'};
+    otherwise
+        labels = {'Axis1','Axis2','Axis3'};
+end
 end


### PR DESCRIPTION
## Summary
- add save_png_checked helper to standardise figure output and verify file size
- update plot_xyz_timeseries to use new saver, apply global legend and 12pt fonts
- enhance plot_frame_comparison to adopt consistent styling and PNG output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_689d74919a008322b3fd49ed66a0dcb6