### PR TITLE
Clarify IMU/GNSS labels in overlay plots

### DIFF
--- a/MATLAB/plot_overlay.m
+++ b/MATLAB/plot_overlay.m
@@ -52,8 +52,9 @@ catch
 end
 
 subplot(4,1,1); hold on;
-plot(t_gnss, vecnorm(pos_gnss,2,2), 'k-', 'DisplayName', 'Measured GNSS');
-plot(t_imu, vecnorm(pos_imu,2,2), 'c--', 'DisplayName', 'Derived IMU');
+[gnssLabel, imuLabel] = get_labels(frame, 'pos');
+plot(t_gnss, vecnorm(pos_gnss,2,2), 'k-', 'DisplayName', gnssLabel);
+plot(t_imu, vecnorm(pos_imu,2,2), 'c--', 'DisplayName', imuLabel);
 if ~isempty(Ttruth) && ~isempty(ptruth)
     plot(Ttruth, vecnorm(ptruth,2,2), 'm-', 'DisplayName', 'Truth');
 end
@@ -62,8 +63,9 @@ ylabel('Position [m]');
 legend('show');
 
 subplot(4,1,2); hold on;
-plot(t_gnss, vecnorm(vel_gnss,2,2), 'k-', 'DisplayName', 'Measured GNSS');
-plot(t_imu, vecnorm(vel_imu,2,2), 'c--', 'DisplayName', 'Derived IMU');
+[gnssLabel, imuLabel] = get_labels(frame, 'vel');
+plot(t_gnss, vecnorm(vel_gnss,2,2), 'k-', 'DisplayName', gnssLabel);
+plot(t_imu, vecnorm(vel_imu,2,2), 'c--', 'DisplayName', imuLabel);
 if ~isempty(Ttruth) && ~isempty(vtruth)
     plot(Ttruth, vecnorm(vtruth,2,2), 'm-', 'DisplayName', 'Truth');
 end
@@ -71,8 +73,9 @@ plot(t_fused, vecnorm(vel_fused,2,2), 'g:', 'DisplayName', ['Fused ' method]);
 ylabel('Velocity [m/s]');
 
 subplot(4,1,3); hold on;
-plot(t_gnss, vecnorm(acc_gnss,2,2), 'k-', 'DisplayName', 'Measured GNSS');
-plot(t_imu, vecnorm(acc_imu,2,2), 'c--', 'DisplayName', 'Derived IMU');
+[gnssLabel, imuLabel] = get_labels(frame, 'acc');
+plot(t_gnss, vecnorm(acc_gnss,2,2), 'k-', 'DisplayName', gnssLabel);
+plot(t_imu, vecnorm(acc_imu,2,2), 'c--', 'DisplayName', imuLabel);
 if ~isempty(Ttruth) && ~isempty(atruth)
     plot(Ttruth, vecnorm(atruth,2,2), 'm-', 'DisplayName', 'Truth');
 end
@@ -80,8 +83,9 @@ plot(t_fused, vecnorm(acc_fused,2,2), 'g:', 'DisplayName', ['Fused ' method]);
 ylabel('Acceleration [m/s^2]');
 
 subplot(4,1,4); hold on;
-plot(pos_gnss(:,1), pos_gnss(:,2), 'k-', 'DisplayName', 'Measured GNSS');
-plot(pos_imu(:,1), pos_imu(:,2), 'c--', 'DisplayName', 'Derived IMU');
+[gnssLabel, imuLabel] = get_labels(frame, 'pos');
+plot(pos_gnss(:,1), pos_gnss(:,2), 'k-', 'DisplayName', gnssLabel);
+plot(pos_imu(:,1), pos_imu(:,2), 'c--', 'DisplayName', imuLabel);
 if ~isempty(ptruth)
     plot(ptruth(:,1), ptruth(:,2), 'm-', 'DisplayName', 'Truth');
 end
@@ -111,5 +115,29 @@ try
 catch
 end
 close(h);
-fprintf('Saved overlay figure to %s\n', png_file);
+    fprintf('Saved overlay figure to %s\n', png_file);
+end
+
+function [gnssLabel, imuLabel] = get_labels(frame, qty)
+%GET_LABELS Return GNSS/IMU legend labels based on frame and quantity.
+frame = lower(frame);
+switch frame
+    case 'ecef'
+        if any(strcmp(qty, {'pos','vel'}))
+            gnssLabel = 'Measured GNSS';
+        else
+            gnssLabel = 'Derived GNSS';
+        end
+        imuLabel = 'Derived IMU';
+    case 'body'
+        gnssLabel = 'Derived GNSS';
+        if strcmp(qty, 'acc')
+            imuLabel = 'Measured IMU';
+        else
+            imuLabel = 'Derived IMU';
+        end
+    otherwise % NED
+        gnssLabel = 'Derived GNSS';
+        imuLabel  = 'Derived IMU';
+end
 end

