### PR TITLE
feat: update task4-6 plotting

### DIFF
--- a/MATLAB/task4_plot_comparisons.m
+++ b/MATLAB/task4_plot_comparisons.m
@@ -1,262 +1,174 @@
 function task4_plot_comparisons(gnss_data, imu_data, fused_data, time_vec)
-%TASK4_PLOT_COMPARISONS Create Task 4 comparison plots for NED, ECEF, Body.
-%
-% function task4_plot_comparisons(gnss_data, imu_data, fused_data, time_vec)
-% Inputs:
-%  - gnss_data, imu_data, fused_data: structs with fields .ned/.ecef/.body
-%    Each frame contains .pos, .vel, .acc arrays of size [N x 3].
-%  - time_vec: time information; can be:
-%    * numeric vector (e.g., 0:dt:T) for one dataset; other datasets are
-%      mapped by linspace(min,max,N)
-%    * scalar duration T (seconds)
-%    * struct with fields 'gnss','imu','fused' (each numeric vector)
-%
-% This function creates three figures (NED, ECEF, Body), each with a 3x3
-% grid (rows: Position/Velocity/Acceleration; columns: axis 1/2/3), plots
-% GNSS (blue), IMU only (dashed orange), and Fused (thick green). Missing
-% signals render as flat zero lines and are annotated.
-%
-% Figures are saved to MATLAB/results as PNGs with 1800x1200 px at 200 DPI
-% with the exact filenames specified in the task.
+%TASK4_PLOT_COMPARISONS Plot GNSS, IMU-only and fused data in 3x3 grids.
+%   task4_plot_comparisons(gnss_data, imu_data, fused_data, time_vec)
+%   creates comparison figures for NED, ECEF and Body frames.  Each figure
+%   contains a 3x3 subplot grid with rows corresponding to Position,
+%   Velocity and Acceleration and columns for the first, second and third
+%   axes.  GNSS (blue solid), IMU only (orange dashed) and fused (green
+%   solid) signals are plotted against the provided time vector.  Missing
+%   data are replaced by grey dashed zero lines and annotated with a red
+%   warning symbol.  Figures are written to MATLAB/results as 1800x1200 PNGs
+%   at 200 DPI.
 
-% Ensure results directory exists
+% Ensure output directory exists
 outDir = fullfile('MATLAB','results');
-if ~exist(outDir, 'dir')
-    mkdir(outDir);
-end
+if ~exist(outDir,'dir'); mkdir(outDir); end
 
-% Shared style
-fs = 12; % font size
-colorGnss  = [0.000, 0.447, 0.741]; % blue
-colorImu   = [0.929, 0.694, 0.125]; % orange
-colorFused = [0.466, 0.674, 0.188]; % green
+% Colours
+colGnss   = [0.000, 0.447, 0.741]; % blue
+colImu    = [0.929, 0.694, 0.125]; % orange
+colFused  = [0.466, 0.674, 0.188]; % green
+colMissing= [0.5   0.5   0.5  ];   % grey
 
-% Suptitle line 2 (fixed per spec)
-subtitle_line2 = 'IMU_X002_GNSS_X002_TRIAD | IMU n=500000 | GNSS n=1250 | Truth n=20087';
+fs = 12;               % font size
+t  = time_vec(:);      % ensure column vector for x-axis
 
-% Plot each frame separately
 frames = {'ned','ecef','body'};
 axisLabels = {
-    {'North','East','Down'}, ... % NED
-    {'X','Y','Z'}, ...           % ECEF
-    {'BX','BY','BZ'}             % Body
+    {'North','East','Down'}, ...
+    {'X','Y','Z'}, ...
+    {'BX','BY','BZ'}
 };
 fileNames = {
-    'IMU_X002_GNSS_X002_TRIAD_task4_all_ned.png',
-    'IMU_X002_GNSS_X002_TRIAD_task4_all_ecef.png',
-    'IMU_X002_GNSS_X002_TRIAD_task4_all_body.png'
+    'IMU_X002_GNSS_X002_TRIAD_task4_ned.png', ...
+    'IMU_X002_GNSS_X002_TRIAD_task4_ecef.png', ...
+    'IMU_X002_GNSS_X002_TRIAD_task4_body.png'
 };
+
+quantities = {'pos','vel','acc'};
+rowLabels  = {'Position [m]','Velocity [m/s]','Acceleration [m/s^2]'};
 
 for k = 1:numel(frames)
     frame = frames{k};
     try
-        % Create figure with required size
-        hFig = figure('Units','pixels','Position',[100 100 1800 1200],'Color','w','Visible','off');
+        hFig = figure('Units','pixels','Position',[100 100 1800 1200], ...
+            'Color','w','Visible','off');
+        sgtitle(sprintf('Task 4: Comparisons in %s Frame | IMU_X002_GNSS_X002_TRIAD', ...
+            upper(frame)), 'FontSize',fs,'FontWeight','bold');
 
-        % Suptitle with two lines
-        frameUpper = upper(frame);
-        line1 = sprintf('Task 4: All data in %s frame', frameUpper);
-        sgtitle({line1; subtitle_line2}, 'FontSize', fs, 'FontWeight','bold');
+        gFrame = getframefield(gnss_data, frame);
+        iFrame = getframefield(imu_data,  frame);
+        fFrame = getframefield(fused_data,frame);
 
-        % Quantities and units per row
-        quantities = {'pos','vel','acc'};
-        yUnits = {'[m]','[m/s]','[m/s²]'};
-        rowTitles = {'Position','Velocity','Acceleration'};
-
-        % Prepare data references for this frame
-        gnssFrame = getframefield(gnss_data, frame);
-        imuFrame  = getframefield(imu_data,  frame);
-        fusedFrame= getframefield(fused_data,frame);
-
-        % Loop rows (quantities) and columns (axes)
         for r = 1:3
             qty = quantities{r};
-            unitStr = yUnits{r};
             for c = 1:3
-                ax = subplot(3,3,(r-1)*3 + c);
-                hold(ax,'on'); grid(ax,'on');
-
-                % Extract column signals and plot
+                ax = subplot(3,3,(r-1)*3 + c); hold(ax,'on'); grid(ax,'on');
+                set(ax,'FontSize',fs);
                 axisName = axisLabels{k}{c};
 
+                warn = false;
+
                 % GNSS
-                [gnssCol, hasGnss]   = getqtycol(gnssFrame, qty, c);
-                tGnss = resolvetime(time_vec, numel(gnssCol), 'gnss');
-                if hasGnss
-                    p1 = plot(ax, tGnss, gnssCol, '-', 'Color', colorGnss, 'LineWidth', 1.0, 'DisplayName', 'GNSS');
+                [col, has] = getqtycol(gFrame, qty, c);
+                if has
+                    col = interp_to_time(col, t);
+                    plot(ax, t, col, '-', 'Color', colGnss, 'LineWidth',1.0, ...
+                        'DisplayName','GNSS');
                 else
