### PR TITLE
Fix frame rotation and plotting helpers

### DIFF
--- a/PYTHON/src/gnss_imu_fusion/kalman.py
+++ b/PYTHON/src/gnss_imu_fusion/kalman.py
@@ -100,7 +100,10 @@ class GNSSIMUKalman:
         # manual integration of position/velocity at IMU
         acc_body = acc_meas - self.kf.x[6:9]
         acc_n = R_bn @ acc_body
-        acc_n += g_n
+        # The accelerometer measurement here is treated as a raw acceleration
+        # (including gravity).  To obtain the specific force in the navigation
+        # frame we subtract the gravity vector rather than add it.
+        acc_n -= g_n
         self.vel_imu += acc_n * dt
         self.pos_imu += self.vel_imu * dt
         if omega_meas is not None and np.linalg.norm(self.lever_arm) > 0:

--- a/PYTHON/src/kalman_filter.py
+++ b/PYTHON/src/kalman_filter.py
@@ -47,11 +47,10 @@ def inject_zupt(kf: KalmanFilter) -> None:
     # Measurement model: z = H x + v, here z = [0,0,0] for velocity components
     H = np.hstack([np.zeros((3, 3)), np.eye(3), np.zeros((3, 7))])  # (3,13)
     R = np.eye(3) * 1e-4
-    z = np.zeros(3)  # use 1D vector for consistent shapes
-    # Innovation and Kalman gain
-    y = z - (H @ kf.x).reshape(3,)
+    z = np.zeros((3, 1))
+    x = kf.x.reshape(-1, 1)
+    y = z - H @ x
     S = H @ kf.P @ H.T + R
     K = kf.P @ H.T @ np.linalg.inv(S)
-    # State/covariance update (keep x as 1D vector)
-    kf.x = (kf.x + K @ y).reshape(-1)
+    kf.x = (x + K @ y)
     kf.P = (np.eye(kf.dim_x) - K @ H) @ kf.P


### PR DESCRIPTION
## Summary
- return NED→ECEF rotation matrix from `_rotation_ecef_to_ned` and adjust conversions accordingly
- allow `save_plot` to honour requested file extensions alongside PNG/MAT saves
- subtract gravity when integrating acceleration in Kalman predictor
- ensure `inject_zupt` operates on column-vector state

## Testing
- `pytest PYTHON/tests/test_frames_orientation.py::test_rotation_ecef_to_ned_right_handed_down[0.0-0.0] -q`
- `pytest PYTHON/tests/test_evaluate_filter_results.py::test_run_evaluation_npz_mismatched_lengths -q`
- `pytest PYTHON/tests/test_kf_bias.py::test_bias_states_and_zupt -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4699a0ea48322aa69c52f94755c11