### PR TITLE
Rename Task7 quaternion plot and document new subtask

### DIFF
--- a/PYTHON/src/run_all_methods.py
+++ b/PYTHON/src/run_all_methods.py
@@ -126,7 +126,7 @@ def run_case(cmd, log_path):
 # ---------------------------------------------------------------------------
 # Task7 Attitude plotting helpers (mirrors logic from run_triad_only.py)
 # ---------------------------------------------------------------------------
-from typing import Dict, Any, List, Tuple
+from typing import Dict, Any, List, Tuple, Optional
 
 
 def _save_png_and_mat(base_png_path: str, data_dict: Dict[str, Any]):
@@ -153,9 +153,9 @@ def _save_png_and_mat(base_png_path: str, data_dict: Dict[str, Any]):
     return pathlib.Path(base_png_path)
 
 
-def _task7_attitude_plots(est_npz: pathlib.Path, truth_file: pathlib.Path, tag: str, results_dir: pathlib.Path,
-                          div_threshold_deg: float = 30.0, div_persist_sec: float = 10.0,
-                          length_scan: str = "60,120,300,600,900,1200",
+def _task7_attitude_plots(est_npz: pathlib.Path, truth_file: Optional[pathlib.Path], tag: str,
+                          results_dir: pathlib.Path, div_threshold_deg: float = 30.0,
+                          div_persist_sec: float = 10.0, length_scan: str = "60,120,300,600,900,1200",
                           subdir: str = "task7_attitude") -> None:
     """Replicate Task7 attitude plots produced by run_triad_only for batch runs.
 
@@ -268,8 +268,8 @@ def _task7_attitude_plots(est_npz: pathlib.Path, truth_file: pathlib.Path, tag: 
         ax.set_title(f'q_{lab}')
         ax.grid(True)
     plt.legend(loc='upper right')
-    plt.suptitle(f'{tag} Task7 (Body→NED): Quaternion Truth vs KF')
-    generated.append(_save_png_and_mat(str(results_dir / f'{tag}_Task7_BodyToNED_attitude_truth_vs_estimate_quaternion.png'),
+    plt.suptitle(f'{tag} Task7.6 (Body→NED): Quaternion Truth vs KF')
+    generated.append(_save_png_and_mat(str(results_dir / f'{tag}_Task7_6_BodyToNED_attitude_truth_vs_estimate_quaternion.png'),
                                        {'t': time_s, 'q_truth': qT, 'q_kf': qE}))
 
     # Quaternion component residuals
@@ -810,8 +810,8 @@ def main(argv=None):
             # Task 7.6 Attitude plots (match run_triad_only output set)
             # ----------------------------
             try:
-                if 'truth_file' in locals() and truth_file is not None and pathlib.Path(truth_file).exists():
-                    _task7_attitude_plots(npz_path, pathlib.Path(truth_file), tag, results_dir)
+                truth_path_obj = pathlib.Path(truth_file) if 'truth_file' in locals() and truth_file else None
+                _task7_attitude_plots(npz_path, truth_path_obj, tag, results_dir)
             except Exception as ex:
                 logger.info(f"[WARN] Task7 attitude plots failed for {tag}: {ex}")
 

--- a/docs/Python/Task7_Python.md
+++ b/docs/Python/Task7_Python.md
@@ -29,6 +29,14 @@ Residual position and velocity are compared with the GNSS data. When a truth tra
 - Figures are saved as `<tag>_task7_5_diff_truth_fused_over_time_<frame>.pdf` for
   all frames (NED, ECEF and Body).
 
+### 7.6 Attitude Truth vs Estimate
+- Generate quaternion plots comparing truth and Kalman filter estimates.
+- Save `<tag>_task7_6_BodyToNED_attitude_truth_vs_estimate_quaternion.png`.
+- Plot quaternion component errors and Euler angle errors over time.
+- Additional files include `<tag>_task7_6_BodyToNED_attitude_quaternion_error_components.png`,
+  `<tag>_task7_6_BodyToNED_attitude_euler_error_over_time.png` and
+  `<tag>_task7_6_attitude_error_angle_over_time.png`.
+
 ## Running the Script
 
 Run the evaluation helper after Task 5 to generate residual and attitude plots:
@@ -47,6 +55,10 @@ All figures are stored in `PYTHON/results/` using the dataset and method tag:
 - `<tag>_task7_3_residuals_position_velocity.pdf`
 - `<tag>_task7_4_attitude_angles_euler.pdf`
 - `<tag>_task7_5_diff_truth_fused_over_time_<frame>.pdf`
+- `<tag>_task7_6_BodyToNED_attitude_truth_vs_estimate_quaternion.png`
+- `<tag>_task7_6_BodyToNED_attitude_quaternion_error_components.png`
+- `<tag>_task7_6_BodyToNED_attitude_euler_error_over_time.png`
+- `<tag>_task7_6_attitude_error_angle_over_time.png`
 
 ## Result
 


### PR DESCRIPTION
## Summary
- Rename Task7 quaternion truth vs estimate plot to include subtask `Task7_6`
- Generate Task7 attitude plots for every run, even when truth data is missing
- Document new Task7.6 attitude plotting outputs and filenames

## Testing
- `pytest -q` *(fails: AssertionError in evaluate_filter_results tests and missing test data)*

------
https://chatgpt.com/codex/tasks/task_e_68c44d71a56c83228d816bef06ef0292