-                    p1 = plot(ax, tGnss, zeros(size(tGnss)), '-', 'Color', colorGnss, 'LineWidth', 1.0, 'DisplayName', 'GNSS (missing)');
+                    plot(ax, t, zeros(size(t)), '--', 'Color', colMissing, ...
+                        'DisplayName','GNSS (missing)');
+                    warn = true;
                 end
 
                 % IMU only
-                [imuCol, hasImu]     = getqtycol(imuFrame,  qty, c);
-                tImu = resolvetime(time_vec, numel(imuCol), 'imu');
-                if hasImu
-                    p2 = plot(ax, tImu, imuCol, '--', 'Color', colorImu, 'LineWidth', 1.0, 'DisplayName', 'IMU only');
+                [col, has] = getqtycol(iFrame, qty, c);
+                if has
+                    col = interp_to_time(col, t);
+                    plot(ax, t, col, '--', 'Color', colImu, 'LineWidth',1.0, ...
+                        'DisplayName','IMU only');
                 else
-                    p2 = plot(ax, tImu, zeros(size(tImu)), '--', 'Color', colorImu, 'LineWidth', 1.0, 'DisplayName', 'IMU only (missing)');
+                    plot(ax, t, zeros(size(t)), '--', 'Color', colMissing, ...
+                        'DisplayName','IMU only (missing)');
+                    warn = true;
                 end
 
                 % Fused
-                [fusedCol, hasFused] = getqtycol(fusedFrame,qty, c);
-                tFused = resolvetime(time_vec, numel(fusedCol), 'fused');
-                if hasFused
-                    p3 = plot(ax, tFused, fusedCol, '-', 'Color', colorFused, 'LineWidth', 2.0, 'DisplayName', 'Fused');
+                [col, has] = getqtycol(fFrame, qty, c);
+                if has
+                    col = interp_to_time(col, t);
+                    plot(ax, t, col, '-', 'Color', colFused, 'LineWidth',1.2, ...
+                        'DisplayName','Fused');
                 else
-                    p3 = plot(ax, tFused, zeros(size(tFused)), '-', 'Color', colorFused, 'LineWidth', 2.0, 'DisplayName', 'Fused (missing)');
+                    plot(ax, t, zeros(size(t)), '--', 'Color', colMissing, ...
+                        'DisplayName','Fused (missing)');
+                    warn = true;
                 end
 
-                % Legend, axes formatting
-                legend(ax,'Location','north');
+                legend(ax,'Location','northwest');
+                ylabel(ax, rowLabels{r});
+                if r == 3, xlabel(ax,'Time [s]'); end
                 axis(ax,'tight');
-                set(ax,'FontSize',fs);
 
-                % Labels
-                yLabelText = sprintf('%s %s %s', axisName, rowTitles{r}, unitStr);
-                ylabel(ax, yLabelText, 'FontSize', fs);
-                if r == 3
-                    xlabel(ax, 'Time [s]', 'FontSize', fs);
-                end
-
-                % Missing annotation if any missing
-                if ~(hasGnss && hasImu && hasFused)
-                    add_missing_annotation(ax, fs);
+                if warn
+                    add_warning(ax, fs);
                 end
             end
         end
 
         % Save figure
-        drawnow;
-        fname = fileNames{k};
-        outPath = fullfile(outDir, fname);
-        % Ensure figure size in pixels is as required before export
         set(hFig,'Units','pixels','Position',[100 100 1800 1200]);
-        exportgraphics(hFig, outPath, 'Resolution', 200);
-
+        outPath = fullfile(outDir,fileNames{k});
+        exportgraphics(hFig, outPath, 'Resolution',200);
         info = dir(outPath);
         if isempty(info) || info.bytes < 5000
-            error('Save failed: %s', fname);
+            error('Save failed: %s', fileNames{k});
         end
-        fprintf('[SAVE] %s (%d bytes)\n', fname, info.bytes);
-
+        fprintf('[SAVE] %s (%d bytes)\n', info.name, info.bytes);
         close(hFig);
     catch ME
-        if exist('hFig','var') && isvalid(hFig)
-            close(hFig);
-        end
-        warning('Failed to generate %s frame figure: %s', upper(frame), ME.message);
+        if exist('hFig','var') && isvalid(hFig), close(hFig); end
+        warning('Failed to generate %s frame plot: %s', upper(frame), ME.message);
     end
 end
 
-% Close any remaining open figures
 close all;
 
 end
 
-% --------- Helpers ---------
-
-function frameStruct = getframefield(dataStruct, frame)
-% Safely get frame sub-struct (.ned/.ecef/.body), or empty struct
+% ---------------------- Helper Functions ----------------------
+function frameStruct = getframefield(S, frame)
 frameStruct = struct();
 try
-    if isstruct(dataStruct) && isfield(dataStruct, frame) && isstruct(dataStruct.(frame))
-        frameStruct = dataStruct.(frame);
+    if isstruct(S) && isfield(S,frame) && isstruct(S.(frame))
+        frameStruct = S.(frame);
     end
 catch
-    frameStruct = struct();
 end
 end
 
 function [col, has] = getqtycol(frameStruct, qty, idx)
-% Get a single column from frameStruct.(qty) if present and valid
-has = false;
-col = [];
+col = zeros(0,1); has = false;
 try
     if isstruct(frameStruct) && isfield(frameStruct, qty)
         arr = frameStruct.(qty);
-        if isnumeric(arr) && ndims(arr) == 2 && size(arr,2) >= idx
-            col = arr(:,idx);
-            has = true;
+        if isnumeric(arr) && ndims(arr)==2 && size(arr,2)>=idx
+            col = arr(:,idx); has = true;
         end
     end
 catch
-    has = false;
-    col = [];
-end
-if ~has
-    % return empty; caller will build time from length zero -> handle as zero vector
-    col = zeros(0,1);
 end
 end
 
