### PR TITLE
Add bias-aware Kalman filter and evaluation trimming

### DIFF
--- a/PYTHON/scripts/eval/run_evaluation_npz.py
+++ b/PYTHON/scripts/eval/run_evaluation_npz.py
@@ -1,0 +1,76 @@
+"""Evaluate fused estimator against truth from an ``*_kf_output.npz`` file."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import numpy as np
+from scipy.signal import correlate
+
+
+def _trim_to_overlap(t_truth: np.ndarray, x_truth: np.ndarray,
+                     t_est: np.ndarray, x_est: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Trim ``truth`` and ``estimate`` arrays to their common time span."""
+    start = max(t_truth[0], t_est[0])
+    end = min(t_truth[-1], t_est[-1])
+    truth_mask = (t_truth >= start) & (t_truth <= end)
+    est_mask = (t_est >= start) & (t_est <= end)
+    t_common = t_est[est_mask]
+    x_est_trim = x_est[est_mask]
+    truth_trim = np.vstack([
+        np.interp(t_common, t_truth[truth_mask], x_truth[truth_mask][:, i])
+        for i in range(x_truth.shape[1])
+    ]).T
+    return t_common, truth_trim, x_est_trim
+
+
+def estimate_time_offset(sig_a: np.ndarray, sig_b: np.ndarray, fs: float) -> float:
+    """Coarse-to-fine grid search for time offset between signals."""
+    t = np.arange(len(sig_a)) / fs
+    def _mse(dt: float) -> float:
+        interp = np.interp(t, t + dt, sig_b, left=np.nan, right=np.nan)
+        mask = ~np.isnan(interp)
+        if not np.any(mask):
+            return np.inf
+        return np.mean((sig_a[mask] - interp[mask]) ** 2)
+
+    coarse = np.arange(-5.0, 5.0, 0.1)
+    errs = [ _mse(dt) for dt in coarse ]
+    best = coarse[int(np.argmin(errs))]
+    fine = np.arange(best - 0.1, best + 0.1, 0.001)
+    errs = [ _mse(dt) for dt in fine ]
+    return float(fine[int(np.argmin(errs))])
+
+
+def run_evaluation_npz(npz_file: str) -> dict[str, np.ndarray | float]:
+    """Return residual metrics for ``npz_file``."""
+    data = np.load(npz_file)
+    t_est = data["time"]
+    vel_est = data.get("vel_ned")
+    if vel_est is None:
+        vel_est = data.get("fused_vel")
+    t_truth = data.get("truth_time")
+    vel_truth = data.get("truth_vel_ned")
+    if t_truth is None or vel_truth is None or len(vel_truth) == 0:
+        raise KeyError("truth_time/truth_vel_ned missing from npz")
+    t_shift = float(data.get("t_shift", 0.0))
+    t_truth = t_truth - t_shift
+    t_common, truth_vel, est_vel = _trim_to_overlap(t_truth, vel_truth, t_est, vel_est)
+    resid = truth_vel - est_vel
+    rmse = np.sqrt(np.mean(resid**2, axis=0))
+    final = resid[-1]
+    max_resid_vel = float(np.max(np.linalg.norm(resid, axis=1)))
+    print("Final velocity error [m/s]:", final)
+    print("Velocity RMSE [m/s]:", rmse)
+    print(f"max_resid_vel = {max_resid_vel:.3f} m/s")
+    return {"rmse_vel": rmse, "final_vel": final, "max_resid_vel": max_resid_vel}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--npz", required=True, help="Path to *_kf_output.npz file")
+    args = ap.parse_args()
+    run_evaluation_npz(args.npz)
+
+
+if __name__ == "__main__":
+    main()

--- a/PYTHON/tests/test_kf_bias.py
+++ b/PYTHON/tests/test_kf_bias.py
@@ -1,0 +1,11 @@
+import numpy as np
+from kalman_filter import init_bias_kalman, inject_zupt
+
+
+def test_bias_states_and_zupt():
+    kf = init_bias_kalman(0.1, np.eye(3), np.eye(3))
+    kf.x[:] = 0.0
+    kf.x[3:6, 0] = np.array([1.0, -2.0, 0.5])
+    inject_zupt(kf)
+    assert np.allclose(kf.x[3:6, 0], 0.0, atol=1e-3)
+    assert np.allclose(np.diag(kf.Q)[10:13], 1e-8)

--- a/PYTHON/tests/test_time_sync.py
+++ b/PYTHON/tests/test_time_sync.py
@@ -1,0 +1,36 @@
+import numpy as np
+from PYTHON.scripts.eval.run_evaluation_npz import (
+    _trim_to_overlap,
+    estimate_time_offset,
+    run_evaluation_npz,
+)
+
+
+def test_trim_to_overlap():
+    t_truth = np.linspace(0, 10, 11)
+    x_truth = np.vstack([t_truth, t_truth, t_truth]).T
+    t_est = np.linspace(2, 8, 7)
+    x_est = np.vstack([t_est, t_est, t_est]).T
+    t, xt, xe = _trim_to_overlap(t_truth, x_truth, t_est, x_est)
+    assert t[0] == 2 and t[-1] == 8
+    assert xt.shape == xe.shape == (7, 3)
+
+
+def test_estimate_time_offset():
+    fs = 10.0
+    t = np.arange(0, 1, 1 / fs)
+    sig = np.sin(2 * np.pi * t)
+    shifted = np.sin(2 * np.pi * (t + 0.2))
+    offset = estimate_time_offset(sig, shifted, fs)
+    assert abs(abs(offset) - 0.2) < 0.02
+
+
+def test_run_evaluation_respects_shift(tmp_path):
+    t_est = np.linspace(0, 5, 6)
+    vel_est = np.vstack([t_est, t_est, t_est]).T
+    t_truth = t_est + 0.5
+    vel_truth = vel_est.copy()
+    f = tmp_path / "data.npz"
+    np.savez(f, time=t_est, vel_ned=vel_est, truth_time=t_truth, truth_vel_ned=vel_truth, t_shift=0.5)
+    out = run_evaluation_npz(str(f))
+    assert np.allclose(out["rmse_vel"], 0.0)


### PR DESCRIPTION
## Summary
- Add Kalman filter helper with gyro bias states and ZUPT injection
- Extend fusion pipeline with bias estimation, optional ZUPT suppression and bias-aware prediction
- Provide evaluation script that trims to common time span and honours time offsets
- Add tests for time synchronisation and bias-aware filter

## Testing
- `pytest` *(fails: tests failing due to missing data and other modules)*
- `pytest tests/test_time_sync.py::test_trim_to_overlap tests/test_time_sync.py::test_estimate_time_offset tests/test_time_sync.py::test_run_evaluation_respects_shift tests/test_kf_bias.py::test_bias_states_and_zupt`

------
https://chatgpt.com/codex/tasks/task_e_68b804e13e448322881a3342c720750b