### PR TITLE
Standardise quaternion convention

### DIFF
--- a/PYTHON/src/gnss_imu_fusion/init_vectors.py
+++ b/PYTHON/src/gnss_imu_fusion/init_vectors.py
@@ -4,6 +4,9 @@ from typing import Iterable, Tuple, Optional
 
 import numpy as np
 from scipy.signal import butter, filtfilt
+from scipy.spatial.transform import Rotation
+
+from utils.quaternion import assert_quaternion_convention
 
 
 def average_rotation_matrices(rotations: Iterable[np.ndarray]) -> np.ndarray:
@@ -239,16 +242,9 @@ def davenport_q_method(
     if q_opt[0] < 0:
         q_opt = -q_opt
 
-    q = np.array([q_opt[0], -q_opt[1], -q_opt[2], -q_opt[3]])
-
-    qw, qx, qy, qz = q
-    R = np.array(
-        [
-            [1 - 2 * (qy**2 + qz**2), 2 * (qx * qy - qw * qz), 2 * (qx * qz + qw * qy)],
-            [2 * (qx * qy + qw * qz), 1 - 2 * (qx**2 + qz**2), 2 * (qy * qz - qw * qx)],
-            [2 * (qx * qz - qw * qy), 2 * (qy * qz + qw * qx), 1 - 2 * (qx**2 + qy**2)],
-        ]
-    )
+    q = np.array([-q_opt[1], -q_opt[2], -q_opt[3], q_opt[0]])
+    assert_quaternion_convention(q)
+    R = Rotation.from_quat(q).as_matrix()
 
     return R, q
 

--- a/PYTHON/src/gnss_imu_fusion/kalman_filter.py
+++ b/PYTHON/src/gnss_imu_fusion/kalman_filter.py
@@ -4,32 +4,42 @@ from __future__ import annotations
 
 import numpy as np
 
+from utils.quaternion import assert_quaternion_convention
+
 
 def quat_multiply(q: np.ndarray, r: np.ndarray) -> np.ndarray:
     """Quaternion multiplication."""
-    w0, x0, y0, z0 = q
-    w1, x1, y1, z1 = r
-    return np.array([
-        w0 * w1 - x0 * x1 - y0 * y1 - z0 * z1,
+    assert_quaternion_convention(q)
+    assert_quaternion_convention(r)
+    x0, y0, z0, w0 = q
+    x1, y1, z1, w1 = r
+    res = np.array([
         w0 * x1 + x0 * w1 + y0 * z1 - z0 * y1,
         w0 * y1 - x0 * z1 + y0 * w1 + z0 * x1,
         w0 * z1 + x0 * y1 - y0 * x1 + z0 * w1,
+        w0 * w1 - x0 * x1 - y0 * y1 - z0 * z1,
     ])
+    assert_quaternion_convention(res)
+    return res
 
 
 def quat_from_rate(omega: np.ndarray, dt: float) -> np.ndarray:
     """Quaternion from angular rate."""
     theta = np.linalg.norm(omega) * dt
     if theta == 0:
-        return np.array([1.0, 0.0, 0.0, 0.0])
-    axis = omega / np.linalg.norm(omega)
-    half = theta / 2.0
-    return np.array([np.cos(half), *(np.sin(half) * axis)])
+        q = np.array([0.0, 0.0, 0.0, 1.0])
+    else:
+        axis = omega / np.linalg.norm(omega)
+        half = theta / 2.0
+        q = np.array([*(np.sin(half) * axis), np.cos(half)])
+    assert_quaternion_convention(q)
+    return q
 
 
 def quat2euler(q: np.ndarray) -> tuple[float, float, float]:
-    """Return roll, pitch, yaw (rad) from w-x-y-z quaternion."""
-    w, x, y, z = q
+    """Return roll, pitch, yaw (rad) from ``[x, y, z, w]`` quaternion."""
+    assert_quaternion_convention(q)
+    x, y, z, w = q
     t2 = +2.0 * (w * y - z * x)
     t2 = np.clip(t2, -1.0, 1.0)
     pitch = np.arcsin(t2)

--- a/PYTHON/src/utils/quaternion.py
+++ b/PYTHON/src/utils/quaternion.py
@@ -1,0 +1,32 @@
+"""Quaternion utilities for repository-wide convention.
+
+All quaternions are expected to be in scalar-last ``[x, y, z, w]`` format and
+represent the rotation from the body frame to the world frame.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+
+def assert_quaternion_convention(q: np.ndarray) -> None:
+    """Validate quaternion shape, normalization and ordering.
+
+    Parameters
+    ----------
+    q : np.ndarray
+        Quaternion or array of quaternions in ``[x, y, z, w]`` order.
+
+    Raises
+    ------
+    AssertionError
+        If the quaternion is not ``(..., 4)`` shaped, not normalised, or clearly
+        not using ``[x, y, z, w]`` order (e.g. identity with scalar first).
+    """
+    q = np.asarray(q, dtype=float)
+    if q.shape[-1] != 4:
+        raise AssertionError("Quaternion must have shape (..., 4)")
+    n = np.linalg.norm(q, axis=-1)
+    if np.any(np.abs(n - 1.0) > 1e-6):
+        raise AssertionError("Quaternion must be unit norm")
+    if np.allclose(q[..., :3], 0.0, atol=1e-6) and not np.allclose(q[..., 3], 1.0, atol=1e-6):
+        raise AssertionError("Quaternion must be in [x, y, z, w] order")

--- a/PYTHON/tests/conftest.py
+++ b/PYTHON/tests/conftest.py
@@ -4,6 +4,8 @@ from pathlib import Path
 # Add the project root and the 'src' directory to sys.path so tests can
 # import application modules without installing the package.
 ROOT = Path(__file__).resolve().parents[2]
-PYTHON_SRC = ROOT / 'PYTHON' / 'src'
+PYTHON_DIR = ROOT / 'PYTHON'
+PYTHON_SRC = PYTHON_DIR / 'src'
 sys.path.insert(0, str(PYTHON_SRC))
+sys.path.insert(0, str(PYTHON_DIR))
 sys.path.insert(0, str(ROOT))

--- a/PYTHON/tests/test_quaternion_convention.py
+++ b/PYTHON/tests/test_quaternion_convention.py
@@ -1,0 +1,18 @@
+import numpy as np
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent / 'PYTHON' / 'src'))
+from utils.quaternion import assert_quaternion_convention
+
+
+def test_assert_quaternion_convention_pass():
+    q = np.array([0.0, 0.0, 0.0, 1.0])
+    assert_quaternion_convention(q)
+
+
+def test_assert_quaternion_convention_fail_non_unit():
+    q = np.array([0.0, 0.0, 0.0, 2.0])
+    with pytest.raises(AssertionError):
+        assert_quaternion_convention(q)


### PR DESCRIPTION
## Summary
- Adopt repository-wide quaternion format `[x, y, z, w]` (body → world)
- Update initialisation, attitude error analysis and Kalman filter utilities to honour new convention with runtime checks
- Add `assert_quaternion_convention` helper and unit tests, adjusting test imports

## Testing
- `pytest tests/test_quaternion_convention.py -q`
- `pytest -q` *(fails: missing data files and several downstream assertion mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_68b7cf7c5dbc8322a933975325445c1c