-function t = resolvetime(tv, n, role)
-% Resolve a time vector of length n for a given role: 'gnss'|'imu'|'fused'
-% Supports:
-%  - tv as struct with fields 'gnss','imu','fused' (or 't_gnss', etc.)
-%  - tv as numeric vector (will map via linspace if lengths differ)
-%  - tv as scalar duration (seconds)
-
-% defaults
-t0 = 0; T = 1400;
-
-if nargin < 3 || isempty(role)
-    role = 'fused';
-end
-
-try
-    if isstruct(tv)
-        % Prefer exact field
-        if isfield(tv, role) && isnumeric(tv.(role)) && isvector(tv.(role))
-            tRaw = tv.(role)(:);
-        elseif isfield(tv, ['t_' role]) && isnumeric(tv.(['t_' role])) && isvector(tv.(['t_' role]))
-            tRaw = tv.(['t_' role])(:);
-        else
-            tRaw = [];
-        end
-        if ~isempty(tRaw)
-            t0 = tRaw(1);
-            T  = tRaw(end);
-            if numel(tRaw) == n
-                t = tRaw;
-                return;
-            end
-        end
-        % fallthrough to build by linspace
-    elseif isnumeric(tv) && isvector(tv)
-        tv = tv(:);
-        t0 = tv(1);
-        T  = tv(end);
-        if numel(tv) == n
-            t = tv;
-            return;
-        end
-    elseif isnumeric(tv) && isscalar(tv)
-        T = tv;
-    end
-catch
-    % ignore and use defaults
-end
-
-% Build by linspace
-if n <= 1
-    t = linspace(t0, T, max(n,2)).';
-    t = t(1:n); % keep n elements (possibly 0)
+function out = interp_to_time(data, t)
+n = numel(data);
+if n == numel(t)
+    out = data(:);
+elseif n > 1
+    tOrig = linspace(t(1), t(end), n);
+    out = interp1(tOrig(:), data(:), t, 'linear', 'extrap');
 else
-    t = linspace(t0, T, n).';
+    out = zeros(size(t));
 end
 end
 
-function add_missing_annotation(ax, fs)
-% Add a red warning text inside the axes
-txt = '\x26A0 Missing data'; % fallback if Unicode warning triangle unsupported
+function add_warning(ax, fs)
 try
-    % Try rendering with the given symbol
-    text(ax, 0.02, 0.90, '\x26A0 Missing data', 'Units','normalized', ...
-        'Color',[0.85 0.1 0.1], 'FontWeight','bold', 'FontSize', fs);
+    text(ax,0.02,0.9,char(9888),'Units','normalized','Color',[0.85 0.1 0.1], ...
+        'FontSize',fs,'FontWeight','bold');
 catch
-    % Fallback
-    text(ax, 0.02, 0.90, txt, 'Units','normalized', ...
-        'Color',[0.85 0.1 0.1], 'FontWeight','bold', 'FontSize', fs);
+    text(ax,0.02,0.9,'!', 'Units','normalized','Color',[0.85 0.1 0.1], ...
+        'FontSize',fs,'FontWeight','bold');
 end
 end
 

--- a/MATLAB/task5_plot_fusion_results.m
+++ b/MATLAB/task5_plot_fusion_results.m
@@ -1,185 +1,102 @@
-function task5_plot_fusion_results(fused_data, raw_data, time_vec)
-%TASK5_PLOT_FUSION_RESULTS Standardized plots for Kalman fused results (Task 5).
-%
-% function task5_plot_fusion_results(fused_data, raw_data, time_vec)
-% Inputs:
-%  - fused_data: struct with frames .ned/.ecef/.body/.mixed containing
-%                .pos, .vel, .acc arrays [N x 3]
-%  - raw_data:   struct with frames .ned/.ecef/.body/.mixed containing
-%                .pos, .vel, .acc arrays [N x 3] (raw IMU/integrated)
-%  - time_vec:   numeric vector, scalar duration, or struct with fields
-%                'fused','raw' (or t_fused/t_raw). Used for x-axes.
-%
-% Outputs: Saves PNGs in MATLAB/results with required names and sizes.
+function task5_plot_fusion_results(fused_data, raw_data, time_vec, blowup_times)
+%TASK5_PLOT_FUSION_RESULTS Plot fused vs raw IMU signals with blow-up markers.
+%   task5_plot_fusion_results(fused_data, raw_data, time_vec, blowup_times)
+%   creates one figure per frame (NED, ECEF, Body).  Each figure is a 3x3
+%   grid (rows: Position/Velocity/Acceleration; columns: axis 1/2/3) showing
+%   fused data (blue solid) against raw IMU integration (red dashed).  Red
+%   dashed vertical lines indicate blow-up times.  Missing data are drawn as
+%   grey dashed zero lines and annotated with a red warning symbol.  Figures
+%   are saved to MATLAB/results as 1800x1200 PNGs at 200 DPI.
 
-% Ensure output directory exists
+if nargin < 4, blowup_times = []; end
+
 outDir = fullfile('MATLAB','results');
 if ~exist(outDir,'dir'); mkdir(outDir); end
 
-fs = 12; % font size
+% Colours
+colFused   = [0.000, 0.447, 0.741]; % blue
+colRaw     = [0.850, 0.325, 0.098]; % red
+colBlow    = [0.85,  0.10,  0.10];  % red for markers
+colMissing = [0.5   0.5   0.5];     % grey
 
-% Colors
-colBlue   = [0.000, 0.447, 0.741];
-colOrange = [0.850, 0.325, 0.098];
-colYellow = [0.929, 0.694, 0.125];
-colRed    = [0.85,  0.10,  0.10];
+fs = 12;               % font size
+t  = time_vec(:);      % x-axis
 
