### PR TITLE
Flatten task plot outputs

### DIFF
--- a/PYTHON/src/evaluate_filter_results.py
+++ b/PYTHON/src/evaluate_filter_results.py
@@ -13,7 +13,7 @@ from typing import Sequence
 import json
 import logging
 
-from naming import plot_path
+from utils.plot_save import save_plot, task_summary
 
 import numpy as np
 import pandas as pd
@@ -149,9 +149,7 @@ def run_evaluation(
         axes[1, i].grid(True)
     fig.suptitle("Task 7 – GNSS - Predicted Residuals")
     fig.tight_layout(rect=[0, 0, 1, 0.95])
-    out_path = plot_path(out_dir, tag or "", 7, "3", "residuals_position_velocity")
-    fig.savefig(out_path)
-    print(f"Saved {out_path}")
+    out_path = save_plot(fig, out_dir, tag or "run", "task7", "3_residuals_position_velocity", ext="pdf")
     try:
         from utils import save_plot_mat, save_plot_fig
         save_plot_mat(fig, str(out_path.with_suffix(".mat")))
@@ -170,9 +168,7 @@ def run_evaluation(
             axes[i].grid(True)
         fig.suptitle(f"Task 7 – Histogram of {name} residuals")
         fig.tight_layout(rect=[0, 0, 1, 0.95])
-        hist_path = plot_path(out_dir, tag or "", 7, f"hist_{name}", "residuals")
-        fig.savefig(hist_path)
-        print(f"Saved {hist_path}")
+        hist_path = save_plot(fig, out_dir, tag or "run", "task7", f"hist_{name}_residuals", ext="pdf")
         try:
             from utils import save_plot_mat, save_plot_fig
             save_plot_mat(fig, str(hist_path.with_suffix(".mat")))
@@ -195,8 +191,7 @@ def run_evaluation(
     axs[2].set_xlabel("Time [s]")
     fig.suptitle("Task 7 – Attitude Angles")
     fig.tight_layout(rect=[0, 0, 1, 0.95])
-    att_out = plot_path(out_dir, tag or "", 7, "4", "attitude_angles_euler")
-    fig.savefig(att_out)
+    att_out = save_plot(fig, out_dir, tag or "run", "task7", "4_attitude_angles_euler", ext="pdf")
     try:
         from utils import save_plot_mat, save_plot_fig
         save_plot_mat(fig, str(att_out.with_suffix(".mat")))
@@ -204,6 +199,7 @@ def run_evaluation(
     except Exception:
         pass
     plt.close(fig)
+    task_summary("task7")
 
 
 def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) -> None:
@@ -307,9 +303,7 @@ def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) ->
         axes[1, i].grid(True)
     fig.suptitle("Task 7 – GNSS - Predicted Residuals")
     fig.tight_layout(rect=[0, 0, 1, 0.95])
-    out_path = plot_path(out_dir, tag or "", 7, "3", "residuals_position_velocity")
-    fig.savefig(out_path)
-    print(f"Saved {out_path}")
+    out_path = save_plot(fig, out_dir, tag or "run", "task7", "3_residuals_position_velocity", ext="pdf")
     plt.close(fig)
 
     rot = R.from_quat(quat[:, [1, 2, 3, 0]])
@@ -324,9 +318,7 @@ def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) ->
     axs[2].set_xlabel("Time [s]")
     fig.suptitle("Task 7 – Attitude Angles")
     fig.tight_layout(rect=[0, 0, 1, 0.95])
-    att_path = plot_path(out_dir, tag or "", 7, "4", "attitude_angles_euler")
-    fig.savefig(att_path)
-    print(f"Saved {att_path}")
+    att_path = save_plot(fig, out_dir, tag or "run", "task7", "4_attitude_angles_euler", ext="pdf")
     plt.close(fig)
 
     # Error norm plots
@@ -344,9 +336,7 @@ def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) ->
     ax.legend()
     ax.grid(True)
     fig.tight_layout()
-    norm_path = plot_path(out_dir, tag or "", 7, "3", "error_norms")
-    fig.savefig(norm_path)
-    print(f"Saved {norm_path}")
+    norm_path = save_plot(fig, out_dir, tag or "run", "task7", "3_error_norms", ext="pdf")
     plt.close(fig)
 
     # Subtask 7.5: difference Truth - Fused in multiple frames
