### PR TITLE
Use Task7_6 name for quaternion plot

### DIFF
--- a/PYTHON/src/GNSS_IMU_Fusion.py
+++ b/PYTHON/src/GNSS_IMU_Fusion.py
@@ -3325,7 +3325,7 @@ def main():
                 # Save with the requested filename pattern
                 imu_tag = Path(imu_file).stem
                 gnss_tag = Path(gnss_file).stem
-                out_name = f"{imu_tag}_{gnss_tag}_{method}_Task7_BodyToNED_attitude_truth_vs_estimate_quaternion.png"
+                out_name = f"{imu_tag}_{gnss_tag}_{method}_Task7_6_BodyToNED_attitude_truth_vs_estimate_quaternion.png"
                 out_path = Path("results") / out_name
                 fig_q.savefig(out_path, dpi=200, bbox_inches="tight")
                 # Also save a MATLAB .mat bundle for plot_any compatibility

--- a/PYTHON/src/evaluate_filter_results.py
+++ b/PYTHON/src/evaluate_filter_results.py
@@ -422,7 +422,7 @@ def run_evaluation_npz(npz_file: str, save_path: str, tag: str | None = None) ->
         if _saved_registry is not None:
             # Patterns to look for (PNG form; .fig/.pdf/.mat variants may also exist)
             patterns = [
-                f"{tag}_Task7_BodyToNED_attitude_truth_vs_estimate_quaternion.png" if tag else None,
+                f"{tag}_Task7_6_BodyToNED_attitude_truth_vs_estimate_quaternion.png" if tag else None,
                 f"{tag}_Task7_6_BodyToNED_attitude_quaternion_error_components.png" if tag else None,
                 f"{tag}_Task7_BodyToNED_attitude_truth_vs_estimate_euler.png" if tag else None,
                 f"{tag}_Task7_6_BodyToNED_attitude_euler_error_over_time.png" if tag else None,

--- a/PYTHON/src/run_triad_only.py
+++ b/PYTHON/src/run_triad_only.py
@@ -752,9 +752,9 @@ def _run_inline_truth_validation(results_dir, tag, kf_mat_path, truth_file, args
         ax.set_title(f'q_{lab}')
         ax.grid(True)
     plt.legend(loc='upper right')
-    plt.suptitle(f'{tag} Task7 (Body→NED): Quaternion Truth vs KF')
+    plt.suptitle(f'{tag} Task7_6 (Body→NED): Quaternion Truth vs KF')
     _save_png_and_mat(
-        os.path.join(results_dir, f'{tag}_Task7_BodyToNED_attitude_truth_vs_estimate_quaternion.png'),
+        os.path.join(results_dir, f'{tag}_Task7_6_BodyToNED_attitude_truth_vs_estimate_quaternion.png'),
         {'t': t_plot, 'q_truth': qT_plot, 'q_kf': qE_plot}
     )
 

--- a/PYTHON/src/validate_with_truth.py
+++ b/PYTHON/src/validate_with_truth.py
@@ -1342,7 +1342,7 @@ def main():
                         plt.xlabel("Time [s]")
                 plt.tight_layout()
                 # Save PNG and MATLAB .fig with Task/Frame in filename
-                f_q_base = f"{tag_prefix}_Task7_BodyToNED_attitude_truth_vs_estimate_quaternion"
+                f_q_base = f"{tag_prefix}_Task7_6_BodyToNED_attitude_truth_vs_estimate_quaternion"
                 fig_q = plt.gcf()
                 try:
                     fig_q.savefig(f"{f_q_base}.png", dpi=200, bbox_inches='tight')


### PR DESCRIPTION
## Summary
- Rename Task7 quaternion plot to Task7_6 in run_triad_only
- Update downstream references to new Task7_6 quaternion filename

## Testing
- `pytest` *(fails: 8 failed, 26 passed, 4 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c450e2ced0832290f048b0fdc09a8a