-% Task 5 subtitle line 2 for comparison figures
-subtitle_line2_cmp = 'IMU_X002_GNSS_X002_TRIAD | ZUPT=479587 | Blow-ups=9662';
-
-% Extract potential blow-up times (seconds) if provided
-blowup_times = extract_blowups(time_vec, fused_data);
-
-% ---------------------- Main NED fused-only figure ----------------------
-try
-    hFig = figure('Units','pixels','Position',[100 100 1800 1200], 'Color','w', 'Visible','off');
-    sgtitle('Task 5: Fused Results in NED Frame | IMU_X002_GNSS_X002_TRIAD', ...
-        'FontSize', fs, 'FontWeight','bold');
-
-    % Get fused NED data
-    fNED = getframefield(fused_data, 'ned');
-    [posN, hasPos] = getqty(fNED, 'pos');
-    [velN, hasVel] = getqty(fNED, 'vel');
-    [accN, hasAcc] = getqty(fNED, 'acc');
-
-    % Resolve times (use fused timeline)
-    tPos = resolvetime(time_vec, size(posN,1), 'fused');
-    tVel = resolvetime(time_vec, size(velN,1), 'fused');
-    tAcc = resolvetime(time_vec, size(accN,1), 'fused');
-
-    % Row 1: Position
-    ax1 = subplot(3,1,1); hold(ax1,'on'); grid(ax1,'on'); set(ax1,'FontSize',fs);
-    if hasPos
-        plot(ax1, tPos, posN(:,1), '-', 'Color', colBlue,   'DisplayName','North');
-        plot(ax1, tPos, posN(:,2), '-', 'Color', colOrange, 'DisplayName','East');
-        plot(ax1, tPos, posN(:,3), '-', 'Color', colYellow, 'DisplayName','Down');
-    else
-        plot(ax1, tPos, zeros(size(tPos)), '-', 'Color', colBlue,   'DisplayName','North (missing)');
-        plot(ax1, tPos, zeros(size(tPos)), '-', 'Color', colOrange, 'DisplayName','East (missing)');
-        plot(ax1, tPos, zeros(size(tPos)), '-', 'Color', colYellow, 'DisplayName','Down (missing)');
-        add_missing_annotation(ax1, fs);
-    end
-    ylabel(ax1,'Position [m]','FontSize',fs);
-    legend(ax1,'Location','north'); axis(ax1,'tight');
-    draw_blowups(ax1, blowup_times, colRed);
-
-    % Row 2: Velocity
-    ax2 = subplot(3,1,2); hold(ax2,'on'); grid(ax2,'on'); set(ax2,'FontSize',fs);
-    if hasVel
-        plot(ax2, tVel, velN(:,1), '-', 'Color', colBlue,   'DisplayName','North');
-        plot(ax2, tVel, velN(:,2), '-', 'Color', colOrange, 'DisplayName','East');
-        plot(ax2, tVel, velN(:,3), '-', 'Color', colYellow, 'DisplayName','Down');
-    else
-        plot(ax2, tVel, zeros(size(tVel)), '-', 'Color', colBlue,   'DisplayName','North (missing)');
-        plot(ax2, tVel, zeros(size(tVel)), '-', 'Color', colOrange, 'DisplayName','East (missing)');
-        plot(ax2, tVel, zeros(size(tVel)), '-', 'Color', colYellow, 'DisplayName','Down (missing)');
-        add_missing_annotation(ax2, fs);
-    end
-    ylabel(ax2,'Velocity [m/s]','FontSize',fs);
-    legend(ax2,'Location','north'); axis(ax2,'tight');
-    draw_blowups(ax2, blowup_times, colRed);
-
-    % Row 3: Acceleration
-    ax3 = subplot(3,1,3); hold(ax3,'on'); grid(ax3,'on'); set(ax3,'FontSize',fs);
-    if hasAcc
-        plot(ax3, tAcc, accN(:,1), '-', 'Color', colBlue,   'DisplayName','North');
-        plot(ax3, tAcc, accN(:,2), '-', 'Color', colOrange, 'DisplayName','East');
-        plot(ax3, tAcc, accN(:,3), '-', 'Color', colYellow, 'DisplayName','Down');
-    else
-        plot(ax3, tAcc, zeros(size(tAcc)), '-', 'Color', colBlue,   'DisplayName','North (missing)');
-        plot(ax3, tAcc, zeros(size(tAcc)), '-', 'Color', colOrange, 'DisplayName','East (missing)');
-        plot(ax3, tAcc, zeros(size(tAcc)), '-', 'Color', colYellow, 'DisplayName','Down (missing)');
-        add_missing_annotation(ax3, fs);
-    end
-    ylabel(ax3,'Acceleration [m/s²]','FontSize',fs);
-    xlabel(ax3,'Time [s]','FontSize',fs);
-    legend(ax3,'Location','north'); axis(ax3,'tight');
-    draw_blowups(ax3, blowup_times, colRed);
-
-    % Save
-    set(hFig,'Units','pixels','Position',[100 100 1800 1200]);
-    outPath = fullfile(outDir,'IMU_X002_GNSS_X002_TRIAD_task5_fused_ned.png');
-    exportgraphics(hFig, outPath, 'Resolution', 200);
-    info = dir(outPath);
-    if isempty(info) || info.bytes < 5000
-        error('Save failed: %s', 'IMU_X002_GNSS_X002_TRIAD_task5_fused_ned.png');
-    end
-    fprintf('[SAVE] %s (%d bytes)\n', info.name, info.bytes);
-    close(hFig);
-catch ME
-    if exist('hFig','var') && isvalid(hFig), close(hFig); end
-    warning('Failed to generate main NED fused figure: %s', ME.message);
-end
-
-% ---------------------- Comparison figures (per frame) ------------------
-frames = {'mixed','ned','ecef','body'};
+frames = {'ned','ecef','body'};
 axisLabels = {
-    {'Axis 1','Axis 2','Axis 3'}, ... % mixed
-    {'North','East','Down'}, ...      % NED
-    {'X','Y','Z'}, ...                % ECEF
-    {'BX','BY','BZ'}                  % Body
+    {'North','East','Down'}, ...
+    {'X','Y','Z'}, ...
+    {'BX','BY','BZ'}
 };
 fileNames = {
-    'IMU_X002_GNSS_X002_TRIAD_task5_comparison_mixed.png', ...
-    'IMU_X002_GNSS_X002_TRIAD_task5_comparison_ned.png',   ...
-    'IMU_X002_GNSS_X002_TRIAD_task5_comparison_ecef.png',  ...
-    'IMU_X002_GNSS_X002_TRIAD_task5_comparison_body.png'   ...
+    'IMU_X002_GNSS_X002_TRIAD_task5_ned.png', ...
+    'IMU_X002_GNSS_X002_TRIAD_task5_ecef.png', ...
+    'IMU_X002_GNSS_X002_TRIAD_task5_body.png'
 };
+
+quantities = {'pos','vel','acc'};
+rowLabels  = {'Position [m]','Velocity [m/s]','Acceleration [m/s^2]'};
 
 for k = 1:numel(frames)
     frame = frames{k};
     try
-        hFig = figure('Units','pixels','Position',[100 100 1800 1200], 'Color','w', 'Visible','off');
-        line1 = sprintf('Task 5: Fused vs Raw in %s frame', upper(frame));
-        sgtitle({line1; subtitle_line2_cmp}, 'FontSize', fs, 'FontWeight','bold');
+        hFig = figure('Units','pixels','Position',[100 100 1800 1200], ...
+            'Color','w','Visible','off');
+        sgtitle(sprintf('Task 5: Fused vs Raw in %s Frame | IMU_X002_GNSS_X002_TRIAD | Blow-ups=%d', ...
+            upper(frame), numel(blowup_times)), 'FontSize',fs,'FontWeight','bold');
 
-        % Frame data
         fFrame = getframefield(fused_data, frame);
         rFrame = getframefield(raw_data,   frame);
-
-        quantities = {'pos','vel','acc'};
-        rowNames   = {'Position','Velocity','Acceleration'};
-        units      = {'[m]','[m/s]','[m/s²]'};
 
         for r = 1:3
             qty = quantities{r};
             for c = 1:3
-                ax = subplot(3,3,(r-1)*3 + c); hold(ax,'on'); grid(ax,'on'); set(ax,'FontSize',fs);
+                ax = subplot(3,3,(r-1)*3 + c); hold(ax,'on'); grid(ax,'on');
+                set(ax,'FontSize',fs);
                 axisName = axisLabels{k}{c};
 
-                % Extract columns
-                [fCol, hasF] = getqtycol(fFrame, qty, c);
-                [rCol, hasR] = getqtycol(rFrame, qty, c);
+                warn = false;
 
