### PR TITLE
Validate radian inputs and enforce NED sign conventions

### DIFF
--- a/PYTHON/src/gnss_imu_fusion/init.py
+++ b/PYTHON/src/gnss_imu_fusion/init.py
@@ -21,6 +21,21 @@ from ..paths import PY_RES_DIR
 from .init_vectors import butter_lowpass_filter
 
 
+def _require_radians(angle: float, name: str) -> None:
+    """Ensure an angle is provided in radians.
+
+    Parameters
+    ----------
+    angle : float
+        The angle value to check.
+    name : str
+        Name of the parameter for error messages.
+    """
+
+    if abs(angle) > 2 * np.pi:
+        raise ValueError(f"{name} must be in radians, got {angle}.")
+
+
 def compute_reference_vectors(
     gnss_file: str, mag_file: Optional[str] = None
 ) -> Tuple[
@@ -54,6 +69,8 @@ def compute_reference_vectors(
     lat_deg, lon_deg, alt = ecef_to_geodetic(x_ecef, y_ecef, z_ecef)
     lat = np.deg2rad(lat_deg)
     lon = np.deg2rad(lon_deg)
+    _require_radians(lat, "latitude")
+    _require_radians(lon, "longitude")
     logging.info("Subtask 1.2: Defining gravity vector in NED frame.")
     g_ned = validate_gravity_vector(lat_deg, alt)
     logging.info("Subtask 1.3: Defining Earth rotation rate vector in NED frame.")

--- a/PYTHON/src/utils/frames.py
+++ b/PYTHON/src/utils/frames.py
@@ -7,14 +7,25 @@ from utils.ecef_llh import lla_to_ecef
 from utils import compute_C_ECEF_to_NED
 
 
+def _validate_ned_rotation(lat_rad: float, lon_rad: float, R: np.ndarray) -> None:
+    """Check that the provided rotation maps gravity to positive down."""
+
+    up = np.array([
+        np.cos(lat_rad) * np.cos(lon_rad),
+        np.cos(lat_rad) * np.sin(lon_rad),
+        np.sin(lat_rad),
+    ])
+    down_ned = R @ (-up)
+    if down_ned[2] <= 0:
+        raise ValueError("NED frame expects positive down; rotation has wrong sign")
+
+
 def _rotation_ecef_to_ned(lat_deg: float, lon_deg: float) -> np.ndarray:
     lat = np.radians(lat_deg)
     lon = np.radians(lon_deg)
-    return np.array([
-        [-np.sin(lat) * np.cos(lon), -np.sin(lon), -np.cos(lat) * np.cos(lon)],
-        [-np.sin(lat) * np.sin(lon),  np.cos(lon), -np.cos(lat) * np.sin(lon)],
-        [ np.cos(lat),               0.0,         -np.sin(lat)],
-    ])
+    R = compute_C_ECEF_to_NED(lat, lon)
+    _validate_ned_rotation(lat, lon, R)
+    return R
 
 
 def ecef_to_ned(x: Iterable[float], y: Iterable[float], z: Iterable[float],
@@ -27,6 +38,9 @@ def ecef_to_ned(x: Iterable[float], y: Iterable[float], z: Iterable[float],
     R = _rotation_ecef_to_ned(lat0, lon0)
     diff = np.vstack((x - x0, y - y0, z - z0))
     ned = R @ diff
+    # Ensure gravity direction is positive down
+    if (R @ (-np.array([x0, y0, z0])))[2] <= 0:
+        raise ValueError("NED conversion produced non-positive down component for gravity")
     return ned[0], ned[1], ned[2]
 
 
@@ -50,7 +64,9 @@ def R_ecef_to_ned(lat_rad: float, lon_rad: float) -> np.ndarray:
     lat_rad, lon_rad : float
         Geodetic latitude and longitude in **radians**.
     """
-    return compute_C_ECEF_to_NED(lat_rad, lon_rad)
+    R = compute_C_ECEF_to_NED(lat_rad, lon_rad)
+    _validate_ned_rotation(lat_rad, lon_rad, R)
+    return R
 
 
 def ecef_vec_to_ned(

--- a/PYTHON/tests/test_ned_sign_convention.py
+++ b/PYTHON/tests/test_ned_sign_convention.py
@@ -1,0 +1,41 @@
+import numpy as np
+from src.utils.frames import ecef_to_ned
+from src.utils.ecef_llh import lla_to_ecef
+
+
+def test_ned_sign_convention():
+    """Verify NED conversion maintains expected sign conventions."""
+    lat0_deg = 10.0
+    lon0_deg = 20.0
+    h0 = 0.0
+
+    # Reference ECEF position
+    lat_rad = np.radians(lat0_deg)
+
+    # Radii of curvature for 1 m displacements
+    a = 6378137.0
+    e2 = 6.69437999014e-3
+    R_N = a / np.sqrt(1 - e2 * np.sin(lat_rad) ** 2)
+    R_E = R_N * np.cos(lat_rad)
+    dlat_deg = np.degrees(1 / (R_N + h0))
+    dlon_deg = np.degrees(1 / (R_E + h0))
+
+    # Points 1 m north, east, down, and up from reference
+    x_n, y_n, z_n = lla_to_ecef(lat0_deg + dlat_deg, lon0_deg, h0)
+    x_e, y_e, z_e = lla_to_ecef(lat0_deg, lon0_deg + dlon_deg, h0)
+    x_d, y_d, z_d = lla_to_ecef(lat0_deg, lon0_deg, h0 - 1.0)
+    x_u, y_u, z_u = lla_to_ecef(lat0_deg, lon0_deg, h0 + 1.0)
+
+    n, e, d = ecef_to_ned(
+        [x_n, x_e, x_d, x_u],
+        [y_n, y_e, y_d, y_u],
+        [z_n, z_e, z_d, z_u],
+        lat0_deg,
+        lon0_deg,
+        h0,
+    )
+
+    assert np.allclose(n[0], 1.0, atol=1e-2)
+    assert np.allclose(e[1], 1.0, atol=1e-2)
+    assert np.allclose(d[2], 1.0, atol=1e-2)
+    assert np.allclose(d[3], -1.0, atol=1e-2)


### PR DESCRIPTION
## Summary
- ensure latitude and longitude are provided in radians in GNSS/IMU initialization
- validate NED rotation matrices and gravity orientation in frame conversions
- add integration test comparing ECEF and NED trajectories to confirm sign conventions

## Testing
- `PYTHONPATH=PYTHON pytest PYTHON/tests/test_frames.py PYTHON/tests/test_utils_additional.py PYTHON/tests/test_ned_sign_convention.py test_env.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7cf7fd640832293fe719770aa2219