--- a/PYTHON/src/plot_overlay.py
+++ b/PYTHON/src/plot_overlay.py
@@ -187,12 +187,13 @@ def _plot_overlay_static(
     if suffix is None:
         suffix = "_overlay_state.pdf" if t_truth is not None else "_overlay.pdf"
 
+    frame_upper = frame.upper()
     axis_labels = {
         "NED": ["\u0394N [m]", "\u0394E [m]", "\u0394D [m]"],
         "ECEF": ["X", "Y", "Z"],
-        "Body": ["X", "Y", "Z"],
+        "BODY": ["X", "Y", "Z"],
     }
-    cols = axis_labels.get(frame, ["X", "Y", "Z"])
+    cols = axis_labels.get(frame_upper, ["X", "Y", "Z"])
 
     fig, axes = plt.subplots(3, 3, figsize=(12, 9), sharex=True)
 
@@ -216,18 +217,24 @@ def _plot_overlay_static(
             ax = axes[row, col]
             values = [fused[:, col]]
             if include_measurements:
+                gnss_label = (
+                    "Measured GNSS" if frame_upper == "ECEF" and row < 2 else "Derived GNSS"
+                )
                 ax.plot(
                     t_gnss,
                     gnss[:, col],
                     color=color_map["GNSS"],
-                    label="Measured GNSS",
+                    label=gnss_label,
+                )
+                imu_label = (
+                    "Measured IMU" if frame_upper == "BODY" and row == 2 else "Derived IMU"
                 )
                 ax.plot(
                     t_imu,
                     imu[:, col],
                     linestyle="--",
                     color=color_map["IMU"],
-                    label="Measured IMU",
+                    label=imu_label,
                 )
                 values.append(gnss[:, col])
                 values.append(imu[:, col])

--- a/PYTHON/src/plot_overlay_interactive.py
+++ b/PYTHON/src/plot_overlay_interactive.py
@@ -78,13 +78,14 @@ def plot_overlay_interactive(
     if truth is not None:
         t_truth, pos_truth, vel_truth, acc_truth = truth
 
+    frame_upper = frame.upper()
     # Define axis labels for different coordinate frames
     axis_labels = {
         "NED": ["ΔN [m]", "ΔE [m]", "ΔD [m]"],
         "ECEF": ["X [m]", "Y [m]", "Z [m]"],
-        "Body": ["X [m]", "Y [m]", "Z [m]"],
+        "BODY": ["X [m]", "Y [m]", "Z [m]"],
     }
-    cols = axis_labels.get(frame, ["X [m]", "Y [m]", "Z [m]"])
+    cols = axis_labels.get(frame_upper, ["X [m]", "Y [m]", "Z [m]"])
 
     # Create subplot figure with 3x3 layout
     subplot_titles = [
@@ -136,12 +137,15 @@ def plot_overlay_interactive(
             # Add measured data if requested
             if include_measurements:
                 # GNSS measurements
+                gnss_label = (
+                    'Measured GNSS' if frame_upper == 'ECEF' and row < 2 else 'Derived GNSS'
+                )
                 fig.add_trace(
                     go.Scatter(
                         x=t_gnss,
                         y=gnss[:, col],
                         mode='lines',
-                        name='Measured GNSS',
+                        name=gnss_label,
                         line=dict(color=colors["GNSS"]),
                         hovertemplate=f'<b>GNSS {data_type}</b><br>' +
                                      f'Time: %{{x:.2f}} s<br>' +
@@ -150,14 +154,17 @@ def plot_overlay_interactive(
                     ),
                     row=subplot_row, col=subplot_col
                 )
-                
+
                 # IMU measurements
+                imu_label = (
+                    'Measured IMU' if frame_upper == 'BODY' and row == 2 else 'Derived IMU'
+                )
                 fig.add_trace(
                     go.Scatter(
                         x=t_imu,
                         y=imu[:, col],
                         mode='lines',
-                        name='Measured IMU',
+                        name=imu_label,
                         line=dict(color=colors["IMU"], dash='dash'),
                         hovertemplate=f'<b>IMU {data_type}</b><br>' +
                                      f'Time: %{{x:.2f}} s<br>' +


### PR DESCRIPTION
## Summary
- Compute frame-specific axis labels and series labels in `plot_overlay`.
- Apply the same dynamic IMU/GNSS labelling logic in the interactive overlay plot.
- Extend derived/measured IMU and GNSS labelling to the MATLAB overlay utility.

## Testing
- `PYTHONPATH=PYTHON pytest PYTHON/tests/test_plot_overlay.py`
- `octave -qf test_matlab_simple.m` *(fails: 'plot_overlay_interactive_3x3' undefined)*

------
https://chatgpt.com/codex/tasks/task_e_689de3daec7083228f66824a7dada57c