### PR TITLE
Fix run_triad_only defaults and truth timeline parsing

### DIFF
--- a/PYTHON/src/run_triad_only.py
+++ b/PYTHON/src/run_triad_only.py
@@ -1030,8 +1030,11 @@ def main(argv: Iterable[str] | None = None) -> None:
     parser.add_argument(
         "--mode",
         choices=["all", "triad"],
-        default="all",
-        help="Mode: run all methods across datasets (all) or TRIAD-only (triad)",
+        default="triad",
+        help=(
+            "Mode: run all methods across datasets (all) or TRIAD-only (triad). "
+            "Default is triad."
+        ),
     )
     parser.add_argument(
         "--show-measurements",


### PR DESCRIPTION
## Summary
- default run_triad_only to TRIAD mode so a single dataset runs by default
- improve timeline utility to detect truth timestamps robustly

## Testing
- `python PYTHON/src/run_triad_only.py --no-plots --dataset X002`
- `pytest -q` *(fails: setting array element with sequence, FileNotFoundError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b7dbd1b07483229f14e627e9961aa4