### PR TITLE
feat: use transformed truth data in task5 plots

### DIFF
--- a/MATLAB/read_truth_file.m
+++ b/MATLAB/read_truth_file.m
@@ -1,27 +1,62 @@
 function truth = read_truth_file(filename)
-%READ_TRUTH_FILE Load STATE_X truth file and convert to NED.
+%READ_TRUTH_FILE Load STATE_X truth file and provide multi-frame states.
 %   TRUTH = READ_TRUTH_FILE(FILENAME) reads the ground truth text file
-%   ``STATE_X*.txt`` which contains ECEF position and velocity along with
-%   quaternions. The output structure has fields:
-%       time     - Nx1 time vector [s]
-%       pos_ned  - Nx3 position in NED [m]
-%       vel_ned  - Nx3 velocity in NED [m/s]
-%
-%   The NED frame uses the first sample as the origin.
+%   ``STATE_X*.txt`` which contains ECEF position, velocity and quaternions.
+%   The returned struct contains fields for the time vector and the
+%   position/velocity/acceleration expressed in the ECEF, NED and Body
+%   reference frames.  Acceleration is obtained by differentiating the
+%   velocity series with forward differences.
 
     if nargin < 1
         error('read_truth_file:MissingFile','Filename required');
     end
+
     data = read_state_file(filename);
-    t = data(:,2);
-    pos_ecef = data(:,3:5);
-    vel_ecef = data(:,6:8);
+    if isempty(data)
+        error('read_truth_file:NoData','Truth file %s contained no data', filename);
+    end
+
+    t         = data(:,2);
+    pos_ecef  = data(:,3:5);
+    vel_ecef  = data(:,6:8);
+    quat_e2b  = data(:,9:12); % quaternions (wxyz) ECEF->Body
+
+    % Estimate acceleration in ECEF via numerical differentiation
+    dt = diff(t);
+    acc_ecef = [zeros(1,3); diff(vel_ecef)./dt];
+
+    % Reference for NED transformation: first sample as origin
     r0 = pos_ecef(1,:);  % origin
     [lat_deg, lon_deg, ~] = ecef_to_geodetic(r0(1), r0(2), r0(3));
-    C = compute_C_ECEF_to_NED(deg2rad(lat_deg), deg2rad(lon_deg));
-    pos_ned = (C * (pos_ecef' - r0')).';
-    vel_ned = (C * vel_ecef').';
+    lat = deg2rad(lat_deg); lon = deg2rad(lon_deg);
+    C_e2n = compute_C_ECEF_to_NED(lat, lon);
+    pos_ned = (C_e2n * (pos_ecef' - r0')).';
+    vel_ned = (C_e2n * vel_ecef').';
+    acc_ned = (C_e2n * acc_ecef').';
+
+    % Body frame using provided quaternions (assumed ECEF->Body)
+    R_e2b = attitude_tools('quat_to_dcm_batch', quat_e2b'); % 3x3xN
+    R_n2e = C_e2n.';
+    N = size(pos_ecef,1);
+    pos_body = zeros(N,3); vel_body = zeros(N,3); acc_body = zeros(N,3);
+    for k = 1:N
+        R_b_n = R_e2b(:,:,k) * R_n2e;
+        pos_body(k,:) = (R_b_n * pos_ned(k,:).').';
+        vel_body(k,:) = (R_b_n * vel_ned(k,:).').';
+        acc_body(k,:) = (R_b_n * acc_ned(k,:).').';
+    end
+
     truth.time = t;
-    truth.pos_ned = pos_ned;
-    truth.vel_ned = vel_ned;
+    truth.ecef.pos = pos_ecef;
+    truth.ecef.vel = vel_ecef;
+    truth.ecef.acc = acc_ecef;
+    truth.ned.pos  = pos_ned;
+    truth.ned.vel  = vel_ned;
+    truth.ned.acc  = acc_ned;
+    truth.body.pos = pos_body;
+    truth.body.vel = vel_body;
+    truth.body.acc = acc_body;
+    truth.lat_ref  = lat;
+    truth.lon_ref  = lon;
+    truth.r0_ecef  = r0;
 end

--- a/MATLAB/task5_plot_fusion_results.m
+++ b/MATLAB/task5_plot_fusion_results.m
@@ -17,6 +17,15 @@ end
 out_dir = fullfile('MATLAB','results');
 if ~exist(out_dir,'dir'); mkdir(out_dir); end
 
+% Persist truth data for later validation in all frames
+try
+    truth_path = fullfile(out_dir,'IMU_X002_GNSS_X002_TRIAD_task5_truth.mat');
+    save(truth_path,'truth_data');
+    fprintf('[SAVE] Truth data saved to %s\n', truth_path);
+catch ME
+    warning('Failed to save truth data: %s', ME.message);
+end
+
 frames = {'ned','ecef','body'};
 frame_names = {'NED','ECEF','Body'};
 quantities = {'pos','vel','acc'};


### PR DESCRIPTION
## Summary
- expand `read_truth_file` to compute ECEF, NED, and body-frame states (pos/vel/acc)
- save truth data in `task5_plot_fusion_results` for later validation

## Testing
- `matlab -batch "truth=read_truth_file('DATA/Truth/STATE_X001_small.txt'); disp(size(truth.ecef.pos)); disp(size(truth.ned.pos)); disp(size(truth.body.pos));"` *(command not found)*
- `octave -qf --eval "truth=read_truth_file('DATA/Truth/STATE_X001_small.txt'); disp(size(truth.ecef.pos)); disp(size(truth.ned.pos)); disp(size(truth.body.pos));"` *(command not found)*
- `matlab -batch "run('test_matlab_simple.m')"` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e1cf04c9883229ccd4a0227dcc984