### PR TITLE
Update Euler plot naming to Task7.6

### DIFF
--- a/PYTHON/src/run_all_methods.py
+++ b/PYTHON/src/run_all_methods.py
@@ -306,8 +306,8 @@ def _task7_attitude_plots(est_npz: pathlib.Path, truth_file: Optional[pathlib.Pa
         if i == 0:
             ax.legend()
     plt.xlabel('Time [s]')
-    plt.suptitle(f'{tag} Task7 (Body→NED): Euler (ZYX) Truth vs KF')
-    generated.append(_save_png_and_mat(str(results_dir / f'{tag}_Task7_BodyToNED_attitude_truth_vs_estimate_euler.png'),
+    plt.suptitle(f'{tag} Task7.6 (Body→NED): Euler (ZYX) Truth vs KF')
+    generated.append(_save_png_and_mat(str(results_dir / f'{tag}_Task7_6_BodyToNED_attitude_truth_vs_estimate_euler.png'),
                                        {'t': time_s, 'e_truth_zyx_deg': eT, 'e_kf_zyx_deg': eE}))
 
     def _wrap_deg(x: np.ndarray) -> np.ndarray:

--- a/PYTHON/src/run_triad_only.py
+++ b/PYTHON/src/run_triad_only.py
@@ -787,9 +787,9 @@ def _run_inline_truth_validation(results_dir, tag, kf_mat_path, truth_file, args
         if i == 0:
             ax.legend()
     plt.xlabel('Time [s]')
-    plt.suptitle(f'{tag} Task7 (Body→NED): Euler (ZYX) Truth vs KF')
+    plt.suptitle(f'{tag} Task7.6 (Body→NED): Euler (ZYX) Truth vs KF')
     _save_png_and_mat(
-        os.path.join(results_dir, f'{tag}_Task7_BodyToNED_attitude_truth_vs_estimate_euler.png'),
+        os.path.join(results_dir, f'{tag}_Task7_6_BodyToNED_attitude_truth_vs_estimate_euler.png'),
         {'t': t_plot, 'e_truth_zyx_deg': eT, 'e_kf_zyx_deg': eE}
     )
 


### PR DESCRIPTION
## Summary
- Rename Euler truth-vs-estimate plots to use Task7.6 naming for consistency
- Mirror naming update in standalone triad run script

## Testing
- `pytest -q` *(fails: 8 failed, 26 passed, 4 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c450e66b4483229f3da25320e7b550