### PR TITLE
Add attitude metrics to summary

### DIFF
--- a/PYTHON/src/summarise_runs.py
+++ b/PYTHON/src/summarise_runs.py
@@ -38,6 +38,20 @@ for r in rows:
     r["dataset"] = pathlib.Path(r["imu"]).stem
     r["rmse_pos"] = float(r["rmse_pos"].replace("m", ""))
     r["final_pos"] = float(r["final_pos"].replace("m", ""))
+    if "rms_resid_pos" in r:
+        r["rms_resid_pos"] = float(r["rms_resid_pos"].replace("m", ""))
+    if "rms_resid_vel" in r:
+        r["rms_resid_vel"] = float(r["rms_resid_vel"].replace("m", ""))
+    if "max_resid_pos" in r:
+        r["max_resid_pos"] = float(r["max_resid_pos"].replace("m", ""))
+    if "max_resid_vel" in r:
+        r["max_resid_vel"] = float(r["max_resid_vel"].replace("m", ""))
+    if "att_err_deg" in r:
+        r["att_err_deg"] = float(r["att_err_deg"])
+    if "q_final" in r:
+        q = r["q_final"].strip("[]").split(",")
+        if len(q) == 4:
+            r["qw"], r["qx"], r["qy"], r["qz"] = map(float, q)
 
 # determine best method per dataset based on final_pos
 best_map = {}
@@ -58,6 +72,15 @@ with open(results_path("summary.csv"), "w", newline="") as fh:
         "gnss",
         "rmse_pos",
         "final_pos",
+        "rms_resid_pos",
+        "max_resid_pos",
+        "rms_resid_vel",
+        "max_resid_vel",
+        "att_err_deg",
+        "qw",
+        "qx",
+        "qy",
+        "qz",
         "best",
     ]
     writer = csv.DictWriter(fh, fieldnames=fieldnames)
@@ -67,13 +90,34 @@ with open(results_path("summary.csv"), "w", newline="") as fh:
 
 # Markdown table --------------------------------------------------------------
 with open(results_path("summary.md"), "w") as fh:
-    hdr_cols = ["dataset", "method", "imu", "gnss", "rmse_pos", "final_pos", "best"]
+    hdr_cols = [
+        "dataset",
+        "method",
+        "imu",
+        "gnss",
+        "rmse_pos",
+        "final_pos",
+        "rms_resid_pos",
+        "max_resid_pos",
+        "rms_resid_vel",
+        "max_resid_vel",
+        "att_err_deg",
+        "qw",
+        "qx",
+        "qy",
+        "qz",
+        "best",
+    ]
     hdr = " | ".join(hdr_cols)
     sep = " | ".join("---" for _ in hdr_cols)
     fh.write(hdr + "\n" + sep + "\n")
     for r in rows:
         fh.write(
-            f"{r['dataset']} | {r['method']} | {r['imu']} | {r['gnss']} | {r['rmse_pos']:.2f} | {r['final_pos']:.2f} | {r['best']}\n"
+            f"{r['dataset']} | {r['method']} | {r['imu']} | {r['gnss']} | "
+            f"{r['rmse_pos']:.2f} | {r['final_pos']:.2f} | {r.get('rms_resid_pos', float('nan')):.2f} | "
+            f"{r.get('max_resid_pos', float('nan')):.2f} | {r.get('rms_resid_vel', float('nan')):.2f} | "
+            f"{r.get('max_resid_vel', float('nan')):.2f} | {r.get('att_err_deg', float('nan')):.2f} | "
+            f"{r.get('qw', float('nan')):.6f} | {r.get('qx', float('nan')):.6f} | {r.get('qy', float('nan')):.6f} | {r.get('qz', float('nan')):.6f} | {r['best']}\n"
         )
 
 print("Created results/summary.csv and results/summary.md")


### PR DESCRIPTION
## Summary
- capture truth-aligned quaternions in fusion pipeline and compute final attitude error
- log final quaternion and attitude error in summary lines
- extend run summariser to parse new metrics and expose them in CSV/Markdown outputs

## Testing
- `pytest` *(fails: 12 failed, 27 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d73ad37083229a7eb29ebf7c48cf