### PR TITLE
Fix Task 4 plot labelling

### DIFF
--- a/PYTHON/scripts/generate_plots_fixed.py
+++ b/PYTHON/scripts/generate_plots_fixed.py
@@ -41,7 +41,7 @@ def main() -> None:
             dataset=DATASET,
             out_dir=OUT_DIR,
             t_fused=t,
-            fused=fused,
+            fused=None,
             t_gnss=t,
             gnss=gnss,
             t_imu=t,


### PR DESCRIPTION
## Summary
- Omit fused data when generating Task 4 grids and clarify GNSS/IMU as measured or derived
- Skip passing fused series to Task 4 plots in the sample plot generator

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_689dab3465888322a075908b7984c237