@@ -448,13 +438,9 @@ def subtask7_5_diff_plot(
 
         fig.suptitle(f"Truth - Fused Differences ({frame} Frame)")
         fig.tight_layout(rect=[0, 0, 1, 0.95])
-        base = plot_path(out_dir, run_id, 7, "5", "diff_truth_fused_over_time")
-        pdf = base.with_name(base.stem + f"_{frame}.pdf")
-        png = pdf.with_suffix(".png")
-        fig.savefig(pdf)
-        print(f"Saved {pdf}")
-        fig.savefig(png)
-        print(f"Saved {png}")
+        base_label = f"5_diff_truth_fused_over_time_{frame}"
+        pdf = save_plot(fig, out_dir, run_id, "task7", base_label, ext="pdf")
+        png = save_plot(fig, out_dir, run_id, "task7", base_label, ext="png")
         try:
             from utils import save_plot_mat, save_plot_fig
             save_plot_mat(fig, str(pdf.with_suffix(".mat")))
@@ -505,7 +491,7 @@ def subtask7_5_diff_plot(
     diff_pos_body = rot.apply(diff_pos_ned, inverse=True)
     diff_vel_body = rot.apply(diff_vel_ned, inverse=True)
     _plot(diff_pos_body, diff_vel_body, ["X", "Y", "Z"], "Body")
-
+    task_summary("task7")
     print(
         "Saved Task 7.5 diff-truth plots for NED/ECEF/Body frames under: "
         f"{out_dir}/"

--- a/PYTHON/src/scripts/plot_utils.py
+++ b/PYTHON/src/scripts/plot_utils.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 from scipy.spatial.transform import Rotation as R
 from typing import List
 import numpy as np
+from utils.plot_save import save_plot as save_and_log
 
 
 def save_plot(fig, outpath, title):
@@ -12,7 +13,7 @@ def save_plot(fig, outpath, title):
     plt.close(fig)
 
 
-def plot_attitude(time, quats, outpath):
+def plot_attitude(time, quats, results_dir, run_id, method):
     r = R.from_quat(quats)
     euler = r.as_euler('xyz', degrees=True)
     fig, axs = plt.subplots(3, 1, figsize=(6, 8))
@@ -21,9 +22,9 @@ def plot_attitude(time, quats, outpath):
         axs[i].plot(time, euler[:, i])
         axs[i].set_ylabel(f"{labels[i]} (°)")
     axs[-1].set_xlabel("Time (s)")
-    fig.suptitle("Task 6: Attitude Angles Over Time")
+    fig.suptitle("Task 5: Attitude Angles Over Time")
     fig.tight_layout(rect=[0, 0, 1, 0.96])
-    fig.savefig(outpath)
+    save_and_log(fig, results_dir, run_id, "task5", f"attitude_{method}")
     plt.close(fig)
 
 

--- a/PYTHON/src/scripts/validate_filter.py
+++ b/PYTHON/src/scripts/validate_filter.py
@@ -11,7 +11,10 @@ def compute_residuals(gnss_times, gnss_pos, filt_times, filt_pos):
     return res
 
 
-def plot_residuals(gnss_times, res, outpath):
+from utils.plot_save import save_plot
+
+
+def plot_residuals(gnss_times, res, results_dir, run_id, method):
     fig, axs = plt.subplots(2, 1, figsize=(8, 6))
     axs[0].plot(gnss_times, res[:, 0], label='North')
     axs[0].plot(gnss_times, res[:, 1], label='East')
@@ -30,5 +33,5 @@ def plot_residuals(gnss_times, res, outpath):
 
     fig.suptitle('Position & Velocity Residuals')
     fig.tight_layout(rect=[0, 0, 1, 0.96])
-    fig.savefig(outpath)
+    save_plot(fig, results_dir, run_id, "task5", f"residuals_{method}")
     plt.close(fig)

--- a/PYTHON/src/task1_reference_vectors.py
+++ b/PYTHON/src/task1_reference_vectors.py
@@ -3,6 +3,7 @@ import json
 import uuid
 from pathlib import Path
 import os
+from utils.plot_save import save_plot, task_summary
 
 import numpy as np
 import pandas as pd
@@ -87,6 +88,7 @@ def task1_reference_vectors(gnss_data: pd.DataFrame, output_dir: str | Path, run
         chrome = getattr(pio.kaleido.scope, "chromium", "unknown")
         print(f"[Task1] Kaleido chromium={chrome}")
         pio.write_image(fig, png_path, width=1200, height=800, scale=2)
+        print(f"[SAVE] {png_path}")
     except Exception as ex:
         print(f"[Task1] Kaleido export failed: {ex}; using Matplotlib fallback")
         import matplotlib.pyplot as plt
@@ -98,7 +100,7 @@ def task1_reference_vectors(gnss_data: pd.DataFrame, output_dir: str | Path, run
         ax.set_xlabel("Lon [deg]")
         ax.set_ylabel("Lat [deg]")
         ax.set_title("Task 1 — Initial GNSS location (fallback)")
-        fig2.savefig(png_path, dpi=200, bbox_inches="tight")
+        save_plot(fig2, output_dir, run_id, "task1", "location_map")
         plt.close(fig2)
 
     info = {
@@ -112,5 +114,5 @@ def task1_reference_vectors(gnss_data: pd.DataFrame, output_dir: str | Path, run
 
     size = os.path.getsize(png_path) if png_path.exists() else 0
     print(f"[Task1] lat={lat_deg:.5f} lon={lon_deg:.5f} dataset={run_id} -> {png_path} bytes={size}")
-
+    task_summary("task1")
     return png_path

--- a/PYTHON/src/task2_plot.py
+++ b/PYTHON/src/task2_plot.py
@@ -8,6 +8,7 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import uuid
 import os
+from utils.plot_save import save_plot, task_summary
 
 
 def save_task2_summary_png(
@@ -74,10 +75,9 @@ def save_task2_summary_png(
     fig.suptitle("Task 2 – Body-frame vector summary")
     fig.tight_layout(rect=[0, 0, 1, 0.95])
 
-    out_png = out_dir / f"{run_id}_task2_summary.png"
-    fig.savefig(out_png, dpi=300)
+    out_png = save_plot(fig, out_dir, run_id, "task2", "static_interval", ext="png", dpi=300)
     plt.close(fig)
-    print(f"[Task2] Summary -> {out_png} bytes={os.path.getsize(out_png)}")
+    task_summary("task2")
     return out_png
 
 
@@ -85,6 +85,7 @@ def task2_measure_body_vectors(
     imu_data,
     static_indices: tuple[int, int],
     output_dir: str | Path,
+    run_id: str,
 ) -> Path:
     """Plot measured gravity and Earth rotation vectors with error bars."""
 
@@ -152,8 +153,7 @@ def task2_measure_body_vectors(
         )
 
     fig.tight_layout()
-    out_png = out_dir / "IMU_X002_GNSS_X002_TRIAD_task2_vectors.png"
-    fig.savefig(out_png, dpi=300)
+    out_png = save_plot(fig, out_dir, run_id, "task2", "vectors", ext="png", dpi=300)
     plt.close(fig)
-    print(f"[Task2] saved plot -> {out_png} bytes={os.path.getsize(out_png)}")
+    task_summary("task2")
     return out_png

--- a/PYTHON/src/task6_plot_truth.py
+++ b/PYTHON/src/task6_plot_truth.py
@@ -202,11 +202,7 @@ def main():
     # Print what we created
     print('[Task6] Output dir:', out_dir)
     pngs = sorted([str(p) for p in out_dir.glob('*.png')])
-    if pngs:
-        print('[Task6] PNGs:')
-        for p in pngs: print('  ', p)
-    else:
-        print('[Task6] No PNGs found. Debug manifest follows.')
+    print(f"[TASK 6] Plots saved to results/: {[Path(p).name for p in pngs]}")
 
     # Dump (or append) manifest
     manifest = out_dir / 'task6_overlay_manifest.json'

--- a/PYTHON/src/utils/plot_save.py
+++ b/PYTHON/src/utils/plot_save.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List
+
+_saved: Dict[str, List[str]] = defaultdict(list)
+
+
+def save_plot(fig, results_dir: str | Path, run_id: str, task_label: str, plot_label: str, ext: str = "png", **kwargs) -> Path:
+    """Save *fig* to ``results_dir`` with a standardised filename.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure
+        Figure object to save.
+    results_dir : str or Path
+        Base directory where plots are stored.
+    run_id : str
+        Identifier for the current run (e.g. ``IMU_X002_GNSS_X002_TRIAD``).
+    task_label : str
+        Task label such as ``"task1"`` or ``"task6"``.
+    plot_label : str
+        Short descriptor for the specific plot.
+    ext : str, optional
+        File extension, defaults to ``"png"``.
+    kwargs : dict
+        Extra arguments forwarded to :meth:`matplotlib.figure.Figure.savefig`.
+    """
+    results_dir = Path(results_dir)
+    results_dir.mkdir(parents=True, exist_ok=True)
+    out_path = results_dir / f"{run_id}_{task_label}_{plot_label}.{ext}"
+    fig.savefig(out_path, **kwargs)
+    print(f"[SAVE] {out_path}")
+    _saved[task_label].append(out_path.name)
+    return out_path
+
+
+def task_summary(task_label: str) -> None:
+    """Print a summary of saved plots for *task_label*."""
+    files = _saved.get(task_label, [])
+    n = task_label.replace("task", "")
+    print(f"[TASK {n}] Plots saved to results/: {files}")


### PR DESCRIPTION
## Summary
- centralize plot saving via `utils.plot_save` and redirect all task plots to PYTHON/results
- pass results directory and run id through CLI flow and remove legacy subdir shuffling
- ensure each task logs saved plot paths with [SAVE] and [TASK] messages

## Testing
- `python PYTHON/src/run_triad_only.py --dataset X002`


------
https://chatgpt.com/codex/tasks/task_e_689d7496e5a08322a1f35c698e5c01ff