-                tF = resolvetime(time_vec, numel(fCol), 'fused');
-                tR = resolvetime(time_vec, numel(rCol), 'raw');
-
-                % Plot Raw IMU (red dashed) and Fused (blue solid)
-                if hasR
-                    plot(ax, tR, rCol, '--', 'Color', colRed, 'LineWidth', 1.0, 'DisplayName', 'IMU raw');
+                % Raw IMU
+                [col, has] = getqtycol(rFrame, qty, c);
+                if has
+                    col = interp_to_time(col, t);
+                    plot(ax, t, col, '--', 'Color', colRaw, 'LineWidth',1.0, ...
+                        'DisplayName','IMU raw');
                 else
-                    plot(ax, tR, zeros(size(tR)), '--', 'Color', colRed, 'LineWidth', 1.0, 'DisplayName', 'IMU raw (missing)');
-                    add_missing_annotation(ax, fs);
-                end
-                if hasF
-                    plot(ax, tF, fCol, '-', 'Color', colBlue, 'LineWidth', 1.5, 'DisplayName', 'Fused');
-                else
-                    plot(ax, tF, zeros(size(tF)), '-', 'Color', colBlue, 'LineWidth', 1.5, 'DisplayName', 'Fused (missing)');
-                    add_missing_annotation(ax, fs);
+                    plot(ax, t, zeros(size(t)), '--', 'Color', colMissing, ...
+                        'DisplayName','IMU raw (missing)');
+                    warn = true;
                 end
 
-                legend(ax,'Location','north'); axis(ax,'tight');
-                ylabel(ax, sprintf('%s %s %s', axisName, rowNames{r}, units{r}), 'FontSize', fs);
-                if r == 3, xlabel(ax,'Time [s]','FontSize',fs); end
+                % Fused
+                [col, has] = getqtycol(fFrame, qty, c);
+                if has
+                    col = interp_to_time(col, t);
+                    plot(ax, t, col, '-', 'Color', colFused, 'LineWidth',1.2, ...
+                        'DisplayName','Fused');
+                else
+                    plot(ax, t, zeros(size(t)), '--', 'Color', colMissing, ...
+                        'DisplayName','Fused (missing)');
+                    warn = true;
+                end
 
-                draw_blowups(ax, blowup_times, colRed);
+                legend(ax,'Location','northwest');
+                ylabel(ax, rowLabels{r});
+                if r == 3, xlabel(ax,'Time [s]'); end
+                axis(ax,'tight');
+                draw_blowups(ax, blowup_times, colBlow);
+
+                if warn
+                    add_warning(ax, fs);
+                end
             end
         end
 
         % Save
         set(hFig,'Units','pixels','Position',[100 100 1800 1200]);
-        outPath = fullfile(outDir, fileNames{k});
-        exportgraphics(hFig, outPath, 'Resolution', 200);
+        outPath = fullfile(outDir,fileNames{k});
+        exportgraphics(hFig, outPath, 'Resolution',200);
         info = dir(outPath);
         if isempty(info) || info.bytes < 5000
             error('Save failed: %s', fileNames{k});
@@ -188,155 +105,70 @@ for k = 1:numel(frames)
         close(hFig);
     catch ME
         if exist('hFig','var') && isvalid(hFig), close(hFig); end
-        warning('Failed to generate comparison figure for %s: %s', upper(frame), ME.message);
+        warning('Failed to generate Task 5 figure for %s: %s', upper(frame), ME.message);
     end
 end
 
-% Close any remaining open figures
 close all;
 
 end
 
-% ------------------------------ Helpers -------------------------------
-
-function frameStruct = getframefield(dataStruct, frame)
-% Safely fetch frame sub-struct or return empty struct
+% ---------------------- Helper Functions ----------------------
+function frameStruct = getframefield(S, frame)
 frameStruct = struct();
 try
-    if isstruct(dataStruct) && isfield(dataStruct, frame) && isstruct(dataStruct.(frame))
-        frameStruct = dataStruct.(frame);
+    if isstruct(S) && isfield(S,frame) && isstruct(S.(frame))
+        frameStruct = S.(frame);
     end
 catch
-    frameStruct = struct();
-end
-end
-
-function [arr, has] = getqty(frameStruct, qty)
-% Get full array for a quantity if valid
-has = false; arr = zeros(0,3);
-try
-    if isstruct(frameStruct) && isfield(frameStruct, qty)
-        cand = frameStruct.(qty);
-        if isnumeric(cand) && ndims(cand)==2 && size(cand,2)>=3
-            arr = cand;
-            has = true;
-        end
-    end
-catch
-    has = false; arr = zeros(0,3);
 end
 end
 
 function [col, has] = getqtycol(frameStruct, qty, idx)
-% Get a single column if present
-has = false; col = zeros(0,1);
+col = zeros(0,1); has = false;
 try
     if isstruct(frameStruct) && isfield(frameStruct, qty)
         arr = frameStruct.(qty);
         if isnumeric(arr) && ndims(arr)==2 && size(arr,2)>=idx
-            col = arr(:,idx);
-            has = true;
+            col = arr(:,idx); has = true;
         end
     end
 catch
-    has = false; col = zeros(0,1);
 end
 end
 
-function t = resolvetime(tv, n, role)
-% Resolve a time vector of length n for role 'fused' or 'raw'
-t0 = 0; T = 1400;
-if nargin < 3 || isempty(role), role = 'fused'; end
-try
-    if isstruct(tv)
-        if isfield(tv, role) && isnumeric(tv.(role)) && isvector(tv.(role))
-            tr = tv.(role)(:);
-        elseif isfield(tv, ['t_' role]) && isnumeric(tv.(['t_' role])) && isvector(tv.(['t_' role]))
-            tr = tv.(['t_' role])(:);
-        else
-            tr = [];
-        end
-        if ~isempty(tr)
-            if numel(tr) == n
-                t = tr; return;
-            end
-            t0 = tr(1); T = tr(end);
-        end
-    elseif isnumeric(tv) && isvector(tv)
-        tv = tv(:);
-        if numel(tv) == n
-            t = tv; return;
-        end
-        t0 = tv(1); T = tv(end);
-    elseif isnumeric(tv) && isscalar(tv)
-        T = tv;
-    end
-catch
-    % use defaults
-end
-if n <= 1
-    t = linspace(t0, T, max(n,2)).';
-    t = t(1:n);
+function out = interp_to_time(data, t)
+n = numel(data);
+if n == numel(t)
+    out = data(:);
+elseif n > 1
+    tOrig = linspace(t(1), t(end), n);
+    out = interp1(tOrig(:), data(:), t, 'linear', 'extrap');
 else
-    t = linspace(t0, T, n).';
+    out = zeros(size(t));
 end
 end
 
