### PR TITLE
feat: add auto-tune and truth alignment

### DIFF
--- a/MATLAB/Task_7.m
+++ b/MATLAB/Task_7.m
@@ -96,8 +96,12 @@ if isempty(E.acc_ned) && isfield(res5,'acc_ecef_est')
     E.acc_ned = attitude_tools('ecef2ned_vec', res5.acc_ecef_est, lat, lon);
 end
 
-% Truth (prefer Task 6 processed NED if available)
-if hasRes6 && isfield(tmp6,'truth_pos_ned') && ~isempty(tmp6.truth_pos_ned)
+% Truth (prefer Task 5 interpolation, then Task 6 processed NED)
+if isfield(res5,'truth_interp')
+    P_ned = res5.truth_interp.pos_ned;
+    V_ned = res5.truth_interp.vel_ned;
+    t_truth_used = t_est; % already aligned
+elseif hasRes6 && isfield(tmp6,'truth_pos_ned') && ~isempty(tmp6.truth_pos_ned)
     P_ned = tmp6.truth_pos_ned; V_ned = tmp6.truth_vel_ned;
 else
     % Build from raw TRUTH file; attempt robust numeric load
@@ -118,7 +122,7 @@ else
             r0 = res5.ref_r0(:)';
         end
         % subtract reference origin for positions
-    P_ned = attitude_tools('ecef2ned_vec', P_ecef - r0, lat, lon);
+        P_ned = attitude_tools('ecef2ned_vec', P_ecef - r0, lat, lon);
     end
     V_ned = [];
     if ~isempty(V_ecef)


### PR DESCRIPTION
## Summary
- add configurable auto-tune, yaw-aid, ZUPT, and GNSS settings in the MATLAB pipeline
- run a reduced sweep via `run_kf_once` before a single full-rate EKF pass
- align truth and estimator by cross-correlating speeds and saving `truth_interp` for downstream tasks
- reuse precomputed truth alignment in Task 6 and Task 7 overlays

## Testing
- `PYTHONPATH=PYTHON/src pytest PYTHON/tests` *(fails: ModuleNotFoundError: No module named 'src')*


------
https://chatgpt.com/codex/tasks/task_e_68b6f8213d90832288d83cac1f967c63