### PR TITLE
Handle array-like gravity inputs

### DIFF
--- a/PYTHON/src/utils_legacy.py
+++ b/PYTHON/src/utils_legacy.py
@@ -447,6 +447,13 @@ def normal_gravity(lat: float, h: float = 0.0) -> float:
     float
         Gravity magnitude in m/s² using the WGS‑84 model.
     """
+    # Allow ``lat`` and ``h`` to be passed as numpy arrays of size one or other
+    # array-like types.  ``np.asarray(x).item()`` reliably extracts the scalar
+    # value without raising "setting an array element with a sequence" errors
+    # when these functions are called with values produced by interpolation
+    # routines.
+    lat = np.asarray(lat).item()
+    h = np.asarray(h).item()
     sin_lat = np.sin(lat)
     g = (
         9.7803253359
@@ -458,6 +465,13 @@ def normal_gravity(lat: float, h: float = 0.0) -> float:
 
 def gravity_ecef(lat: float, lon: float, h: float = 0.0) -> np.ndarray:
     """Return gravity vector in ECEF coordinates."""
+    # Accept latitude, longitude and height provided as scalars or length-one
+    # arrays.  ``np.asarray(x).item()`` extracts the underlying float so
+    # downstream computations operate on plain Python scalars even if callers
+    # supply numpy scalars or arrays.
+    lat = np.asarray(lat).item()
+    lon = np.asarray(lon).item()
+    h = np.asarray(h).item()
     g_ned = np.array([0.0, 0.0, normal_gravity(lat, h)])
     return compute_C_ECEF_to_NED(lat, lon).T @ g_ned
 

--- a/PYTHON/tests/test_utils_additional.py
+++ b/PYTHON/tests/test_utils_additional.py
@@ -4,6 +4,8 @@ from src.utils import (
     save_static_zupt_params,
     ecef_to_ned,
     compute_C_ECEF_to_NED,
+    gravity_ecef,
+    normal_gravity,
     zero_base_time,
 )
 
@@ -58,3 +60,13 @@ def test_zero_base_time_empty_and_shift():
     assert zero_base_time([]).size == 0
     t = np.array([5.0, 6.5, 7.0])
     assert np.allclose(zero_base_time(t), t - 5.0)
+
+
+def test_gravity_functions_accept_array_inputs():
+    lat = np.array([0.1])
+    lon = np.array([0.2])
+    h = np.array([50.0])
+    g_mag = normal_gravity(lat, h)
+    assert isinstance(g_mag, float)
+    g_vec = gravity_ecef(lat, lon, h)
+    assert g_vec.shape == (3,)


### PR DESCRIPTION
## Summary
- Make normal_gravity and gravity_ecef robust to array-like latitude/longitude/height values
- Add regression test confirming array inputs are accepted

## Testing
- `pytest`
- `pytest PYTHON/tests/test_utils_additional.py::test_gravity_functions_accept_array_inputs -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7d9bc2bec8322a56a20839a777b57