### PR TITLE
Add quaternion overlays to Task 6 plots

### DIFF
--- a/PYTHON/src/task6_overlay_all_frames.py
+++ b/PYTHON/src/task6_overlay_all_frames.py
@@ -299,7 +299,7 @@ def load_truth(path: str) -> Dict[str, np.ndarray]:
     p = Path(path)
     out: Dict[str, np.ndarray] = {}
     if p.suffix.lower() == '.txt':
-        t, pos, vel = read_truth_txt(p)
+        t, pos, vel, quat = read_truth_txt(p)
         if t.size == 0 or pos.shape[0] == 0:
             raise ValueError(
                 f"Truth invalid: shapes t:{t.shape} pos:{pos.shape} vel:{vel.shape}"
@@ -307,6 +307,8 @@ def load_truth(path: str) -> Dict[str, np.ndarray]:
         out["time"] = t
         out["pos_ecef"] = pos
         out["vel_ecef"] = vel
+        if quat.size:
+            out["att_quat"] = quat
         return out
     try:
         df = pd.read_csv(p, sep=None, engine="python")

--- a/PYTHON/src/utils/read_truth_txt.py
+++ b/PYTHON/src/utils/read_truth_txt.py
@@ -5,28 +5,46 @@ import numpy as np
 
 
 def read_truth_txt(path: str | Path):
-    """Return ``t_truth``, ``pos_ecef`` and ``vel_ecef`` arrays from STATE_X text file.
+    """Return ``t_truth``, ``pos_ecef``, ``vel_ecef`` and ``quat_wxyz`` arrays.
 
     The truth files have columns::
-        count  time  X_ECEF_m  Y_ECEF_m  Z_ECEF_m  VX_ECEF_mps  VY_ECEF_mps  VZ_ECEF_mps ...
-    ``vel`` columns are optional; if missing, zeros are returned with a warning.
+        count  time  X_ECEF_m  Y_ECEF_m  Z_ECEF_m  VX_ECEF_mps  VY_ECEF_mps
+        VZ_ECEF_mps  q0  q1  q2  q3
+
+    ``vel`` and ``quat`` columns are optional; missing series are returned as
+    zeros with a warning.
     """
+
     p = Path(path)
     arr = np.loadtxt(p, comments="#")
     if arr.ndim == 1:
         arr = arr.reshape(1, -1)
     if arr.size == 0:
-        return np.array([]), np.zeros((0, 3)), np.zeros((0, 3))
+        return (
+            np.array([]),
+            np.zeros((0, 3)),
+            np.zeros((0, 3)),
+            np.zeros((0, 4)),
+        )
     if arr.shape[1] < 5:
         raise ValueError(f"Truth file {p} has insufficient columns: {arr.shape[1]}")
+
     t_truth = arr[:, 1].astype(float)
     pos_ecef = arr[:, 2:5].astype(float)
+
     if arr.shape[1] >= 8:
         vel_ecef = arr[:, 5:8].astype(float)
     else:
         vel_ecef = np.zeros_like(pos_ecef)
         print(f"[Task6][WARN] {p} lacks velocity columns; using zeros")
-    return t_truth, pos_ecef, vel_ecef
+
+    if arr.shape[1] >= 12:
+        quat_wxyz = arr[:, 8:12].astype(float)
+    else:
+        quat_wxyz = np.zeros((arr.shape[0], 4))
+        print(f"[Task6][WARN] {p} lacks quaternion columns; using zeros")
+
+    return t_truth, pos_ecef, vel_ecef, quat_wxyz
 
 
 __all__ = ["read_truth_txt"]


### PR DESCRIPTION
## Summary
- parse quaternion columns from truth state files
- propagate truth quaternions through Task 6 overlay workflow
- generate Task 6 quaternion overlay plots alongside position/velocity frames

## Testing
- `pytest` *(fails: FileNotFoundError in test_validate_3sigma.py and other assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e8e5e0348322b28466b546b069df