### PR TITLE
Add NED frame orientation tests and integration checks

### DIFF
--- a/PYTHON/src/gnss_imu_fusion/integration.py
+++ b/PYTHON/src/gnss_imu_fusion/integration.py
@@ -29,6 +29,19 @@ def integrate_trajectory(
 ]:
     """Integrate body-frame accelerations to position and velocity.
 
+    Parameters
+    ----------
+    acc_body : np.ndarray
+        Specific force measurements in the body frame.
+    imu_time : np.ndarray
+        Sample times corresponding to ``acc_body``.
+    C_B_N : np.ndarray, shape (3, 3)
+        Rotation matrix from the body frame to NED.  The matrix must be
+        orthonormal.
+    g_NED : np.ndarray, optional
+        Constant gravity vector expressed in NED.  Required when ``lat`` and
+        ``lon`` are not provided.
+
     If ``lat`` and ``lon`` are provided (or ``g_ecef`` is given), a
     position-dependent gravity vector is removed in the ECEF frame before
     converting the acceleration back to NED for integration.  Otherwise a
@@ -38,6 +51,10 @@ def integrate_trajectory(
     values at the start, middle and end of the integration to help diagnose
     divergence issues.
     """
+
+    C_B_N = np.asarray(C_B_N)
+    if not np.allclose(C_B_N.T @ C_B_N, np.eye(3), atol=1e-6):
+        raise ValueError("C_B_N must be an orthonormal body->NED rotation matrix")
 
     n = len(imu_time)
     pos = np.zeros((n, 3))

--- a/PYTHON/tests/test_frames_orientation.py
+++ b/PYTHON/tests/test_frames_orientation.py
@@ -1,0 +1,61 @@
+import pytest
+from src.utils import compute_C_ECEF_to_NED
+from src.utils.frames import _rotation_ecef_to_ned
+
+np = pytest.importorskip("numpy")
+
+
+@pytest.mark.parametrize("lat_deg, lon_deg", [
+    (0.0, 0.0),
+    (45.0, 45.0),
+    (-30.0, 120.0),
+])
+def test_compute_C_ECEF_to_NED_right_handed_down(lat_deg, lon_deg):
+    lat_rad = np.radians(lat_deg)
+    lon_rad = np.radians(lon_deg)
+    C = compute_C_ECEF_to_NED(lat_rad, lon_rad)
+
+    # Orthonormal and right-handed
+    assert np.allclose(C @ C.T, np.eye(3), atol=1e-6)
+    assert np.isclose(np.linalg.det(C), 1.0, atol=1e-6)
+
+    # +Z down: local up vector maps to negative NED Z
+    up = np.array([
+        np.cos(lat_rad) * np.cos(lon_rad),
+        np.cos(lat_rad) * np.sin(lon_rad),
+        np.sin(lat_rad),
+    ])
+    assert np.allclose(C @ up, [0.0, 0.0, -1.0], atol=1e-6)
+
+    # Right-handed check via cross product
+    assert np.allclose(np.cross(C[0], C[1]), C[2], atol=1e-6)
+
+
+@pytest.mark.parametrize("lat_deg, lon_deg", [
+    (0.0, 0.0),
+    (45.0, 45.0),
+    (-30.0, 120.0),
+])
+def test_rotation_ecef_to_ned_right_handed_down(lat_deg, lon_deg):
+    R = _rotation_ecef_to_ned(lat_deg, lon_deg)
+    lat_rad = np.radians(lat_deg)
+    lon_rad = np.radians(lon_deg)
+
+    # Orthonormal and right-handed
+    assert np.allclose(R @ R.T, np.eye(3), atol=1e-6)
+    assert np.isclose(np.linalg.det(R), 1.0, atol=1e-6)
+
+    # +Z down: third column points toward Earth
+    up = np.array([
+        np.cos(lat_rad) * np.cos(lon_rad),
+        np.cos(lat_rad) * np.sin(lon_rad),
+        np.sin(lat_rad),
+    ])
+    assert np.allclose(R[:, 2], -up, atol=1e-6)
+
+    # Right-handed check via cross product
+    assert np.allclose(np.cross(R[:, 0], R[:, 1]), R[:, 2], atol=1e-6)
+
+    # Relationship with compute_C_ECEF_to_NED
+    C = compute_C_ECEF_to_NED(lat_rad, lon_rad)
+    assert np.allclose(C, R.T, atol=1e-6)

--- a/PYTHON/tests/test_gnss_init_velocity.py
+++ b/PYTHON/tests/test_gnss_init_velocity.py
@@ -1,0 +1,43 @@
+import pytest
+from src.gnss_imu_fusion.init import compute_reference_vectors
+from src.utils.ecef_llh import lla_to_ecef
+
+np = pytest.importorskip("numpy")
+pd = pytest.importorskip("pandas")
+
+
+def test_initial_velocity_conversion(tmp_path):
+    # Known latitude/longitude where the transformation is simple
+    lat_deg = 0.0
+    lon_deg = 0.0
+    alt = 0.0
+    x, y, z = lla_to_ecef(lat_deg, lon_deg, alt)
+
+    # ECEF velocity pointing toward geographic north (+Z axis)
+    vx, vy, vz = 0.0, 0.0, 100.0
+    df = pd.DataFrame(
+        {
+            "X_ECEF_m": [x],
+            "Y_ECEF_m": [y],
+            "Z_ECEF_m": [z],
+            "VX_ECEF_mps": [vx],
+            "VY_ECEF_mps": [vy],
+            "VZ_ECEF_mps": [vz],
+        }
+    )
+    csv_path = tmp_path / "gnss.csv"
+    df.to_csv(csv_path, index=False)
+
+    (
+        _,
+        _,
+        _,
+        _,
+        _,
+        _,
+        initial_vel_ned,
+        _,
+        _,
+    ) = compute_reference_vectors(str(csv_path))
+
+    assert np.allclose(initial_vel_ned, np.array([100.0, 0.0, 0.0]), atol=1e-6)


### PR DESCRIPTION
## Summary
- document body-to-NED rotation in `integrate_trajectory` and validate orthonormality
- add tests ensuring `compute_C_ECEF_to_NED` and `_rotation_ecef_to_ned` yield right-handed +Z-down NED frames
- regression test for `compute_reference_vectors` initial velocity conversion

## Testing
- `PYTHONPATH=PYTHON pytest PYTHON/tests/test_frames_orientation.py PYTHON/tests/test_gnss_init_velocity.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7cf526f948322b693fe16c556f3dc