### PR TITLE
Handle empty GNSS path in MATLAB Task 6 and add CLI script

### DIFF
--- a/MATLAB/README_pipeline.md
+++ b/MATLAB/README_pipeline.md
@@ -162,6 +162,18 @@ then calls `plot_overlay` for the NED, ECEF and body frames, saving the
 figures `<METHOD>_NED_overlay_truth.pdf`, `<METHOD>_ECEF_overlay_truth.pdf`
 and `<METHOD>_Body_overlay_truth.pdf` in `MATLAB/results/`.
 
+For non-interactive use, a helper script `run_task6_truth.m` accepts the
+Task‑5 output file and an optional truth path and then exits MATLAB when
+finished. IMU and GNSS paths are not required in this mode; if the truth path
+is empty `Task_6` attempts to resolve it via `resolve_truth_path`.
+
+```bash
+matlab -batch "addpath('MATLAB'); run_task6_truth('MATLAB/results/<task5>.mat', 'STATE_X001.txt')"
+```
+
+This command-line entry point keeps the MATLAB overlay workflow separate from
+the Python scripts such as `python src/validate_with_truth.py`.
+
 ### Compatibility notes
 
 Some older MATLAB releases expect the ellipsoid name for `ecef2lla` as a

--- a/MATLAB/Task_6.m
+++ b/MATLAB/Task_6.m
@@ -9,9 +9,11 @@ function Task_6(task5_file, imu_path, gnss_path, truth_file)
 %   that residuals are expressed in a consistent frame. The resulting
 %   ``*_overlay_truth.pdf`` files are written to the directory returned by
 %   ``project_paths()``. If TRUTH_FILE is empty it will be resolved using
-%   ``resolve_truth_path``. This function expects the initialization
-%   output from Task 1 and the filter output from Task 5 to reside in that
-%   same directory.
+%   ``resolve_truth_path``. IMU_PATH and GNSS_PATH may be empty when only
+%   precomputed Task 5 results and a truth file are available; suitable
+%   placeholders are then used when constructing output identifiers. This
+%   function expects the initialization output from Task 1 and the filter
+%   output from Task 5 to reside in that same directory.
 %
 % Usage:
 %   Task_6(task5_file, imu_path, gnss_path, truth_file)
@@ -39,7 +41,13 @@ fprintf('Starting Task 6 overlay ...\n');
 start_time = tic;
 
 [~, imu_name, ~]  = fileparts(imu_path);
+if isempty(imu_name)
+    imu_name = 'no_imu';
+end
 [~, gnss_name, ~] = fileparts(gnss_path);
+if isempty(gnss_name)
+    gnss_name = 'no_gnss';
+end
 
 
 % paths and results_dir already defined above
@@ -91,9 +99,17 @@ end
 % Build output directory using method and dataset identifiers
 % Compute run_id locally to avoid dependency on path setup
 [~, imu_file, imu_ext]   = fileparts(imu_path);
+if isempty(imu_file) && isempty(imu_ext)
+    imu_tag = 'NO_IMU';
+else
+    imu_tag  = strrep(upper([imu_file imu_ext]),  '.DAT','');
+end
 [~, gnss_file, gnss_ext] = fileparts(gnss_path);
-imu_tag  = strrep(upper([imu_file imu_ext]),  '.DAT','');
-gnss_tag = strrep(upper([gnss_file gnss_ext]),'.CSV','');
+if isempty(gnss_file) && isempty(gnss_ext)
+    gnss_tag = 'NO_GNSS';
+else
+    gnss_tag = strrep(upper([gnss_file gnss_ext]),'.CSV','');
+end
 rid = sprintf('%s_%s_%s', imu_tag, gnss_tag, upper(method));
 run_id = rid;
 out_dir = fullfile(results_dir, run_id);

--- a/MATLAB/run_task6_truth.m
+++ b/MATLAB/run_task6_truth.m
@@ -1,0 +1,30 @@
+function run_task6_truth(task5_file, truth_file)
+%RUN_TASK6_TRUTH Run Task_6 with optional truth overlay and exit.
+%   run_task6_truth(task5_file, truth_file) calls Task_6 with empty IMU and
+%   GNSS paths. TRUTH_FILE may be empty; in that case Task_6 will attempt to
+%   locate the reference via resolve_truth_path. This helper is intended for
+%   non-interactive CLI use, e.g.:
+%
+%   matlab -batch "addpath('MATLAB'); run_task6_truth('results/task5.mat','STATE_X001.txt')"
+%
+%   On completion MATLAB exits automatically. A non-zero exit status is
+%   used when Task_6 throws an error.
+%
+% Inputs:
+%   task5_file  - Path to Task 5 result file.
+%   truth_file  - Path to truth state file (optional).
+%
+% See also: Task_6, resolve_truth_path
+
+if nargin < 2
+    truth_file = '';
+end
+
+try
+    Task_6(task5_file, '', '', truth_file);
+    exit;
+catch ME
+    fprintf('run_task6_truth: %s\n', ME.message);
+    exit(1);
+end
+end


### PR DESCRIPTION
## Summary
- Ensure Task_6 tolerates missing IMU/GNSS paths and resolves truth data with `resolve_truth_path`
- Add `run_task6_truth.m` for command-line Task 6 execution and automatic MATLAB exit
- Document new CLI helper and separation from Python workflow in `README_pipeline.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*


------
https://chatgpt.com/codex/tasks/task_e_68b7b7596770832297be6733096d55d5