-function add_missing_annotation(ax, fs)
-% Add a red missing data label
+function add_warning(ax, fs)
 try
-    text(ax, 0.02, 0.88, '\x26A0 Missing data', 'Units','normalized', ...
-        'Color',[0.85 0.1 0.1], 'FontWeight','bold', 'FontSize', fs);
+    text(ax,0.02,0.9,char(9888),'Units','normalized','Color',[0.85 0.1 0.1], ...
+        'FontSize',fs,'FontWeight','bold');
 catch
-    text(ax, 0.02, 0.88, 'Missing data', 'Units','normalized', ...
-        'Color',[0.85 0.1 0.1], 'FontWeight','bold', 'FontSize', fs);
+    text(ax,0.02,0.9,'!', 'Units','normalized','Color',[0.85 0.1 0.1], ...
+        'FontSize',fs,'FontWeight','bold');
 end
 end
 
-function draw_blowups(ax, blowup_times, col)
-% Draw vertical lines at provided times
-if nargin < 3 || isempty(col)
-    col = [0.85 0.1 0.1];
-end
-if isempty(blowup_times) || ~isnumeric(blowup_times)
-    return;
-end
-bt = blowup_times(:)';
-for t = bt
+function draw_blowups(ax, times, col)
+if isempty(times), return; end
+times = times(:)';
+for tt = times
     try
-        xline(ax, t, '-', 'Color', col, 'LineWidth', 0.75, 'HandleVisibility','off');
+        xline(ax, tt, '--', 'Color', col, 'HandleVisibility','off');
     catch
-        % older MATLAB without xline; fallback
         yl = ylim(ax);
-        plot(ax, [t t], yl, '-', 'Color', col, 'LineWidth', 0.75, 'HandleVisibility','off');
+        plot(ax, [tt tt], yl, '--', 'Color', col, 'HandleVisibility','off');
     end
-end
-end
-
-function bt = extract_blowups(tv, fused)
-% Attempt to find blow-up times (seconds) from inputs
-bt = [];
-try
-    if isstruct(fused)
-        if isfield(fused,'blowups') && isnumeric(fused.blowups)
-            bt = fused.blowups(:)';
-            return;
-        elseif isfield(fused,'blowup_times') && isnumeric(fused.blowup_times)
-            bt = fused.blowup_times(:)';
-            return;
-        end
-    end
-    if isstruct(tv)
-        if isfield(tv,'blowups') && isnumeric(tv.blowups)
-            bt = tv.blowups(:)';
-            return;
-        elseif isfield(tv,'t_blowups') && isnumeric(tv.t_blowups)
-            bt = tv.t_blowups(:)';
-            return;
-        end
-    end
-catch
-    bt = [];
 end
 end
 

--- a/MATLAB/task6_overlay_truth.m
+++ b/MATLAB/task6_overlay_truth.m
@@ -1,21 +1,23 @@
 function task6_overlay_truth(fused_data, truth_data, time_vec)
-%TASK6_OVERLAY_TRUTH Plot fused vs truth differences and error norms.
-%
-% function task6_overlay_truth(fused_data, truth_data, time_vec)
-% Inputs
-%  - fused_data: struct with frames .ned/.ecef/.body having .pos/.vel/.acc [N x 3]
-%  - truth_data: same frame structure with ground truth arrays [N x 3]
-%  - time_vec: numeric vector, scalar duration, or struct with fields
-%               'fused'/'truth' (or 't_fused'/'t_truth').
-%
-% Saves 4 PNGs into MATLAB/results per the spec, with size checks.
+%TASK6_OVERLAY_TRUTH Plot fused minus truth differences for Task 6.
+%   task6_overlay_truth(fused_data, truth_data, time_vec) creates three
+%   figures (NED, ECEF, Body).  Each figure is a 3x3 grid with rows for
+%   Position/Velocity/Acceleration differences and columns for axes 1/2/3.
+%   The differences (fused - truth) are plotted in blue with horizontal red
+%   lines at ±1.  The number of samples exceeding the threshold is shown as
+%   text.  Missing inputs produce grey dashed zero lines and a red warning
+%   symbol.  Figures are saved as 1800x1200 PNGs at 200 DPI in
+%   MATLAB/results.
 
 outDir = fullfile('MATLAB','results');
 if ~exist(outDir,'dir'); mkdir(outDir); end
 
+colDiff    = [0.000, 0.447, 0.741]; % blue
+colThresh  = [0.85,  0.10,  0.10];  % red
+colMissing = [0.5   0.5   0.5];     % grey
+
 fs = 12;
