### PR TITLE
Document dataset characteristics and GNSS format

### DIFF
--- a/DATA/README.md
+++ b/DATA/README.md
@@ -1,0 +1,14 @@
+# Dataset overview
+
+This directory contains the logs used by the IMU–GNSS fusion scripts.
+
+* **Run X001** – baseline trajectory with ideal sensors.
+* **Run X002** – same path but with additional measurement noise.
+* **Run X003** – reuses the GNSS trace from `X002` while injecting a constant bias into the IMU.
+
+GNSS CSV files provide only Earth‑centred Earth‑fixed (ECEF) position and velocity.
+The latitude, longitude and altitude columns are kept at zero.  The pipeline
+recovers any needed geodetic coordinates from the ECEF values.
+
+Each run also has a shortened `*_small` variant for quick testing that contains
+the first 1,000 IMU samples and ten GNSS epochs.

--- a/PYTHON/src/run_all_datasets.py
+++ b/PYTHON/src/run_all_datasets.py
@@ -51,9 +51,12 @@ LOG_DIR = HERE / "logs"
 LOG_DIR.mkdir(exist_ok=True)
 
 DEFAULT_DATASETS = [
-    ("IMU_X001.dat", "GNSS_X001.csv"),
-    ("IMU_X002.dat", "GNSS_X002.csv"),
-    ("IMU_X003.dat", "GNSS_X002.csv"),  # dataset X003 shares GNSS_X002
+    ("IMU_X001.dat", "GNSS_X001.csv"),  # X001: clean baseline
+    ("IMU_X002.dat", "GNSS_X002.csv"),  # X002: additional sensor noise
+    (
+        "IMU_X003.dat",
+        "GNSS_X002.csv",
+    ),  # X003: IMU bias, GNSS reused from X002
 ]
 
 DEFAULT_METHODS = ["TRIAD", "Davenport", "SVD"]

--- a/README.md
+++ b/README.md
@@ -188,9 +188,13 @@ The pipeline tasks correspond to steps in the MATLAB implementation. Each task p
 
 The repository includes three IMU logs and two GNSS traces:
 
-- `DATA/IMU/IMU_X001.dat` with `DATA/GNSS/GNSS_X001.csv`
-- `DATA/IMU/IMU_X002.dat` with `DATA/GNSS/GNSS_X002.csv`
-- `DATA/IMU/IMU_X003.dat` with `DATA/GNSS/GNSS_X002.csv` (no dedicated GNSS log was recorded)
+- `DATA/IMU/IMU_X001.dat` with `DATA/GNSS/GNSS_X001.csv` – baseline run without additional errors.
+- `DATA/IMU/IMU_X002.dat` with `DATA/GNSS/GNSS_X002.csv` – same trajectory with extra measurement noise.
+- `DATA/IMU/IMU_X003.dat` with `DATA/GNSS/GNSS_X002.csv` – reuses the X002 GNSS log but adds a constant bias to the IMU.
+
+The GNSS CSV files record only Earth-centred Earth-fixed (ECEF) coordinates and
+velocities; the latitude, longitude and altitude columns are left at zero.  Any
+geodetic coordinates used by the pipeline are derived from the ECEF values.
 
 For quick tests the repository also provides truncated versions of each file:
 


### PR DESCRIPTION
## Summary
- Document X001/X002/X003 dataset differences and note that GNSS logs contain only ECEF coordinates
- Add DATA/README with dataset overview and quick-test hints
- Clarify default dataset list in `run_all_datasets.py`

## Testing
- `python PYTHON/src/GNSS_IMU_Fusion.py --imu-file DATA/IMU/IMU_X001_small.dat --gnss-file DATA/GNSS/GNSS_X001_small.csv --method TRIAD`
- `python PYTHON/src/GNSS_IMU_Fusion.py --imu-file DATA/IMU/IMU_X002_small.dat --gnss-file DATA/GNSS/GNSS_X002_small.csv --method TRIAD`
- `python PYTHON/src/GNSS_IMU_Fusion.py --imu-file DATA/IMU/IMU_X003_small.dat --gnss-file DATA/GNSS/GNSS_X002_small.csv --method TRIAD`
- `PYTHONPATH=$PWD/PYTHON pytest PYTHON/tests -q` *(fails: 18 failed, 44 passed, 9 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d2a6275c8322b1217eada15a5861