### PR TITLE
Fix lat/lon array shapes in integration

### DIFF
--- a/PYTHON/src/gnss_imu_fusion/integration.py
+++ b/PYTHON/src/gnss_imu_fusion/integration.py
@@ -88,12 +88,16 @@ def integrate_trajectory(
                 )
         return pos, vel, acc, None, None
 
-    lat = np.asarray(lat)
-    lon = np.asarray(lon)
+    # ``lat`` and ``lon`` may arrive as column vectors from interpolation
+    # routines.  Reshape to 1-D so that ``lat[i]`` and ``lon[i]`` yield scalars
+    # rather than 1-element arrays, which would propagate through trig
+    # functions and break the construction of rotation matrices.
+    lat = np.asarray(lat, dtype=float).reshape(-1)
+    lon = np.asarray(lon, dtype=float).reshape(-1)
     if h is None:
         h = np.zeros(n)
     else:
-        h = np.asarray(h)
+        h = np.asarray(h, dtype=float).reshape(-1)
 
     if g_ecef is None:
         g_ecef = np.array([gravity_ecef(lat[i], lon[i], h[i]) for i in range(n)])


### PR DESCRIPTION
## Summary
- Handle 1-column `lat`/`lon` arrays in `integrate_trajectory` by reshaping to 1‑D
- Ensure optional altitude array `h` is reshaped similarly for consistency

## Testing
- `pytest -q` *(fails: test_run_evaluation_npz_mismatched_lengths, test_run_evaluation_npz_quat_longer, test_run_evaluation_npz_diff_plot, test_frames_orientation tests, test_kalman_gravity, test_plot_fused_vs_truth, test_plot_overlay tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b7dc1d75b883229886ed86ec4a6343