### PR TITLE
chore: update deployment workflow and package metadata

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -50,8 +50,7 @@ jobs:
     # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
     environment:
       name: pypi
-      # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
-      # url: https://pypi.org/p/YOURPROJECT
+      url: https://pypi.org/project/imu_gnss_fusion/
       #
       # ALTERNATIVE: if your GitHub Release name is the PyPI project version string
       # ALTERNATIVE: exactly, uncomment the following line instead:

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -50,8 +50,7 @@ jobs:
     # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
     environment:
       name: pypi
-      # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
-      # url: https://pypi.org/p/YOURPROJECT
+      url: https://pypi.org/project/imu_gnss_fusion/
       #
       # ALTERNATIVE: if your GitHub Release name is the PyPI project version string
       # ALTERNATIVE: exactly, uncomment the following line instead:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,14 +1,14 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "IMU_GNSS_Fusion"
-version: "0.1.0"
+version: "1.0.1"
 date-released: 2025-06-14
 authors:
   - name: "VimsRocz"
 preferred-citation:
   type: software
   title: "IMU_GNSS_Fusion"
-  version: "0.1.0"
+  version: "1.0.1"
   authors:
     - name: "VimsRocz"
   url: "https://github.com/VimsRocz/IMU"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "imu_gnss_fusion"
-version = "1.0.0"
+version = "1.0.1"
 description = "Python GNSS-IMU fusion and orientation estimation"
-authors = [{ name = "Your Name", email = "you@example.com" }]
+authors = [{ name = "VimsRocz" }]
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- bump package metadata to version 1.0.1 and set author
- sync citation version
- expose PyPI project URL in publishing workflows for clearer deployment status

## Testing
- `pip install -e .[tests]` *(fails: Multiple top-level packages discovered)*
- `pytest -q` *(fails: 22 failed, 63 passed, 5 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c43f9f5a8083228732dbad5e2dbbd1