-colDiff = [0.000, 0.447, 0.741]; % blue
-colThr  = [0.85,  0.10,  0.10];  % red
+t  = time_vec(:);
 
 frames = {'ned','ecef','body'};
 axisLabels = {
@@ -26,70 +28,69 @@ axisLabels = {
 fileNames = {
     'IMU_X002_GNSS_X002_TRIAD_task6_diff_ned.png', ...
     'IMU_X002_GNSS_X002_TRIAD_task6_diff_ecef.png', ...
-    'IMU_X002_GNSS_X002_TRIAD_task6_diff_body.png'  ...
+    'IMU_X002_GNSS_X002_TRIAD_task6_diff_body.png'
 };
+
+quantities = {'pos','vel','acc'};
+rowLabels  = {'Position Diff [m]','Velocity Diff [m/s]','Acceleration Diff [m/s^2]'};
 
 for k = 1:numel(frames)
     frame = frames{k};
     try
+        hFig = figure('Units','pixels','Position',[100 100 1800 1200], ...
+            'Color','w','Visible','off');
+        sgtitle(sprintf('Task 6: Fused - Truth Diffs in %s | IMU_X002_GNSS_X002_TRIAD', ...
+            upper(frame)), 'FontSize',fs,'FontWeight','bold');
+
         fFrame = getframefield(fused_data, frame);
         tFrame = getframefield(truth_data, frame);
 
-        % Differences (align lengths by truncation)
-        [posDiff, hasPos] = diff_aligned(fFrame, tFrame, 'pos');
-        [velDiff, hasVel] = diff_aligned(fFrame, tFrame, 'vel');
-
-        % Time vectors (use fused timeline length where available)
-        nPos = size(posDiff,1); nVel = size(velDiff,1);
-        tPos = resolvetime(time_vec, nPos, 'fused');
-        tVel = resolvetime(time_vec, nVel, 'fused');
-
-        hFig = figure('Units','pixels','Position',[100 100 1800 1200], 'Color','w', 'Visible','off');
-        sgtitle(sprintf('Task 6: Fused vs Truth Diffs in %s | IMU_X002_GNSS_X002_TRIAD', upper(frame)), ...
-            'FontSize', fs, 'FontWeight','bold');
-
-        rowNames = {'Position Diff [m]','Velocity Diff [m/s]'};
-        for r = 1:2
+        for r = 1:3
+            qty = quantities{r};
             for c = 1:3
-                ax = subplot(2,3,(r-1)*3 + c); hold(ax,'on'); grid(ax,'on'); set(ax,'FontSize',fs);
+                ax = subplot(3,3,(r-1)*3 + c); hold(ax,'on'); grid(ax,'on');
+                set(ax,'FontSize',fs);
                 axisName = axisLabels{k}{c};
-                if r == 1
-                    if hasPos
-                        plot(ax, tPos, posDiff(:,c), '-', 'Color', colDiff, 'LineWidth', 1.25, 'DisplayName','Diff');
-                        nExc = sum(abs(posDiff(:,c)) > 1);
-                    else
-                        plot(ax, tPos, zeros(size(tPos)), '-', 'Color', colDiff, 'LineWidth', 1.25, 'DisplayName','Diff (missing)');
-                        nExc = 0; add_missing_annotation(ax, fs);
-                    end
-                    thr = 1; yline(ax, thr, '-', 'Color', colThr, 'HandleVisibility','off'); yline(ax, -thr, '-', 'Color', colThr, 'HandleVisibility','off');
-                    title(ax, sprintf('%s %s', axisName, rowNames{r}), 'FontSize', fs);
+
+                warn = false;
+                thr  = 1; % threshold for exceedance
+                nExc = 0;
+
+                [fCol, hasF] = getqtycol(fFrame, qty, c);
+                [tCol, hasT] = getqtycol(tFrame, qty, c);
+                if hasF && hasT
+                    fCol = interp_to_time(fCol, t);
+                    tCol = interp_to_time(tCol, t);
+                    diffCol = fCol - tCol;
+                    plot(ax, t, diffCol, '-', 'Color', colDiff, 'LineWidth',1.2, ...
+                        'DisplayName','Diff');
+                    nExc = sum(abs(diffCol) > thr);
                 else
-                    if hasVel
-                        plot(ax, tVel, velDiff(:,c), '-', 'Color', colDiff, 'LineWidth', 1.25, 'DisplayName','Diff');
-                        nExc = sum(abs(velDiff(:,c)) > 1);
-                    else
-                        plot(ax, tVel, zeros(size(tVel)), '-', 'Color', colDiff, 'LineWidth', 1.25, 'DisplayName','Diff (missing)');
-                        nExc = 0; add_missing_annotation(ax, fs);
-                    end
-                    thr = 1; yline(ax, thr, '-', 'Color', colThr, 'HandleVisibility','off'); yline(ax, -thr, '-', 'Color', colThr, 'HandleVisibility','off');
-                    title(ax, sprintf('%s %s', axisName, rowNames{r}), 'FontSize', fs);
+                    plot(ax, t, zeros(size(t)), '--', 'Color', colMissing, ...
+                        'DisplayName','Diff (missing)');
+                    warn = true;
                 end
 
-                if r == 2
-                    xlabel(ax,'Time [s]','FontSize',fs);
-                end
-                % Exceedance annotation
-                text(ax, 0.02, 0.90, sprintf('Samples exceeding 1m/1m/s: %d', nExc), ...
-                    'Units','normalized','Color',colThr,'FontSize',fs,'FontWeight','bold');
+                yline(ax, thr, '-', 'Color', colThresh, 'HandleVisibility','off');
+                yline(ax,-thr, '-', 'Color', colThresh, 'HandleVisibility','off');
+                text(ax,0.02,0.85,sprintf('Exceed >1: %d', nExc), ...
+                    'Units','normalized','Color',colThresh,'FontSize',fs,'FontWeight','bold');
 
+                legend(ax,'Location','northwest');
+                ylabel(ax, rowLabels{r});
+                if r == 3, xlabel(ax,'Time [s]'); end
                 axis(ax,'tight');
+
+                if warn
+                    add_warning(ax, fs);
+                end
             end
         end
 
         % Save figure
         set(hFig,'Units','pixels','Position',[100 100 1800 1200]);
-        outPath = fullfile(outDir, fileNames{k});
-        exportgraphics(hFig, outPath, 'Resolution', 200);
+        outPath = fullfile(outDir,fileNames{k});
+        exportgraphics(hFig, outPath, 'Resolution',200);
         info = dir(outPath);
         if isempty(info) || info.bytes < 5000
             error('Save failed: %s', fileNames{k});
@@ -98,134 +99,57 @@ for k = 1:numel(frames)
         close(hFig);
     catch ME
         if exist('hFig','var') && isvalid(hFig), close(hFig); end
-        warning('Failed to generate Task 6 diffs for %s: %s', upper(frame), ME.message);
+        warning('Failed to generate Task 6 figure for %s: %s', upper(frame), ME.message);
     end
 end
 
-% ---------------------- Error Norms Figure (NED priority) ---------------
-% Choose frame for norms (NED -> ECEF -> BODY)
-frameOrder = {'ned','ecef','body'};
-chosen = '';
-for i = 1:numel(frameOrder)
-    if isfield(fused_data, frameOrder{i}) && isfield(truth_data, frameOrder{i})
-        chosen = frameOrder{i}; break;
-    end
-end
-if isempty(chosen); chosen = 'ned'; end % fall back to ned naming
-
-try
-    fFrame = getframefield(fused_data, chosen);
-    tFrame = getframefield(truth_data, chosen);
-    [posDiff, hasPos] = diff_aligned(fFrame, tFrame, 'pos');
-    [velDiff, hasVel] = diff_aligned(fFrame, tFrame, 'vel');
-    [accDiff, hasAcc] = diff_aligned(fFrame, tFrame, 'acc');
-    tPos = resolvetime(time_vec, size(posDiff,1), 'fused');
-    tVel = resolvetime(time_vec, size(velDiff,1), 'fused');
-    tAcc = resolvetime(time_vec, size(accDiff,1), 'fused');
-
-    posNorm = nrm(posDiff);
-    velNorm = nrm(velDiff);
-    accNorm = nrm(accDiff);
-
-    hFig = figure('Units','pixels','Position',[100 100 1800 1200], 'Color','w', 'Visible','off');
-    sgtitle('Task 6: Error Norms | IMU_X002_GNSS_X002_TRIAD', 'FontSize', fs, 'FontWeight','bold');
-
-    ax1 = subplot(3,1,1); hold(ax1,'on'); grid(ax1,'on'); set(ax1,'FontSize',fs);
-    if hasPos, plot(ax1, tPos, posNorm, '-', 'Color', colDiff, 'DisplayName','Error Norm');
-    else, plot(ax1, tPos, zeros(size(tPos)), '-', 'Color', colDiff, 'DisplayName','Error Norm (missing)'); add_missing_annotation(ax1, fs); end
-    ylabel(ax1,'Position Norm [m]','FontSize',fs); legend(ax1,'Location','north'); axis(ax1,'tight');
-
-    ax2 = subplot(3,1,2); hold(ax2,'on'); grid(ax2,'on'); set(ax2,'FontSize',fs);
-    if hasVel, plot(ax2, tVel, velNorm, '-', 'Color', colDiff, 'DisplayName','Error Norm');
-    else, plot(ax2, tVel, zeros(size(tVel)), '-', 'Color', colDiff, 'DisplayName','Error Norm (missing)'); add_missing_annotation(ax2, fs); end
-    ylabel(ax2,'Velocity Norm [m/s]','FontSize',fs); legend(ax2,'Location','north'); axis(ax2,'tight');
-
-    ax3 = subplot(3,1,3); hold(ax3,'on'); grid(ax3,'on'); set(ax3,'FontSize',fs);
-    if hasAcc, plot(ax3, tAcc, accNorm, '-', 'Color', colDiff, 'DisplayName','Error Norm');
-    else, plot(ax3, tAcc, zeros(size(tAcc)), '-', 'Color', colDiff, 'DisplayName','Error Norm (missing)'); add_missing_annotation(ax3, fs); end
-    ylabel(ax3,'Acceleration Norm [m/s²]','FontSize',fs); xlabel(ax3,'Time [s]','FontSize',fs); legend(ax3,'Location','north'); axis(ax3,'tight');
-
-    % Save
-    set(hFig,'Units','pixels','Position',[100 100 1800 1200]);
-    outPath = fullfile(outDir, 'IMU_X002_GNSS_X002_TRIAD_task6_error_norms.png');
-    exportgraphics(hFig, outPath, 'Resolution', 200);
-    info = dir(outPath);
-    if isempty(info) || info.bytes < 5000
-        error('Save failed: %s', 'IMU_X002_GNSS_X002_TRIAD_task6_error_norms.png');
-    end
-    fprintf('[SAVE] %s (%d bytes)\n', info.name, info.bytes);
-    close(hFig);
-catch ME
-    if exist('hFig','var') && isvalid(hFig), close(hFig); end
-    warning('Failed to generate Task 6 error norms: %s', ME.message);
-end
-
-% Close any remaining open figures
 close all;
 
 end
 
-% ----------------------------- Helpers ---------------------------------
-
-function frameStruct = getframefield(dataStruct, frame)
+% ---------------------- Helper Functions ----------------------
+function frameStruct = getframefield(S, frame)
 frameStruct = struct();
 try
-    if isstruct(dataStruct) && isfield(dataStruct, frame) && isstruct(dataStruct.(frame))
-        frameStruct = dataStruct.(frame);
+    if isstruct(S) && isfield(S,frame) && isstruct(S.(frame))
+        frameStruct = S.(frame);
     end
 catch
-    frameStruct = struct();
 end
 end
 
-function [diffs, has] = diff_aligned(fFrame, tFrame, qty)
-diffs = zeros(0,3); has = false;
+function [col, has] = getqtycol(frameStruct, qty, idx)
+col = zeros(0,1); has = false;
 try
-    if isstruct(fFrame) && isstruct(tFrame) && isfield(fFrame, qty) && isfield(tFrame, qty)
-        A = fFrame.(qty); B = tFrame.(qty);
-        if isnumeric(A) && isnumeric(B) && size(A,2)>=3 && size(B,2)>=3
-            n = min(size(A,1), size(B,1));
-            diffs = A(1:n,1:3) - B(1:n,1:3);
-            has = true;
+    if isstruct(frameStruct) && isfield(frameStruct, qty)
+        arr = frameStruct.(qty);
+        if isnumeric(arr) && ndims(arr)==2 && size(arr,2)>=idx
+            col = arr(:,idx); has = true;
         end
     end
 catch
-    diffs = zeros(0,3); has = false;
 end
 end
 
-function t = resolvetime(tv, n, role)
-t0 = 0; T = 1400; if nargin<3||isempty(role), role='fused'; end
-try
-    if isstruct(tv)
-        if isfield(tv, role) && isnumeric(tv.(role)) && isvector(tv.(role))
-            tr = tv.(role)(:); if numel(tr)==n, t=tr; return; else, t0=tr(1); T=tr(end); end
-        elseif isfield(tv, ['t_' role]) && isnumeric(tv.(['t_' role])) && isvector(tv.(['t_' role]))
-            tr = tv.(['t_' role])(:); if numel(tr)==n, t=tr; return; else, t0=tr(1); T=tr(end); end
-        end
-    elseif isnumeric(tv) && isvector(tv)
-        tv=tv(:); if numel(tv)==n, t=tv; return; else, t0=tv(1); T=tv(end); end
-    elseif isnumeric(tv) && isscalar(tv)
-        T = tv;
-    end
-catch
-end
-if n<=1, t = linspace(t0,T,max(n,2)).'; t=t(1:n); else, t = linspace(t0,T,n).'; end
-end
-
-function add_missing_annotation(ax, fs)
-try
-    text(ax, 0.02, 0.90, '\x26A0 Missing data', 'Units','normalized', 'Color',[0.85 0.1 0.1], 'FontWeight','bold', 'FontSize', fs);
-catch
-    text(ax, 0.02, 0.90, 'Missing data', 'Units','normalized', 'Color',[0.85 0.1 0.1], 'FontWeight','bold', 'FontSize', fs);
-end
-end
-
-function v = nrm(M)
-if isempty(M)
-    v = zeros(0,1);
+function out = interp_to_time(data, t)
+n = numel(data);
+if n == numel(t)
+    out = data(:);
+elseif n > 1
+    tOrig = linspace(t(1), t(end), n);
+    out = interp1(tOrig(:), data(:), t, 'linear', 'extrap');
 else
-    v = sqrt(sum(M.^2, 2));
+    out = zeros(size(t));
+end
+end
+
+function add_warning(ax, fs)
+try
+    text(ax,0.02,0.9,char(9888),'Units','normalized','Color',[0.85 0.1 0.1], ...
+        'FontSize',fs,'FontWeight','bold');
+catch
+    text(ax,0.02,0.9,'!', 'Units','normalized','Color',[0.85 0.1 0.1], ...
+        'FontSize',fs,'FontWeight','bold');
 end
 end
 


### PR DESCRIPTION
## Summary
- Rewrite Task 4 comparison plotting with 3x3 grids per frame and missing-data warnings
- Add Task 5 fused vs raw IMU plots with blow-up markers and per-frame output
- Implement Task 6 fused-minus-truth diff plots with threshold annotations

## Testing
- `pytest -q` *(fails: No module named 'src')*
- `pip install -e .[tests]` *(fails: Multiple top-level packages discovered in a flat-layout)*

------
https://chatgpt.com/codex/tasks/task_e_689d9aba447c832283f3064f29b91c95