### PR TITLE
Add derived IMU/GNSS results for Task 4

### DIFF
--- a/MATLAB/task4_gnss_imu_integration.m
+++ b/MATLAB/task4_gnss_imu_integration.m
@@ -75,6 +75,39 @@ for i=2:N
     pos_imu_ned(i,:) = pos_imu_ned(i-1,:) + vel_imu_ned(i,:)*dt;
 end
 
+%% Frame transformations
+accel_ecef_gnss = [zeros(1,3); diff(ecef_vel)./diff(gnss_data.Posix_Time)];
+C_n2b = C_b2n';
+
+% GNSS derived quantities
+pos_body_gnss = (C_n2b*pos_ned_gnss.').';
+vel_body_gnss = (C_n2b*vel_ned_gnss.').';
+accel_body_gnss = (C_n2b*accel_ned_gnss.').';
+
+derived_gnss.ecef.acc = accel_ecef_gnss;
+derived_gnss.body.pos = pos_body_gnss;
+derived_gnss.body.vel = vel_body_gnss;
+derived_gnss.body.acc = accel_body_gnss;
+derived_gnss.ned.pos  = pos_ned_gnss;
+derived_gnss.ned.vel  = vel_ned_gnss;
+derived_gnss.ned.acc  = accel_ned_gnss;
+
+% IMU derived quantities
+pos_ecef_imu = (C_n2e*pos_imu_ned.').' + r0.';
+vel_ecef_imu = (C_n2e*vel_imu_ned.').';
+accel_ecef_imu = (C_n2e*accel_ned.').';
+pos_imu_body = (C_n2b*pos_imu_ned.').';
+vel_imu_body = (C_n2b*vel_imu_ned.').';
+
+derived_imu.ecef.pos = pos_ecef_imu;
+derived_imu.ecef.vel = vel_ecef_imu;
+derived_imu.ecef.acc = accel_ecef_imu;
+derived_imu.body.pos = pos_imu_body;
+derived_imu.body.vel = vel_imu_body;
+derived_imu.ned.pos  = pos_imu_ned;
+derived_imu.ned.vel  = vel_imu_ned;
+derived_imu.ned.acc  = accel_ned;
+
 %% Validation information
 rms_acc = sqrt(mean(sum(accel_ned_gnss.^2,2)));
 fprintf('GNSS NED pos first=[%.2f %.2f %.2f], last=[%.2f %.2f %.2f]\n', ...
@@ -97,5 +130,6 @@ save_plot(fig, 'IMU', 'GNSS', 'TRIAD', 4, cfg.plots.save_pdf, cfg.plots.save_png
 %% Save results
 out_file = fullfile(results_dir,'Task4_results_IMU_GNSS.mat');
 save(out_file,'pos_ned_gnss','vel_ned_gnss','accel_ned_gnss', ...
-                 'pos_imu_ned','vel_imu_ned','accel_ned','C_e2n','C_n2e','r0','lat_ref','lon_ref');
+                 'pos_imu_ned','vel_imu_ned','accel_ned','C_e2n','C_n2e','r0','lat_ref','lon_ref', ...
+                 'derived_gnss','derived_imu');
 end

--- a/MATLAB/task4_plot_comparisons.m
+++ b/MATLAB/task4_plot_comparisons.m
@@ -9,7 +9,7 @@ function task4_plot_comparisons(gnss_data, imu_data, fused_data, time_vec)
 %   MATLAB/results as 1800x1200 PNGs at 200 DPI.
 % Removed redundant individual NED pos/vel/acc plots as they do not make
 % sense in Task 4.
-% Task 4: Removed Fused labels; using measured/derived for GNSS/IMU.
+% Task 4: Label results as "Derived GNSS" or "Derived IMU".
 
 disp('Task 4: Removed nonsensical individual NED plots.');
 
@@ -45,17 +45,8 @@ for k = 1:numel(frames)
 
         gFrame = getframefield(gnss_data, frame);
         iFrame = getframefield(imu_data,  frame);
-
-        if strcmp(frame,'ned')
-            gnssLabel = 'GNSS (derived)';
-            imuLabel  = 'IMU only (derived)';
-        elseif strcmp(frame,'ecef')
-            gnssLabel = 'GNSS (measured)';
-            imuLabel  = 'IMU only (derived)';
-        else
-            gnssLabel = 'GNSS (derived)';
-            imuLabel  = 'IMU (measured)';
-        end
+        gnssLabel = 'Derived GNSS';
+        imuLabel  = 'Derived IMU';
 
         for r = 1:3
             qty = quantities{r};
@@ -118,7 +109,7 @@ end
 
 close all;
 
-disp('Task 4: Updated all_ned plot with measured/derived labels; no fused data.');
+disp('Task 4: Updated all_ned plot with Derived GNSS/IMU labels; no fused data.');
 
 end
 

--- a/Report/task4_integration.md
+++ b/Report/task4_integration.md
@@ -12,3 +12,9 @@ results/run_triad_only/<tag>_task4_all_ned.pdf
 results/run_triad_only/<tag>_task4_all_ecef.pdf
 results/run_triad_only/<tag>_task4_all_body.pdf
 ```
+
+The results file `Task4_results_IMU_GNSS.mat` now groups the outputs into
+`derived_imu` and `derived_gnss` structures. Each structure contains
+position, velocity and, where available, acceleration in the ECEF, body and
+NED frames. This labelling distinguishes quantities derived from the IMU
+integration from those derived from GNSS measurements.


### PR DESCRIPTION
## Summary
- Capture ECEF, body, and NED frame outputs for both sensors and group them into `derived_imu` and `derived_gnss` structures
- Update Task 4 comparison plots to label data as **Derived GNSS** or **Derived IMU**
- Document the new Task 4 result structures in the integration report

## Testing
- `make test` *(failed: Multiple top-level packages discovered)*
- `pytest` *(29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689dd7ec065c832294dfd15dcf6594e1